### PR TITLE
restricted range of python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,4 +61,5 @@ setup(
     url='https://github.com/pyfar/pyfar',
     version='0.1.0',
     zip_safe=False,
+    python_requires='>=3.7,<3.9'
 )


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

As discussed during the weekly

### Changes proposed in this pull request:

- Restrict python version to >=3.8,<3.9 in setup.py

I've tested this using `pip install -e path/to/my/local/pyfar` and it worked as expected. I get

ERROR: Package 'pyfar' requires a different Python: 3.9.2 not in '<3.9,>=3.7'
and
ERROR: Package 'pyfar' requires a different Python: 3.6.13 not in '<3.9,>=3.7'

when installing pyfar in environments with out of range python versions.

Everything works fine if for python 3.7 and 3.8.