### PR TITLE
fft_norm was not passed in signal.__getitem__

### DIFF
--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -366,6 +366,7 @@ class Signal(Audio):
             sampling_rate=self.sampling_rate,
             domain=self.domain,
             signal_type=self.signal_type,
+            fft_norm=self.fft_norm,
             dtype=self.dtype)
 
         return items


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes nothing

### Changes proposed in this pull request:

- add fft_norm to signal.__getitem__