### PR TITLE
Implemented equality checks with deepdiff

### DIFF
--- a/pyfar/coordinates.py
+++ b/pyfar/coordinates.py
@@ -3,6 +3,7 @@ import numpy as np
 from scipy.spatial import cKDTree
 from scipy.spatial.transform import Rotation as sp_rot
 import copy
+import deepdiff
 import re
 from . import utils
 
@@ -1676,6 +1677,10 @@ class Coordinates(object):
             _repr += f"\nComment: {self._comment}"
 
         return _repr
+
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return not deepdiff.DeepDiff(self, other)
 
 
 def cart2sph(x, y, z):

--- a/pyfar/dsp/classes.py
+++ b/pyfar/dsp/classes.py
@@ -216,6 +216,10 @@ class Filter(object):
         """Return a deep copy of the Filter object."""
         return utils.copy(self)
 
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return not deepdiff.DeepDiff(self, other)
+
 
 class FilterFIR(Filter):
     """

--- a/pyfar/dsp/classes.py
+++ b/pyfar/dsp/classes.py
@@ -1,4 +1,5 @@
 import copy
+import deepdiff
 import warnings
 
 import numpy as np

--- a/pyfar/orientations.py
+++ b/pyfar/orientations.py
@@ -215,4 +215,5 @@ class Orientations(Rotation):
 
     def __eq__(self, other):
         """Check for equality of two objects."""
-        return not deepdiff.DeepDiff(self, other)
+        return not deepdiff.DeepDiff(self, other) \
+            and not deepdiff.DeepDiff(self.as_quat(), other.as_quat())

--- a/pyfar/orientations.py
+++ b/pyfar/orientations.py
@@ -215,5 +215,4 @@ class Orientations(Rotation):
 
     def __eq__(self, other):
         """Check for equality of two objects."""
-        return not deepdiff.DeepDiff(self, other) \
-            and not deepdiff.DeepDiff(self.as_quat(), other.as_quat())
+        return np.array_equal(self.as_quat(), other.as_quat())

--- a/pyfar/orientations.py
+++ b/pyfar/orientations.py
@@ -1,5 +1,6 @@
 from scipy.spatial.transform import Rotation
 import numpy as np
+import deepdiff
 
 import pyfar
 
@@ -211,3 +212,7 @@ class Orientations(Rotation):
         quats = self.as_quat()
         quats[idx] = quat
         self = super().from_quat(quats)
+
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return not deepdiff.DeepDiff(self, other)

--- a/pyfar/orientations.py
+++ b/pyfar/orientations.py
@@ -1,6 +1,5 @@
 from scipy.spatial.transform import Rotation
 import numpy as np
-import deepdiff
 
 import pyfar
 

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -56,7 +56,6 @@ class _Audio(object):
         """Check for equality of two objects."""
         return not deepdiff.DeepDiff(self, other)
 
-
     @property
     def domain(self):
         """The domain the data is stored in"""

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -54,7 +54,7 @@ class _Audio(object):
 
     def __eq__(self, other):
         """Check for equality of two objects."""
-        return not deepdiff.DeepDiff(self, other)
+        return not deepdiff.DeepDiff(self.__dict__, other.__dict__)
 
     @property
     def domain(self):

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -52,6 +52,11 @@ class _Audio(object):
         # methods to fail that require data.)
         self._data = np.atleast_2d(np.nan)
 
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return not deepdiff.DeepDiff(self, other)
+
+
     @property
     def domain(self):
         """The domain the data is stored in"""
@@ -688,10 +693,6 @@ class Signal(FrequencyData, TimeData):
         numpy's array iteration.
         """
         return SignalIterator(self._data.__iter__(), self)
-
-    def __eq__(self, other):
-        """Check for equality of two objects."""
-        return not deepdiff.DeepDiff(self, other)
 
 
 class SignalIterator(object):

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -15,6 +15,7 @@ the functions have to be called explicitly.
 """
 
 import warnings
+import deepdiff
 import numpy as np
 from pyfar import fft as fft
 from typing import Callable
@@ -687,6 +688,10 @@ class Signal(FrequencyData, TimeData):
         numpy's array iteration.
         """
         return SignalIterator(self._data.__iter__(), self)
