### PR TITLE
replace bumpversion by bump2version in requirements

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,5 @@
 pip
-bumpversion
+bump2version
 wheel
 watchdog
 flake8

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup_requirements = ['pytest-runner', ]
 
 test_requirements = [
     'pytest',
-    'bumpversion',
+    'bump2version',
     'wheel',
     'watchdog',
     'flake8',


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes  #11 

### Changes proposed in this pull request:

- replace the deprecated bump version dependency 
