### PR TITLE
Replace deprecated numpy types by builtins

### DIFF
--- a/pyfar/_codec.py
+++ b/pyfar/_codec.py
@@ -295,7 +295,7 @@ def _is_dtype(obj):
     """ True if object is `numpy.dtype`.
     """
     return isinstance(obj, type) and (
-        obj.__module__ == 'numpy' or obj == np.complex)
+        obj.__module__ == 'numpy' or obj == complex)
 
 
 def _is_numpy_scalar(obj):

--- a/pyfar/dsp/filter.py
+++ b/pyfar/dsp/filter.py
@@ -800,13 +800,13 @@ def _center_frequencies_fractional_octaves_iec(nominal, num_fractions):
     if num_fractions == 1:
         nominal = np.array([
             31.5, 63, 125, 250, 500, 1e3,
-            2e3, 4e3, 8e3, 16e3], dtype=np.float)
+            2e3, 4e3, 8e3, 16e3], dtype=float)
     elif num_fractions == 3:
         nominal = np.array([
             25, 31.5, 40, 50, 63, 80, 100, 125, 160,
             200, 250, 315, 400, 500, 630, 800, 1000,
             1250, 1600, 2000, 2500, 3150, 4000, 5000,
-            6300, 8000, 10000, 12500, 16000, 20000], dtype=np.float)
+            6300, 8000, 10000, 12500, 16000, 20000], dtype=float)
 
     reference_freq = 1e3
     octave_ratio = 10**(3/10)

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -140,7 +140,7 @@ class MultipleFractionFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         den = self._denominator
-        num = np.int(np.rint(den*x/self._base))
+        num = int(np.rint(den*x/self._base))
         com = self._gcd(num, den)
         (num, den) = (int(num / com), int(den/com))
         if den == 1:

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -310,7 +310,7 @@ class TimeData(_Audio):
             like, a numpy array of indices is returned.
         """
         times = np.atleast_1d(value)
-        indices = np.zeros_like(times).astype(np.int)
+        indices = np.zeros_like(times).astype(int)
         for idx, time in enumerate(times):
             indices[idx] = np.argmin(np.abs(self.times - time))
         return np.squeeze(indices)
@@ -466,7 +466,7 @@ class FrequencyData(_Audio):
             a numpy array of indices is returned.
         """
         freqs = np.atleast_1d(value)
-        indices = np.zeros_like(freqs).astype(np.int)
+        indices = np.zeros_like(freqs).astype(int)
         for idx, freq in enumerate(freqs):
             indices[idx] = np.argmin(np.abs(self.frequencies - freq))
         return np.squeeze(indices)

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -364,7 +364,7 @@ class FrequencyData(_Audio):
 
     """
     def __init__(self, data, frequencies, fft_norm=None, comment=None,
-                 dtype=np.complex):
+                 dtype=complex):
         """Init FrequencyData with data, and frequencies.
 
         Attributes
@@ -398,7 +398,7 @@ class FrequencyData(_Audio):
         _Audio.__init__(self, 'freq', comment, dtype)
 
         # init data
-        self._data = np.atleast_2d(np.asarray(data, dtype=np.complex))
+        self._data = np.atleast_2d(np.asarray(data, dtype=complex))
 
         # init frequencies
         self._frequencies = np.atleast_1d(np.asarray(frequencies).flatten())
@@ -590,7 +590,7 @@ class Signal(FrequencyData, TimeData):
 
             TimeData.__init__(self, data, self.times, comment, dtype)
         elif domain == 'freq':
-            self._data = np.atleast_2d(np.asarray(data, dtype=np.complex))
+            self._data = np.atleast_2d(np.asarray(data, dtype=complex))
 
             n_bins = self._data.shape[-1]
             if n_samples is None:

--- a/pyfar/spatial/external/eq_area_partitions.py
+++ b/pyfar/spatial/external/eq_area_partitions.py
@@ -107,7 +107,7 @@ def point_set_polar(dimension, N):
 
             a_point = (a_top + a_bot)/2
 
-            point_l_n = np.arange(0, np.size(points_l), dtype=np.int)
+            point_l_n = np.arange(0, np.size(points_l), dtype=int)
             # points_l = points_l[np.newaxis]
 
             if dimension == 2:
@@ -172,7 +172,7 @@ def caps(dimension, N):
     """
     if dimension == 1:
         s_cap = np.linspace(2*np.pi/N, 2*np.pi, N)
-        n_regions = np.ones(10, dtype=np.int)
+        n_regions = np.ones(10, dtype=int)
     elif N == 1:
         s_cap = np.pi
         n_regions = 1
@@ -282,7 +282,7 @@ def round_to_naturals(N, r_regions):
         The rounded integer number per collar.
     """
     r_regions = np.asarray(r_regions)
-    n_regions = np.zeros(r_regions.shape, dtype=np.int)
+    n_regions = np.zeros(r_regions.shape, dtype=int)
     discrepancy = 0
 
     for zone_n in range(0, np.size(r_regions)):
