### PR TITLE
Docs hosting on readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,20 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF
+formats:
+  - pdf
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: requirements_dev.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,8 +56,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'pyfar'
-copyright = u"2019, Marco Berzborn"
-author = u"Marco Berzborn"
+copyright = u"2020, The pyfar developers"
+author = u"The pyfar developers"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #28 

### Changes proposed in this pull request:

Use ReadTheDocs.org to build and host the sphinx documentation.
The docs for the pull request branch are found here: https://pyfar.readthedocs.io/en/feature-readthedocs/
