### PR TITLE
local import of external sampling submodule in spatial

### DIFF
--- a/pyfar/dsp/filter.py
+++ b/pyfar/dsp/filter.py
@@ -3,7 +3,7 @@ import scipy.signal as spsignal
 
 from .classes import (FilterIIR, FilterSOS)
 
-import pyfar.dsp._audiofilter as iir
+from . import _audiofilter as iir
 
 
 def butter(signal, N, frequency, btype='lowpass', sampling_rate=None):

--- a/pyfar/spatial/samplings.py
+++ b/pyfar/spatial/samplings.py
@@ -7,8 +7,8 @@ import urllib3
 import os
 import scipy.io as sio
 from pyfar.coordinates import Coordinates
-from pyfar.spatial.external import (
-    samplings_lebedev, eq_area_partitions)
+
+from .external import (samplings_lebedev, eq_area_partitions)
 
 
 def cart_equidistant_cube(n_points):


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #51 

### Changes proposed in this pull request:

- Replace private submodules without a `__init__.py` with a local import 
