### PR TITLE
added workflow for automatic project assignment

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -31,12 +31,8 @@ Use one of these labels:
 
 Use a second label to let us know to which module the issue is related:
 
-- **signal**
-- **coordinates**
-- **orientations**
-- **io**
-- **dsp**
-- **filter**
-- **plot**
-- **spatial**
-- **fft**
+- **signal**, **coordinates**, **orientations**, etc.
+
+## Project
+
+**Do not assign your issue to a project.** This is done automatically.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,12 +22,8 @@ Use one of these labels:
 
 Use a second label to let us know to which module the issue is related:
 
-- **signal**
-- **coordinates**
-- **orientations**
-- **io**
-- **dsp**
-- **filter**
-- **plot**
-- **spatial**
-- **fft**
+- **signal**, **coordinates**, **orientations**, etc.
+
+## Project
+
+**Do not assign your issue to a project.** This is done automatically.

--- a/.github/workflows/assign_to_project.yml
+++ b/.github/workflows/assign_to_project.yml
@@ -1,0 +1,44 @@
+name: Assign to one project
+
+on:
+  issues:
+    types: [opened, labeled, unlabeled]
+  pull_request:
+    types: [opened, labeled, unlabeled]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign new and labeled issues/pull-requests to project code backlog
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: |
+        github.event.action == 'opened' &&
+        (contains(github.event.issue.labels.*.name, 'bug') ||
+        contains(github.event.pull_request.labels.*.name, 'bug') ||
+        contains(github.event.issue.labels.*.name, 'dependencies') ||
+        contains(github.event.pull_request.labels.*.name, 'dependencies') ||
+        contains(github.event.issue.labels.*.name, 'documentation') ||
+        contains(github.event.pull_request.labels.*.name, 'documentation') ||
+        contains(github.event.issue.labels.*.name, 'duplicate') ||
+        contains(github.event.pull_request.labels.*.name, 'duplicate') ||
+        contains(github.event.issue.labels.*.name, 'enhancement') ||
+        contains(github.event.pull_request.labels.*.name, 'enhancement') ||
+        contains(github.event.issue.labels.*.name, 'feature') ||
+        contains(github.event.pull_request.labels.*.name, 'feature') ||
+        contains(github.event.issue.labels.*.name, 'hot') ||
+        contains(github.event.pull_request.labels.*.name, 'hot'))
+      with:
+        project: 'https://github.com/pyfar/pyfar/projects/2'
+
+    - name: Assign new and labeled issues/pull-requests to project general
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: |
+        github.event.action == 'opened' &&
+        (contains(github.event.issue.labels.*.name, 'question') ||
+        contains(github.event.pull_request.labels.*.name, 'question'))
+      with:
+        project: 'https://github.com/pyfar/pyfar/projects/3'


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #12 

### Changes proposed in this pull request:

added wokflow that will
- assign a new issue/pull-request to *Code Backlog* if labeled bug, dependencies, documentation, duplicate, enhancement, feature, or hot
- assign a new issue/pull-request to *General* if labeled question

Tested on a private repo - worked like a charm. If a new issue/pull-request is opened, the workflow's status is shown at https://github.com/pyfar/pyfar/actions. Once this finished, the issue/pull-request is assigned to the project.