### PR TITLE
moved stub_utils

### DIFF
--- a/pyfar/testing/__init__.py
+++ b/pyfar/testing/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+
+"""Testing sub-package for pyfar."""
+
+from . import stub_utils
+
+__all__ = ['stub_utils']

--- a/pyfar/testing/stub_utils.py
+++ b/pyfar/testing/stub_utils.py
@@ -1,3 +1,10 @@
+"""
+Contains tools to easily generate stubs for the most common pyfar Classes.
+
+Stubs are used instead of pyfar objects for testing functions that have pyfar
+objects as input arguments. This makes testing such functions independent from
+the pyfar objects themselves and helps to find bugs.
+"""
 import numpy as np
 
 from unittest import mock
@@ -18,7 +25,7 @@ def signal_stub(time, freq, sampling_rate, fft_norm):
     sampling_rate : float
         Sampling rate
     fft_norm : 'unitary', 'amplitude', 'rms', 'power', 'psd'
-        See documentaion of pyfar.fft.normalization.
+        See documentation of pyfar.fft.normalization.
 
     Returns
     -------
@@ -67,7 +74,7 @@ def impulse_func(delay, n_samples, fft_norm, cshape):
     n_samples : int
         Number of samples
     fft_norm : 'none', 'rms'
-        See documentaion of pyfar.fft.normalization.
+        See documentation of pyfar.fft.normalization.
     cshape : tuple
         Channel shape
 
@@ -115,7 +122,7 @@ def sine_func(frequency, sampling_rate, n_samples, fft_norm, cshape):
     n_samples : int
         Number of samples
     fft_norm : 'none', 'rms'
-        See documentaion of pyfar.fft.normalization.
+        See documentation of pyfar.fft.normalization.
     cshape : tuple
         Channel shape
 
@@ -184,7 +191,7 @@ def noise_func(sigma, n_samples, cshape):
 
 def _normalization(freq, n_samples, fft_norm):
     """Normalized spectrum as defined in _[1],
-    see documentaion of pyfar.fft.normalization.
+    see documentation of pyfar.fft.normalization.
 
     Parameters
     ----------
@@ -193,7 +200,7 @@ def _normalization(freq, n_samples, fft_norm):
     n_samples : int
         Number of samples
     fft_norm : 'none', 'rms'
-        See documentaion of pyfar.fft.normalization.
+        See documentation of pyfar.fft.normalization.
 
     Returns
     -------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,8 +5,7 @@ import sofa
 import scipy.io.wavfile as wavfile
 
 from pyfar.orientations import Orientations
-
-import stub_utils
+from pyfar.testing import stub_utils
 
 
 @pytest.fixture

--- a/tests/test_stub_utils.py
+++ b/tests/test_stub_utils.py
@@ -3,8 +3,7 @@ import numpy as np
 import numpy.testing as npt
 
 from pyfar import Signal
-
-import stub_utils
+from pyfar.testing import stub_utils
 
 
 def test_signal_stub_properties():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

**Make `stub_utils.py` accessible from other packages.**

Other packages, for example the room acoustic package, also work with pyfar objects and thus require stubs of the pyfar objects for testing. It is thus desired, to make the stub utils from pyfar available to other packages.

### Changes proposed in this pull request:

- added module `pyfar.testing` which contains `stub_utils.py`

**Note:** Do not check the code in `pyfar/testing/stub_utils.py` during the review. The content is identical to the old `tests/stub_utils.py` (Only docstring added)