+
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return not deepdiff.DeepDiff(self, other)
 
 
 class SignalIterator(object):

--- a/pyfar/spatial/spatial.py
+++ b/pyfar/spatial/spatial.py
@@ -1,3 +1,4 @@
+import deepdiff
 import numpy as np
 from scipy import spatial as spat
 
@@ -31,6 +32,12 @@ class SphericalVoronoi(spat.SphericalVoronoi):
             raise ValueError("All sampling points need to be on the \
                     same radius.")
         super().__init__(points, radius_round, center)
+
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return not deepdiff.DeepDiff(
+            self, other, ignore_type_in_groups=[
+                (np.int32, np.intc), (np.int64, np.intc)])
 
 
 def calculate_sph_voronoi_weights(

--- a/pyfar/spatial/spatial.py
+++ b/pyfar/spatial/spatial.py
@@ -36,9 +36,7 @@ class SphericalVoronoi(spat.SphericalVoronoi):
 
     def __eq__(self, other):
         """Check for equality of two objects."""
-        return not deepdiff.DeepDiff(
-            self, other, ignore_type_in_groups=[
-                (np.int32, np.intc), (np.int64, np.intc)])
+        return not deepdiff.DeepDiff(self, other)
 
     def copy(self):
         """Return a deep copy of the Coordinates object."""

--- a/pyfar/spatial/spatial.py
+++ b/pyfar/spatial/spatial.py
@@ -1,5 +1,6 @@
 import deepdiff
 import numpy as np
+from pyfar import utils
 from scipy import spatial as spat
 
 
@@ -38,6 +39,10 @@ class SphericalVoronoi(spat.SphericalVoronoi):
         return not deepdiff.DeepDiff(
             self, other, ignore_type_in_groups=[
                 (np.int32, np.intc), (np.int64, np.intc)])
+
+    def copy(self):
+        """Return a deep copy of the Coordinates object."""
+        return utils.copy(self)
 
 
 def calculate_sph_voronoi_weights(

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,3 +16,4 @@ pyfftw
 matplotlib
 python-sofa>=0.2.0
 urllib3
+deepdiff

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     'pyfftw',
     'matplotlib',
     'python-sofa>=0.2.0',
-    'urllib3'
+    'urllib3',
+    'deepdiff'
 ]
 
 setup_requirements = ['pytest-runner', ]
@@ -31,7 +32,7 @@ test_requirements = [
     'tox',
     'coverage',
     'Sphinx',
-    'twine',
+    'twine'
 ]
 
 setup(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -580,11 +580,10 @@ def coordinates():
 
 
 @pytest.fixture
-def signal():
+def sine_signal(sine):
     """ Signal object without Mock or MagicMock wrapper.
     """
-    sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
-    return Signal(sine, 44100, len(sine), domain='time')
+    return Signal(sine.time, sine.sampling_rate, domain='time')
 
 
 @pytest.fixture
@@ -639,35 +638,7 @@ def filterSOS():
 def sphericalvoronoi():
     """ SphericalVoronoi object.
     """
-    dihedral = 2 * np.arcsin(np.cos(np.pi / 3) / np.sin(np.pi / 5))
-    R = np.tan(np.pi / 3) * np.tan(dihedral / 2)
-    rho = np.cos(np.pi / 5) / np.sin(np.pi / 10)
-
-    theta1 = np.arccos(
-        (np.cos(np.pi / 5) / np.sin(np.pi / 5)) /
-        np.tan(np.pi / 3))
-
-    a2 = 2 * np.arccos(rho / R)
-
-    theta2 = theta1 + a2
-    theta3 = np.pi - theta2
-    theta4 = np.pi - theta1
-
-    phi1 = 0
-    phi2 = 2 * np.pi / 3
-    phi3 = 4 * np.pi / 3
-
-    theta = np.concatenate((
-        np.tile(theta1, 3),
-        np.tile(theta2, 3),
-        np.tile(theta3, 3),
-        np.tile(theta4, 3)))
-    phi = np.tile(np.array(
-            [phi1, phi2, phi3, phi1 + np.pi / 3,
-             phi2 + np.pi / 3, phi3 + np.pi / 3]), 2)
-    rad = np.ones(np.size(theta))
-
-    s = Coordinates(
-        phi, theta, rad,
-        domain='sph', convention='top_colat')
-    return SphericalVoronoi(s)
+    points = np.array(
+        [[0, 0, 1], [0, 0, -1], [1, 0, 0], [0, 1, 0], [0, -1, 0], [-1, 0, 0]])
+    sampling = Coordinates(points[:, 0], points[:, 1], points[:, 2])
+    return SphericalVoronoi(sampling)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,12 @@ import os.path
 import sofa
 import scipy.io.wavfile as wavfile
 
+from pyfar.spatial.spatial import SphericalVoronoi
 from pyfar.orientations import Orientations
+from pyfar.coordinates import Coordinates
+from pyfar.signal import Signal
+import pyfar.dsp.classes as fo
+import pyfar.io
 
 import stub_utils
 
@@ -554,4 +559,21 @@ def positions():
 
 @pytest.fixture
 def orientations(views, ups):
+    """ Orientations object uses fixtures `views` and `ups`.
+    """
     return Orientations.from_view_up(views, ups)
+
+
+@pytest.fixture
+def coordinates():
+    """ Coordinates object.
+    """
+    return Coordinates([0, 1], [2, 3], [4, 5])
+
+
+@pytest.fixture
+def signal():
+    """ Signal object without Mock or MagicMock wrapper.
+    """
+    sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
+    return Signal(sine, 44100, len(sine), domain='time')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -577,3 +577,39 @@ def signal():
     """
     sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
     return Signal(sine, 44100, len(sine), domain='time')
+
+
+
+@pytest.fixture
+def filter():
+    """ Filter object.
+    """
+    coeff = np.array([[[1, 0, 0], [1, 0, 0]]])
+    state = np.array([[[1, 0]]])
+    return fo.Filter(coefficients=coeff, state=state, comment='my comment')
+
+
+@pytest.fixture
+def filterIIR():
+    """ FilterIIR object.
+    """
+    coeff = np.array([[1, 1 / 2, 0], [1, 0, 0]])
+    return fo.FilterIIR(coeff, sampling_rate=2 * np.pi)
+
+
+@pytest.fixture
+def filterFIR():
+    """ FilterFIR objectr.
+    """
+    coeff = np.array([
+        [1, 1 / 2, 0],
+        [1, 1 / 4, 1 / 8]])
+    return fo.FilterFIR(coeff, sampling_rate=2*np.pi)
+
+
+@pytest.fixture
+def filterSOS():
+    """ FilterSOS objectr.
+    """
+    sos = np.array([[1, 1/2, 0, 1, 0, 0]])
+    return fo.FilterSOS(sos, sampling_rate=2*np.pi)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ from pyfar.orientations import Orientations
 from pyfar.coordinates import Coordinates
 from pyfar.signal import Signal
 import pyfar.dsp.classes as fo
-import pyfar.io
 
 import stub_utils
 
@@ -589,12 +588,25 @@ def signal():
 
 
 @pytest.fixture
-def filter():
+def coeffs():
+    return np.array([[[1, 0, 0], [1, 0, 0]]])
+
+
+@pytest.fixture
+def state():
+    return np.array([[[1, 0]]])
+
+
+@pytest.fixture
+def comment():
+    return 'any comment'
+
+
+@pytest.fixture
+def filter(coeffs, state):
     """ Filter object.
     """
-    coeff = np.array([[[1, 0, 0], [1, 0, 0]]])
-    state = np.array([[[1, 0]]])
-    return fo.Filter(coefficients=coeff, state=state, comment='my comment')
+    return fo.Filter(coefficients=coeffs, state=state)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -579,7 +579,6 @@ def signal():
     return Signal(sine, 44100, len(sine), domain='time')
 
 
-
 @pytest.fixture
 def filter():
     """ Filter object.
@@ -613,3 +612,41 @@ def filterSOS():
     """
     sos = np.array([[1, 1/2, 0, 1, 0, 0]])
     return fo.FilterSOS(sos, sampling_rate=2*np.pi)
+
+
+@pytest.fixture
+def sphericalvoronoi():
+    """ SphericalVoronoi object.
+    """
+    dihedral = 2 * np.arcsin(np.cos(np.pi / 3) / np.sin(np.pi / 5))
+    R = np.tan(np.pi / 3) * np.tan(dihedral / 2)
+    rho = np.cos(np.pi / 5) / np.sin(np.pi / 10)
+
+    theta1 = np.arccos(
+        (np.cos(np.pi / 5) / np.sin(np.pi / 5)) /
+        np.tan(np.pi / 3))
+
+    a2 = 2 * np.arccos(rho / R)
+
+    theta2 = theta1 + a2
+    theta3 = np.pi - theta2
+    theta4 = np.pi - theta1
+
+    phi1 = 0
+    phi2 = 2 * np.pi / 3
+    phi3 = 4 * np.pi / 3
+
+    theta = np.concatenate((
+        np.tile(theta1, 3),
+        np.tile(theta2, 3),
+        np.tile(theta3, 3),
+        np.tile(theta4, 3)))
+    phi = np.tile(np.array(
+            [phi1, phi2, phi3, phi1 + np.pi / 3,
+             phi2 + np.pi / 3, phi3 + np.pi / 3]), 2)
+    rad = np.ones(np.size(theta))
+
+    s = Coordinates(
+        phi, theta, rad,
+        domain='sph', convention='top_colat')
+    return SphericalVoronoi(s)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -544,16 +544,25 @@ def generate_sofa_postype_error(
 
 @pytest.fixture
 def views():
+    """ Used for the creation of Orientation objects with
+    `Orientations.from_view_up`
+    """
     return [[1, 0, 0], [2, 0, 0], [-1, 0, 0]]
 
 
 @pytest.fixture
 def ups():
+    """ Used for the creation of Orientation objects with
+    `Orientations.from_view_up`
+    """
     return [[0, 1, 0], [0, -2, 0], [0, 1, 0]]
 
 
 @pytest.fixture
 def positions():
+    """ Used for the visualization of Orientation objects with
+    `Orientations.show`
+    """
     return [[0, 0.5, 0], [0, -0.5, 0], [1, 1, 1]]
 
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -577,32 +577,43 @@ def test_converters():
     coordinates.cart2cyl(0, 0, 1)
     coordinates.cyl2cart(0, 0, 1)
 
+
 @pytest.mark.parametrize(
     'points_1, points_2, points_3, actual, expected', [
         (1, 1, 1,                Coordinates(1, 1, -1),                 False),
         ([1, 1], [1, 1], [1, 1], Coordinates([1, 1], [1, 1], [1, 2]),   False),
-        ([1, 1], [1, 1], [1, 1], Coordinates([1, 1.0],[1, 1.0],[1, 1]), True)
+        ([1, 1], [1, 1], [1, 1], Coordinates([1, 1.0], [1, 1.0], [1, 1]), True)
     ])
 def test___eq___differInPoints(
         points_1, points_2, points_3, actual, expected):
+    """ This function checks against 3 different pairings of Coordinates.
+    """
     coordinates = Coordinates(points_1, points_2, points_3)
     comparison = coordinates == actual
     assert comparison == expected
 
 
-def test___eq___differInDomain():
+def test___eq___ForwardAndBackwardsDomainTransform_Equal():
+    coordinates = Coordinates(1, 2, 3, domain='cart')
+    actual = coordinates.copy()
+    actual.get_sph()
+    actual.get_cart()
+    assert coordinates == actual
+
+
+def test___eq___differInDomain_notEqual():
     coordinates = Coordinates(1, 2, 3, domain='sph', convention='side')
     actual = Coordinates(1, 2, 3, domain='sph', convention='front')
     assert not coordinates == actual
 
 
-def test___eq___differInConvention():
+def test___eq___differInConvention_notEqual():
     coordinates = Coordinates(domain='sph', convention='top_elev')
     actual = Coordinates(domain='sph', convention='front')
     assert not coordinates == actual
 
 
-def test___eq___differInUnit():
+def test___eq___differInUnit_notEqual():
     coordinates = Coordinates(
         [1, 1], [1, 1], [1, 1],
         convention='top_colat', domain='sph', unit='rad')
@@ -613,19 +624,19 @@ def test___eq___differInUnit():
     assert not is_equal
 
 
-def test___eq___differInWeigths():
+def test___eq___differInWeigths_notEqual():
     coordinates = Coordinates(1, 2, 3, weights=.5)
     actual = Coordinates(1, 2, 3, weights=0.0)
     assert not coordinates == actual
 
 
-def test___eq___differInShOrder():
+def test___eq___differInShOrder_notEqual():
     coordinates = Coordinates(1, 2, 3, sh_order=2)
     actual = Coordinates(1, 2, 3, sh_order=8)
     assert not coordinates == actual
 
 
-def test___eq___differInShComment():
+def test___eq___differInShComment_notEqual():
     coordinates = Coordinates(1, 2, 3, comment="Madre mia!")
     actual = Coordinates(1, 2, 3, comment="Oh my woooooosh!")
     assert not coordinates == actual

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -1,5 +1,6 @@
 import numpy as np
 import numpy.testing as npt
+import pytest
 from pytest import raises
 
 from pyfar.coordinates import Coordinates
@@ -575,3 +576,56 @@ def test_converters():
     coordinates.sph2cart(0, 0, 1)
     coordinates.cart2cyl(0, 0, 1)
     coordinates.cyl2cart(0, 0, 1)
+
+@pytest.mark.parametrize(
+    'points_1, points_2, points_3, actual, expected', [
+        (1, 1, 1,                Coordinates(1, 1, -1),                 False),
+        ([1, 1], [1, 1], [1, 1], Coordinates([1, 1], [1, 1], [1, 2]),   False),
+        ([1, 1], [1, 1], [1, 1], Coordinates([1, 1.0],[1, 1.0],[1, 1]), True)
+    ])
+def test___eq___differInPoints(
+        points_1, points_2, points_3, actual, expected):
+    coordinates = Coordinates(points_1, points_2, points_3)
+    comparison = coordinates == actual
+    assert comparison == expected
+
+
+def test___eq___differInDomain():
+    coordinates = Coordinates(1, 2, 3, domain='sph', convention='side')
+    actual = Coordinates(1, 2, 3, domain='sph', convention='front')
+    assert not coordinates == actual
+
+
+def test___eq___differInConvention():
+    coordinates = Coordinates(domain='sph', convention='top_elev')
+    actual = Coordinates(domain='sph', convention='front')
+    assert not coordinates == actual
+
+
+def test___eq___differInUnit():
+    coordinates = Coordinates(
+        [1, 1], [1, 1], [1, 1],
+        convention='top_colat', domain='sph', unit='rad')
+    actual = Coordinates(
+        [1, 1], [1, 1], [1, 1],
+        convention='top_colat', domain='sph', unit='deg')
+    is_equal = coordinates == actual
+    assert not is_equal
+
+
+def test___eq___differInWeigths():
+    coordinates = Coordinates(1, 2, 3, weights=.5)
+    actual = Coordinates(1, 2, 3, weights=0.0)
+    assert not coordinates == actual
+
+
+def test___eq___differInShOrder():
+    coordinates = Coordinates(1, 2, 3, sh_order=2)
+    actual = Coordinates(1, 2, 3, sh_order=8)
+    assert not coordinates == actual
+
+
+def test___eq___differInShComment():
+    coordinates = Coordinates(1, 2, 3, comment="Madre mia!")
+    actual = Coordinates(1, 2, 3, comment="Oh my woooooosh!")
+    assert not coordinates == actual

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -171,3 +171,15 @@ def test_atleast_3d_first_dim():
     desired = arr.copy()
     arr_3d = fo.atleast_3d_first_dim(arr)
     npt.assert_array_equal(arr_3d, desired)
+
+
+def test___eq___equal(filter):
+    actual = filter.copy()
+    assert filter == actual
+
+
+def test___eq___notEqual(filter):
+    coeff = np.array([[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
+    state = np.array([[[1.0, 0.0]]])
+    actual = fo.Filter(coefficients=coeff, state=state, comment='my comment')
+    assert not filter == actual

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -184,5 +184,5 @@ def test___eq___notEqual(filter, coeffs, state):
     actual = fo.Filter(coefficients=coeffs, state=2 * state)
     assert not filter == actual
     actual = filter.copy()
-    actual.comment = "A completely different thing"
+    actual.comment = f'{actual.comment} A completely different thing'
     assert not filter == actual

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -178,8 +178,11 @@ def test___eq___equal(filter):
     assert filter == actual
 
 
-def test___eq___notEqual(filter):
-    coeff = np.array([[[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]]])
-    state = np.array([[[1.0, 0.0]]])
-    actual = fo.Filter(coefficients=coeff, state=state, comment='my comment')
+def test___eq___notEqual(filter, coeffs, state):
+    actual = fo.Filter(coefficients=2 * coeffs, state=state)
+    assert not filter == actual
+    actual = fo.Filter(coefficients=coeffs, state=2 * state)
+    assert not filter == actual
+    actual = filter.copy()
+    actual.comment = "A completely different thing"
     assert not filter == actual

--- a/tests/test_orientations.py
+++ b/tests/test_orientations.py
@@ -230,13 +230,11 @@ def test_orientations_rotation(views, ups, positions, orientations):
 
 
 def test___eq___equal(orientations, views, ups):
-    comparable = Orientations.from_view_up(views, ups)
-    is_equal = orientations == comparable
-    assert is_equal
+    actual = Orientations.from_view_up(views, ups)
+    assert orientations == actual
 
 
-def test___eq___not_equal(orientations, views, ups):
+def test___eq___notEqual(orientations, views, ups):
     rot_z45 = Rotation.from_euler('z', 45, degrees=True)
-    comparable = Orientations.from_view_up(views, ups) * rot_z45
-    is_equal = orientations == comparable
-    assert not is_equal
+    actual = Orientations.from_view_up(views, ups) * rot_z45
+    assert not orientations == actual

--- a/tests/test_orientations.py
+++ b/tests/test_orientations.py
@@ -227,3 +227,16 @@ def test_orientations_rotation(views, ups, positions, orientations):
     orientations = Orientations.from_view_up(views, ups)
     orientations = orientations * rot_x45
     orientations.show(positions)
+
+
+def test___eq___equal(orientations, views, ups):
+    comparable = Orientations.from_view_up(views, ups)
+    is_equal = orientations == comparable
+    assert is_equal
+
+
+def test___eq___not_equal(orientations, views, ups):
+    rot_z45 = Rotation.from_euler('z', 45, degrees=True)
+    comparable = Orientations.from_view_up(views, ups) * rot_z45
+    is_equal = orientations == comparable
+    assert not is_equal

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -373,14 +373,15 @@ def test_flatten():
     assert id(signal_in) != id(signal_out)
 
 
-
 def test___eq___equal(signal):
     sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
     actual = Signal(sine, 44100, len(sine), domain='time')
+    # TODO: This will fail due to infinite recursion error, see SignalIterator
     assert signal == actual
 
 
 def test___eq___notEqual(signal):
     sine = np.sin(2 * np.pi * 220 * np.arange(0, 1, 1 / 44100))
     actual = Signal(sine, 44100, len(sine), domain='time')
+    # TODO: This will fail due to infinite recursion error, see SignalIterator
     assert not signal == actual

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -373,16 +373,16 @@ def test_flatten():
     assert id(signal_in) != id(signal_out)
 
 
-def test___eq___equal(signal):
-    actual = signal.copy()
-    assert signal == actual
+def test___eq___equal(sine_signal):
+    actual = sine_signal.copy()
+    assert sine_signal == actual
 
 
-def test___eq___notEqual(signal, sine):
+def test___eq___notEqual(sine_signal, sine):
     actual = Signal(0.5 * sine.time, sine.sampling_rate, domain='time')
-    assert not signal == actual
+    assert not sine_signal == actual
     actual = Signal(sine.time, 2 * sine.sampling_rate, domain='time')
-    assert not signal == actual
-    actual = signal.copy()
-    actual.comment = "A completely different thing"
-    assert not signal == actual
+    assert not sine_signal == actual
+    actual = sine_signal.copy()
+    actual.comment += "A completely different thing"
+    assert not sine_signal == actual

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -374,13 +374,15 @@ def test_flatten():
 
 
 def test___eq___equal(signal):
-    sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
-    actual = Signal(sine, 44100, len(sine), domain='time')
+    actual = signal.copy()
     assert signal == actual
 
-import deepdiff
 
-def test___eq___notEqual(signal):
-    sine = np.sin(2 * np.pi * 220 * np.arange(0, 1, 1 / 44100))
-    actual = Signal(sine, 44100, len(sine), domain='time')
+def test___eq___notEqual(signal, sine):
+    actual = Signal(0.5 * sine.time, sine.sampling_rate, domain='time')
+    assert not signal == actual
+    actual = Signal(sine.time, 2 * sine.sampling_rate, domain='time')
+    assert not signal == actual
+    actual = signal.copy()
+    actual.comment = "A completely different thing"
     assert not signal == actual

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -371,3 +371,16 @@ def test_flatten():
 
     npt.assert_allclose(signal_in._data.reshape((6, -1)), signal_out._data)
     assert id(signal_in) != id(signal_out)
+
+
+
+def test___eq___equal(signal):
+    sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
+    actual = Signal(sine, 44100, len(sine), domain='time')
+    assert signal == actual
+
+
+def test___eq___notEqual(signal):
+    sine = np.sin(2 * np.pi * 220 * np.arange(0, 1, 1 / 44100))
+    actual = Signal(sine, 44100, len(sine), domain='time')
+    assert not signal == actual

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -376,12 +376,11 @@ def test_flatten():
 def test___eq___equal(signal):
     sine = np.sin(2 * np.pi * 440 * np.arange(0, 1, 1 / 44100))
     actual = Signal(sine, 44100, len(sine), domain='time')
-    # TODO: This will fail due to infinite recursion error, see SignalIterator
     assert signal == actual
 
+import deepdiff
 
 def test___eq___notEqual(signal):
     sine = np.sin(2 * np.pi * 220 * np.arange(0, 1, 1 / 44100))
     actual = Signal(sine, 44100, len(sine), domain='time')
-    # TODO: This will fail due to infinite recursion error, see SignalIterator
     assert not signal == actual

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -88,3 +88,14 @@ def test_voronoi_error_not_enough_points():
     s = Coordinates(points[0], points[1], points[2])
     with pytest.raises(ValueError, match='points needs to be at least 4'):
         spatial.calculate_sph_voronoi_weights(s)
+
+
+def test___eq___equal(sphericalvoronoi):
+    actual = sphericalvoronoi.copy()
+    assert sphericalvoronoi == actual
+
+
+def test___eq___notEqual(sphericalvoronoi):
+    actual = sphericalvoronoi.copy()
+    actual.center += 42
+    assert not sphericalvoronoi == actual

--- a/tests/test_spatial.py
+++ b/tests/test_spatial.py
@@ -97,5 +97,5 @@ def test___eq___equal(sphericalvoronoi):
 
 def test___eq___notEqual(sphericalvoronoi):
     actual = sphericalvoronoi.copy()
-    actual.center += 42
+    actual.center = 42
     assert not sphericalvoronoi == actual

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,12 +3,13 @@ import numpy as np
 import numpy.testing as npt
 
 
-def test_copy():
+def test_copy(sphericalvoronoi):
     """ Test copy method used by several classes."""
     obj_list = [pyfar.Signal(1000, 44100),
                 pyfar.Orientations(),
                 pyfar.Coordinates(),
-                pyfar.dsp.Filter()]
+                pyfar.dsp.Filter(),
+                sphericalvoronoi]
 
     for obj in obj_list:
         # Create copy


### PR DESCRIPTION
Every public class has now the `__eq__(self)`-method. This enables comparison with `actual == other`. Deepdiff has been chosen because it compares recursivly, shows differences if present and has some nice ignore -features. Moreover it seems to be very stable and is very well supported.

### Test Not Passing
Two tests in test_signal are deliberately not passing. `SignalIterator` seems to have an infinite recursion problem.