@@ -351,12 +351,12 @@ def num_collars(N, c_polar, a_ideal):
         The real number of collars.
 
     """
-    if np.int((N > 2) and (a_ideal > 0)):
+    if int((N > 2) and (a_ideal > 0)):
         n_collars = np.maximum(1, np.rint((np.pi - 2*c_polar) / a_ideal))
     else:
         n_collars = 0
 
-    return np.int(n_collars)
+    return int(n_collars)
 
 
 def circle_offset(n_top, n_bot, extra_twist=False):

--- a/pyfar/spatial/samplings.py
+++ b/pyfar/spatial/samplings.py
@@ -482,7 +482,7 @@ def sph_t_design(degree=None, sh_order=None, criterion='const_energy',
         raise ValueError('degree must be between 1 and 180.')
 
     # get the number of points
-    n_points = np.int(np.ceil((degree + 1)**2 / 2) + 1)
+    n_points = int(np.ceil((degree + 1)**2 / 2) + 1)
     n_points_exceptions = {3: 8, 5: 18, 7: 32, 9: 50, 11: 72, 13: 98, 15: 128}
     if degree in n_points_exceptions:
         n_points = n_points_exceptions[degree]
@@ -1020,7 +1020,7 @@ def _sph_t_design_load_data(degrees='all'):
 
     for degree in degrees:
         # number of sampling points
-        n_points = np.int(np.ceil((degree + 1)**2 / 2) + 1)
+        n_points = int(np.ceil((degree + 1)**2 / 2) + 1)
         if degree in n_points_exceptions:
             n_points = n_points_exceptions[degree]
 

--- a/pyfar/testing/stub_utils.py
+++ b/pyfar/testing/stub_utils.py
@@ -154,7 +154,7 @@ def sine_func(frequency, sampling_rate, n_samples, fft_norm, cshape):
     time = np.sin(2 * np.pi * frequency[..., np.newaxis] * times)
     # Spectrum
     n_bins = int(n_samples / 2) + 1
-    freq = np.zeros(cshape + (n_bins,), dtype=np.complex)
+    freq = np.zeros(cshape + (n_bins,), dtype=complex)
     for idx, f in np.ndenumerate(frequency):
         f_bin = int(f / sampling_rate * n_samples)
         freq[idx + (f_bin,)] = -0.5j * float(n_samples)

--- a/tests/test_eq_area_partitions.py
+++ b/tests/test_eq_area_partitions.py
@@ -23,7 +23,7 @@ def test_caps_dim_1():
          2.513274122871834, 3.141592653589793, 3.769911184307752,
          4.398229715025710, 5.026548245743669, 5.654866776461628,
          6.283185307179586])
-    reference_regions = np.ones(10, dtype=np.int)
+    reference_regions = np.ones(10, dtype=int)
     dim = 1
     N = 10
     s_cap, n_regions = eq.caps(dim, N)

--- a/tests/test_stub_utils.py
+++ b/tests/test_stub_utils.py
@@ -136,7 +136,7 @@ def test_impulse_func_multi_channel():
 def test_normalization_none():
     """ Test unitary FFT normalization implemented in stubs_utils.py"""
     n_samples = 4
-    freq = np.array([1, 1, 1], dtype=np.complex)
+    freq = np.array([1, 1, 1], dtype=complex)
     freq_norm = stub_utils._normalization(freq, n_samples, 'none')
     npt.assert_allclose(freq, freq_norm, rtol=1e-10)
 
@@ -145,8 +145,8 @@ def test_normalization_rms_even():
     """ Test RMS FFT normalization implemented in stubs_utils.py,
     even number of samples."""
     n_samples = 4
-    freq = np.array([1, 1, 1], dtype=np.complex)
-    freq_norm_truth = np.array([1, np.sqrt(2), 1], dtype=np.complex)
+    freq = np.array([1, 1, 1], dtype=complex)
+    freq_norm_truth = np.array([1, np.sqrt(2), 1], dtype=complex)
     freq_norm_truth /= n_samples
     freq_norm = stub_utils._normalization(freq, n_samples, 'rms')
     npt.assert_allclose(freq_norm, freq_norm_truth, rtol=1e-10)
@@ -156,8 +156,8 @@ def test_normalization_rms_odd():
     """ Test RMS FFT normalization implemented in stubs_utils.py,
     odd number of samples."""
     n_samples = 5
-    freq = np.array([1, 1, 1], dtype=np.complex)
-    freq_norm_truth = np.array([1, np.sqrt(2), np.sqrt(2)], dtype=np.complex)
+    freq = np.array([1, 1, 1], dtype=complex)
+    freq_norm_truth = np.array([1, np.sqrt(2), np.sqrt(2)], dtype=complex)
     freq_norm_truth /= n_samples
     freq_norm = stub_utils._normalization(freq, n_samples, 'rms')
     npt.assert_allclose(freq_norm, freq_norm_truth, rtol=1e-10)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #103 

### Changes proposed in this pull request:

Replace deprecated numpy aliases of types by builtins. For a full list of deprecated types see the numpy release notes [here](https://numpy.org/devdocs/release/1.20.0-notes.html).
