### PR TITLE
Documentation for audio classes

### DIFF
--- a/docs/pyfar.classes_audio.rst
+++ b/docs/pyfar.classes_audio.rst
@@ -4,6 +4,6 @@ Audio (Signal, TimeData, FrequencyData)
 .. automodule:: pyfar.signal
    :members:
    :undoc-members:
-   :special-members: __init__
+   :special-members: [, __init__, __getitem__, __setitem__, __iter__, ]
    :show-inheritance:
    :inherited-members:

--- a/docs/pyfar.classes_audio.rst
+++ b/docs/pyfar.classes_audio.rst
@@ -6,3 +6,4 @@ Audio (Signal, TimeData, FrequencyData)
    :undoc-members:
    :special-members: __init__
    :show-inheritance:
+   :inherited-members:

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -381,7 +381,7 @@ class FrequencyData(_Audio):
         fft_norm : str, optional
             The normalization of the Discrete Fourier Transform (DFT). Can be
             'none', 'unitary', 'amplitude', 'rms', 'power', or 'psd'. See
-            :py:func:`pyfar.dsp.fft.normalization` and _[#] for more
+            :py:func:`pyfar.dsp.fft.normalization` and [#]_ for more
             information. The default is 'none', which is typically used for
             energy signals, such as impulse responses.
         comment : str, optional
@@ -558,7 +558,7 @@ class Signal(FrequencyData, TimeData):
         fft_norm : str, optional
             The normalization of the Discrete Fourier Transform (DFT). Can be
             'none', 'unitary', 'amplitude', 'rms', 'power', or 'psd'. See
-            :py:func:`pyfar.dsp.fft.normalization` and _[#] for more
+            :py:func:`pyfar.dsp.fft.normalization` and [#]_ for more
             information. The default is 'none', which is typically used for
             energy signals, such as impulse responses.
         comment : str

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -1,5 +1,5 @@
 """
-Provide Container classes and arithmethic operations for audio data.
+Container classes and arithmethic operations for audio data.
 
 The classes `TimeData` and `DataFrequency` are intended to store incomplete or
 non-equidistant audio data in the time and frequency domain. The class `Signal`
@@ -11,16 +11,16 @@ are implemented in the methods `add`, `subtract`, `multiply`, `divide`, and
 `power`. For example, two Signal, TimeData, or FrequencyData instances can be
 added in the time domain by
 
-> result = pyfar.signal.add((signal_1, signal_2), 'time')
+``result = pyfar.signal.add((signal_1, signal_2), 'time')``
 
 and in the frequency domain by
 
-> result = pyfar.signal.add((signal_1, signal_2), 'freq')
+``result = pyfar.signal.add((signal_1, signal_2), 'freq')``
 
 This also works with more than two instances and supports array likes and
 scalar values, e.g.,
 
-> result = pyfar.signal.add((signal_1, 1), 'time')
+``result = pyfar.signal.add((signal_1, 1), 'time')``
 
 In this case the scalar `1` is broadcasted, i.e., 1 is added to every sample of
 the Signal (or every bin in case of a frequency domain operation).
@@ -29,19 +29,19 @@ The operators `+`, `-`, `*`, `/`, and `**` are overloaded for convenience.
 Note, however, that their behavior depends on the Audio object. Frequency
 domain operations are applied for `Signal` and `FrequencyData` objects, i.e,
 
-> result = signal1 + signal2
+``result = signal1 + signal2``
 
 is equivalent to
 
-> result = pyfar.signal.add((signal1, signal2), 'freq')
+``result = pyfar.signal.add((signal1, signal2), 'freq')``
 
 Time domain operations are applied for `TimeData` objects, i.e.,
 
-> result = time_data_1 + time_data_2
+``result = time_data_1 + time_data_2``
 
 is equivalent to
 
-> result = pyfar.signal.add((time_data_1, time_data_2), 'time')
+``result = pyfar.signal.add((time_data_1, time_data_2), 'time')``
 
 """
 

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -43,6 +43,11 @@ is equivalent to
 
 ``result = pyfar.signal.add((time_data_1, time_data_2), 'time')``
 
+In addition to the arithmetic operations, the is equal operator is overloaded
+to allow comparisons
+
+``signal_1 == signal_2``.
+
 """
 
 from copy import deepcopy
@@ -199,7 +204,18 @@ class _Audio():
         raise NotImplementedError("To be implemented by derived classes.")
 
     def __getitem__(self, key):
-        """Get signal channels at key.
+        """
+        Get copied slice of the audio object at key.
+
+        Examples
+        --------
+        Get the first channel of a multi channel Signal object
+
+        >>> import pyfar
+        >>> signal = pyfar.signals.noise(10, rms=[1, 1])
+        >>> first_channel = signal[0]
+
+
         """
         if isinstance(key, (int, slice, tuple)):
             try:
@@ -213,7 +229,16 @@ class _Audio():
         return self._return_item(data)
 
     def __setitem__(self, key, value):
-        """Set signal channels at key.
+        """
+        Set channels of audio object at key.
+
+        Examples
+        --------
+        Set the first channel of a multi channel Signal object
+
+        >>> import pyfar
+        >>> signal = pyfar.signals.noise(10, rms=[1, 1])
+        >>> signal[0] = pyfar.signals.noise(10, rms=2)
         """
         self._assert_matching_meta_data(value)
         if isinstance(key, (int, slice)):
@@ -226,8 +251,21 @@ class _Audio():
                     "Index must be int, not {}".format(type(key).__name__))
 
     def __iter__(self):
-        """Iterator for signals. The actual iteration is handled through
-        numpy's array iteration.
+        """Iterator for audio objects.
+
+        Iterate across the first dimension of an audio object. The actual
+        iteration is handled through numpy's array iteration.
+
+        Examples
+        --------
+        Iterate channels of a Signal object
+
+        >>> import pyfar
+        >>>
+        >>> signal = pyfar.signals.impulse(2, amplitude=[1, 1, 1])
+        >>> for idx, channel in enumerate(signal):
+        >>>     channel.time *= idx
+        >>>     signal[idx] = channel
         """
         return _SignalIterator(self._data.__iter__(), self)
 

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -250,25 +250,6 @@ class _Audio():
             raise TypeError(
                     "Index must be int, not {}".format(type(key).__name__))
 
-    def __iter__(self):
-        """Iterator for audio objects.
-
-        Iterate across the first dimension of an audio object. The actual
-        iteration is handled through numpy's array iteration.
-
-        Examples
-        --------
-        Iterate channels of a Signal object
-
-        >>> import pyfar
-        >>>
-        >>> signal = pyfar.signals.impulse(2, amplitude=[1, 1, 1])
-        >>> for idx, channel in enumerate(signal):
-        >>>     channel.time *= idx
-        >>>     signal[idx] = channel
-        """
-        return _SignalIterator(self._data.__iter__(), self)
-
 
 class TimeData(_Audio):
     """Class for time data.
@@ -819,6 +800,25 @@ class Signal(FrequencyData, TimeData):
         """Length of the object which is the number of samples stored.
         """
         return self.n_samples
+
+    def __iter__(self):
+        """Iterator for audio objects.
+
+        Iterate across the first dimension of an audio object. The actual
+        iteration is handled through numpy's array iteration.
+
+        Examples
+        --------
+        Iterate channels of a Signal object
+
+        >>> import pyfar
+        >>>
+        >>> signal = pyfar.signals.impulse(2, amplitude=[1, 1, 1])
+        >>> for idx, channel in enumerate(signal):
+        >>>     channel.time *= idx
+        >>>     signal[idx] = channel
+        """
+        return _SignalIterator(self._data.__iter__(), self)
 
 
 class _SignalIterator(object):

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -400,7 +400,7 @@ class TimeData(_Audio):
 
 
 class FrequencyData(_Audio):
-    """Class for frequency data object.
+    """Class for frequency data.
 
     Objects of this class contain frequency data which is not directly
     convertable to the time domain, i.e., non-equidistantly spaced bins or
@@ -416,9 +416,7 @@ class FrequencyData(_Audio):
         data : array, double
             Raw data in the frequency domain. The memory layout of Data is 'C'.
             E.g. data of shape (3, 2, 1024) has 3 x 2 channels with 1024
-            frequency bins each. Frequency data must be provided as single
-            sided spectra, i.e., for all frequencies between 0 Hz and half the
-            sampling rate.
+            frequency bins each.
         frequencies : array, double
             Frequencies of the data in Hz. The number of frequencies must match
             the size of the last dimension of data.

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -225,6 +225,12 @@ class _Audio():
             raise TypeError(
                     "Index must be int, not {}".format(type(key).__name__))
 
+    def __iter__(self):
+        """Iterator for signals. The actual iteration is handled through
+        numpy's array iteration.
+        """
+        return _SignalIterator(self._data.__iter__(), self)
+
 
 class TimeData(_Audio):
     """Class for time data.
@@ -778,14 +784,8 @@ class Signal(FrequencyData, TimeData):
         """
         return self.n_samples
 
-    def __iter__(self):
-        """Iterator for signals. The actual iteration is handled through
-        numpy's array iteration.
-        """
-        return SignalIterator(self._data.__iter__(), self)
 
-
-class SignalIterator(object):
+class _SignalIterator(object):
     """Iterator for signals
     """
     def __init__(self, array_iterator, signal):

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -27,7 +27,7 @@ the Signal (or every bin in case of a frequency domain operation).
 
 The operators `+`, `-`, `*`, `/`, and `**` are overloaded for convenience.
 Note, however, that their behavior depends on the Audio object. Frequency
-domain operations are applied for `Signal` and `FrequencyData` objects, i.e,
+domain operations are applied for Signal and FrequencyData objects, i.e,
 
 ``result = signal1 + signal2``
 
@@ -35,7 +35,7 @@ is equivalent to
 
 ``result = pyfar.signal.add((signal1, signal2), 'freq')``
 
-Time domain operations are applied for `TimeData` objects, i.e.,
+Time domain operations are applied for TimeData objects, i.e.,
 
 ``result = time_data_1 + time_data_2``
 
@@ -43,7 +43,7 @@ is equivalent to
 
 ``result = pyfar.signal.add((time_data_1, time_data_2), 'time')``
 
-In addition to the arithmetic operations, the is equal operator is overloaded
+In addition to the arithmetic operations, the equality operator is overloaded
 to allow comparisons
 
 ``signal_1 == signal_2``.
@@ -93,12 +93,12 @@ class _Audio():
 
     @property
     def domain(self):
-        """The domain the data is stored in"""
+        """The domain the data is stored in."""
         return self._domain
 
     @property
     def dtype(self):
-        """The data type of the signal. This can be any data type and precision
+        """The data type of the audio object. This can be any data type and precision
         supported by numpy."""
         return self._dtype
 
@@ -107,27 +107,27 @@ class _Audio():
         """
         Return channel shape.
 
-        The channel shape gives the shape of the signal data excluding the last
-        dimension, which is `self.n_samples` for time domain signals and
-        `self.n_bins` for frequency domain signals.
+        The channel shape gives the shape of the audio data excluding the last
+        dimension, which is `n_samples` for time domain objects and
+        `n_bins` for frequency domain objects.
         """
         return self._data.shape[:-1]
 
     def reshape(self, newshape):
         """
-        Return reshaped copy of the signal.
+        Return reshaped copy of the audio object.
 
         Parameters
         ----------
         newshape : int, tuple
-            new cshape of the signal. One entry of newshape dimension can be
+            new cshape of the audio object. One entry of newshape dimension can be
             -1. In this case, the value is inferred from the remaining
             dimensions.
 
         Returns
         -------
-        reshaped : Signal
-            reshaped copy of the signal.
+        reshaped : Signal, FrequencyData, TimeData
+            reshaped copy of the audio object.
 
         Notes
         -----
@@ -150,25 +150,25 @@ class _Audio():
                 newshape + (length_last_dimension, ))
         except ValueError:
             if np.prod(newshape) != np.prod(self.cshape):
-                raise ValueError((f"Can not reshape signal of cshape "
+                raise ValueError((f"Can not reshape audio object of cshape "
                                   f"{self.cshape} to {newshape}"))
 
         return reshaped
 
     def flatten(self):
-        """Return flattened copy of the signal.
+        """Return flattened copy of the audio object.
 
         Returns
         -------
-        flat : Signal
-            Flattened copy of signal with
-            `flat.cshape = np.prod(signal.cshape)`
+        flat : Signal, FrequencyData, TimeData
+            Flattened copy of audio object with
+            `flat.cshape = np.prod(audio.cshape)`
 
         Notes
         -----
         The number of samples and frequency bins always remains the same, e.g.,
-        a signal of `cshape=(4,3)` and `n_samples=512` will have
-        `chsape=(12, )` and `n_samples=512` after flattening.
+        an audio object of `cshape=(4,3)` and `n_samples=512` will have
+        `cshape=(12, )` and `n_samples=512` after flattening.
 
         """
         newshape = int(np.prod(self.cshape))
@@ -186,7 +186,7 @@ class _Audio():
         self._comment = 'none' if value is None else str(value)
 
     def copy(self):
-        """Return a copy of the Signal object."""
+        """Return a copy of the audio object."""
         return deepcopy(self)
 
     def _return_item(self):
@@ -255,7 +255,7 @@ class TimeData(_Audio):
     """Class for time data.
 
     Objects of this class contain time data which is not directly convertable
-    to thefrequency domain, i.e., non-equidistantly spaced samples.
+    to frequency domain, i.e., non-equidistant samples.
 
     """
     def __init__(self, data, times, comment=None, dtype=np.double):
@@ -273,7 +273,7 @@ class TimeData(_Audio):
         comment : str, optional
             A comment related to the data. The default is None.
         dtype : string, optional
-            Raw data type of the signal. The default is float64.
+            Raw data type of the audio object. The default is float64.
         """
 
         _Audio.__init__(self, 'time', comment, dtype)
@@ -312,7 +312,7 @@ class TimeData(_Audio):
 
     @property
     def signal_length(self):
-        """The length of the signal in seconds."""
+        """The length of the data in seconds."""
         return self.times[-1]
 
     @property
@@ -410,7 +410,7 @@ class FrequencyData(_Audio):
         comment : str, optional
             A comment related to the data. The default is None.
         dtype : string, optional
-            Raw data type of the signal. The default is float64.
+            Raw data type of the audio object. The default is float64.
 
         References
         ----------
@@ -547,8 +547,7 @@ class Signal(FrequencyData, TimeData):
     """Class for audio signals.
 
     Objects of this class contain data which is directly convertable between
-    time and frequency domain. Equally spaced samples or frequency bins,
-    respectively.
+    time and frequency domain (equally spaced samples and frequency bins).
 
     """
     def __init__(
@@ -571,7 +570,7 @@ class Signal(FrequencyData, TimeData):
             must be provided as single sided spectra, i.e., for all frequencies
             between 0 Hz and half the sampling rate.
         sampling_rate : double
-            Sampling rate in Hertz
+            Sampling rate in Hz
         n_samples : int, optional
             Number of samples of the time signal. Required if domain is 'freq'.
             The default is None, which assumes an even number of samples if the
@@ -587,7 +586,7 @@ class Signal(FrequencyData, TimeData):
         comment : str
             A comment related to the data. The default is None.
         dtype : string, optional
-            Raw data type of the signal. The default is float64
+            Raw data type of the audio object. The default is float64
 
         References
         ----------
@@ -846,7 +845,7 @@ class _SignalIterator(object):
 
 
 def add(data: tuple, domain='freq'):
-    """Add pyfar audio objects, array likes, an scalars.
+    """Add pyfar audio objects, array likes, and scalars.
 
     Pyfar audio objects are: Signal, TimeData, and FrequencyData.
 
@@ -866,7 +865,7 @@ def add(data: tuple, domain='freq'):
     -------
     results : Signal, numpy array
         Result of the operation as numpy array, if `data` contains only array
-        likes and numbers. Result as pyfar audio object if `data`contains a an
+        likes and numbers. Result as pyfar audio object if `data` contains an
         audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
         Otherwise the first ``fft_norm`` that is not 'none' is used.
 
@@ -875,7 +874,7 @@ def add(data: tuple, domain='freq'):
 
 
 def subtract(data: tuple, domain='freq'):
-    """Subtract pyfar audio objects, array likes, an scalars.
+    """Subtract pyfar audio objects, array likes, and scalars.
 
     Pyfar audio objects are: Signal, TimeData, and FrequencyData.
 
@@ -895,7 +894,7 @@ def subtract(data: tuple, domain='freq'):
     -------
     results : Signal, numpy array
         Result of the operation as numpy array, if `data` contains only array
-        likes and numbers. Result as pyfar audio object if `data`contains a an
+        likes and numbers. Result as pyfar audio object if `data` contains an
         audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
         Otherwise the first ``fft_norm`` that is not 'none' is used.
 
@@ -904,7 +903,7 @@ def subtract(data: tuple, domain='freq'):
 
 
 def multiply(data: tuple, domain='freq'):
-    """Multiply pyfar audio objects, array likes, an scalars.
+    """Multiply pyfar audio objects, array likes, and scalars.
 
     Pyfar audio objects are: Signal, TimeData, and FrequencyData.
 
@@ -924,7 +923,7 @@ def multiply(data: tuple, domain='freq'):
     -------
     results : Signal, numpy array
         Result of the operation as numpy array, if `data` contains only array
-        likes and numbers. Result as pyfar audio object if `data`contains a an
+        likes and numbers. Result as pyfar audio object if `data` contains an
         audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
         Otherwise the first ``fft_norm`` that is not 'none' is used.
 
@@ -933,7 +932,7 @@ def multiply(data: tuple, domain='freq'):
 
 
 def divide(data: tuple, domain='freq'):
-    """Divide pyfar audio objects, array likes, an scalars.
+    """Divide pyfar audio objects, array likes, and scalars.
 
     Parameters
     ----------
@@ -951,7 +950,7 @@ def divide(data: tuple, domain='freq'):
     -------
     results : Signal, numpy array
         Result of the operation as numpy array, if `data` contains only array
-        likes and numbers. Result as pyfar audio object if `data`contains a an
+        likes and numbers. Result as pyfar audio object if `data` contains an
         audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
         Otherwise the first ``fft_norm`` that is not 'none' is used.
 
@@ -960,7 +959,7 @@ def divide(data: tuple, domain='freq'):
 
 
 def power(data: tuple, domain='freq'):
-    """Power of pyfar audio objects, array likes, an scalars.
+    """Power of pyfar audio objects, array likes, and scalars.
 
     Parameters
     ----------
@@ -978,7 +977,7 @@ def power(data: tuple, domain='freq'):
     -------
     results : Signal, numpy array
         Result of the operation as numpy array, if `data` contains only array
-        likes and numbers. Result as pyfar audio object if `data`contains a an
+        likes and numbers. Result as pyfar audio object if `data` contains an
         audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
         Otherwise the first ``fft_norm`` that is not 'none' is used.
 

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -801,9 +801,9 @@ class Signal(FrequencyData, TimeData):
         return self.n_samples
 
     def __iter__(self):
-        """Iterator for audio objects.
+        """Iterator for Signal objects.
 
-        Iterate across the first dimension of an audio object. The actual
+        Iterate across the first dimension of a Signal object. The actual
         iteration is handled through numpy's array iteration.
 
         Examples

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -120,8 +120,8 @@ class _Audio():
         Parameters
         ----------
         newshape : int, tuple
-            new cshape of the audio object. One entry of newshape dimension can be
-            -1. In this case, the value is inferred from the remaining
+            new cshape of the audio object. One entry of newshape dimension
+            can be -1. In this case, the value is inferred from the remaining
             dimensions.
 
         Returns

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -1,15 +1,16 @@
 """
 Container classes and arithmethic operations for audio data.
 
-The classes `TimeData` and `DataFrequency` are intended to store incomplete or
-non-equidistant audio data in the time and frequency domain. The class `Signal`
-can be used to store equidistant and complete audio data that can be converted
-between the time and frequency domain by means of the Fourier transform.
+The classes :py:func:`TimeData` and :py:func:`FrequencyData` are intended to
+store incomplete or non-equidistant audio data in the time and frequency
+domain. The class :py:func:`Signal` can be used to store equidistant and
+complete audio data that can be converted between the time and frequency
+domain by means of the Fourier transform.
 
 Arithmetic operations can be applied in the time and frequency domain and
-are implemented in the methods `add`, `subtract`, `multiply`, `divide`, and
-`power`. For example, two Signal, TimeData, or FrequencyData instances can be
-added in the time domain by
+are implemented in the methods ``add``, ``subtract``, ``multiply``, ``divide``,
+and ``power``. For example, two :py:func:`Signal`, :py:func:`TimeData`, or
+:py:func:`FrequencyData` instances can be added in the time domain by
 
 ``result = pyfar.signal.add((signal_1, signal_2), 'time')``
 
@@ -22,12 +23,13 @@ scalar values, e.g.,
 
 ``result = pyfar.signal.add((signal_1, 1), 'time')``
 
-In this case the scalar `1` is broadcasted, i.e., 1 is added to every sample of
-the Signal (or every bin in case of a frequency domain operation).
+In this case the scalar `1` is broadcasted, i.e., it is is added to every
+sample of `signal` (or every bin in case of a frequency domain operation).
 
-The operators `+`, `-`, `*`, `/`, and `**` are overloaded for convenience.
-Note, however, that their behavior depends on the Audio object. Frequency
-domain operations are applied for Signal and FrequencyData objects, i.e,
+The operators ``+``, ``-``, ``*``, ``/``, and ``**`` are overloaded for
+convenience. Note, however, that their behavior depends on the Audio object.
+Frequency domain operations are applied for :py:func:`Signal` and
+:py:func:`FrequencyData` objects, i.e,
 
 ``result = signal1 + signal2``
 
@@ -35,7 +37,7 @@ is equivalent to
 
 ``result = pyfar.signal.add((signal1, signal2), 'freq')``
 
-Time domain operations are applied for TimeData objects, i.e.,
+Time domain operations are applied for :py:func:`TimeData` objects, i.e.,
 
 ``result = time_data_1 + time_data_2``
 
@@ -62,7 +64,8 @@ class _Audio():
     """Abstract class for audio objects.
 
     This class holds all the methods and properties that are common to its
-    three sub-classes `TimeData`, `FrequencyData`, and `Signal`.
+    three sub-classes :py:func:`TimeData`, :py:func:`FrequencyData`, and
+    :py:func:`Signal`.
     """
 
     def __init__(self, domain, comment=None, dtype=np.double):
@@ -98,8 +101,8 @@ class _Audio():
 
     @property
     def dtype(self):
-        """The data type of the audio object. This can be any data type and precision
-        supported by numpy."""
+        """The data type of the audio object. This can be any data type and
+        precision supported by numpy."""
         return self._dtype
 
     @property
@@ -120,9 +123,9 @@ class _Audio():
         Parameters
         ----------
         newshape : int, tuple
-            new cshape of the audio object. One entry of newshape dimension
-            can be -1. In this case, the value is inferred from the remaining
-            dimensions.
+            new `cshape` of the audio object. One entry of newshape dimension
+            can be ``-1``. In this case, the value is inferred from the
+            remaining dimensions.
 
         Returns
         -------
@@ -162,13 +165,13 @@ class _Audio():
         -------
         flat : Signal, FrequencyData, TimeData
             Flattened copy of audio object with
-            `flat.cshape = np.prod(audio.cshape)`
+            ``flat.cshape = np.prod(audio.cshape)``
 
         Notes
         -----
         The number of samples and frequency bins always remains the same, e.g.,
-        an audio object of `cshape=(4,3)` and `n_samples=512` will have
-        `cshape=(12, )` and `n_samples=512` after flattening.
+        an audio object of ``cshape=(4,3)`` and ``n_samples=512`` will have
+        ``cshape=(12, )`` and ``n_samples=512`` after flattening.
 
         """
         newshape = int(np.prod(self.cshape))
@@ -209,7 +212,7 @@ class _Audio():
 
         Examples
         --------
-        Get the first channel of a multi channel Signal object
+        Get the first channel of a multi channel audio object
 
         >>> import pyfar
         >>> signal = pyfar.signals.noise(10, rms=[1, 1])
@@ -234,7 +237,7 @@ class _Audio():
 
         Examples
         --------
-        Set the first channel of a multi channel Signal object
+        Set the first channel of a multi channel audio object
 
         >>> import pyfar
         >>> signal = pyfar.signals.noise(10, rms=[1, 1])
@@ -265,15 +268,15 @@ class TimeData(_Audio):
         ----------
         data : array, double
             Raw data in the time domain. The memory layout of data is 'C'.
-            E.g. data of shape (3, 2, 1024) has 3 x 2 channels with
+            E.g. data of ``shape = (3, 2, 1024)`` has 3 x 2 channels with
             1024 samples each.
         times : array, double
             Times in seconds at which the data is sampled. The number of times
-            must match the size of the last dimension of data.
+            must match the `size` of the last dimension of `data`.
         comment : str, optional
-            A comment related to the data. The default is None.
+            A comment related to `data`. The default is ``'none'``.
         dtype : string, optional
-            Raw data type of the audio object. The default is float64.
+            Raw data type of the audio object. The default is `float64`.
         """
 
         _Audio.__init__(self, 'time', comment, dtype)
@@ -341,14 +344,16 @@ class TimeData(_Audio):
         return np.squeeze(indices)
 
     def _assert_matching_meta_data(self, other):
-        """Check if the meta data matches across two TimeData objects."""
+        """
+        Check if the meta data matches across two :py:func:`TimeData` objects.
+        """
         if not isinstance(other, TimeData):
             raise ValueError("Comparison only valid against TimeData objects.")
         if self.n_samples != other.n_samples:
             raise ValueError("The number of samples does not match.")
 
     def _return_item(self, data):
-        """Return new TimeData object with data."""
+        """Return new :py:func:`TimeData` object with data."""
         item = TimeData(
             data, times=self.times, comment=self.comment, dtype=self.dtype)
         return item
@@ -396,21 +401,21 @@ class FrequencyData(_Audio):
         ----------
         data : array, double
             Raw data in the frequency domain. The memory layout of Data is 'C'.
-            E.g. data of shape (3, 2, 1024) has 3 x 2 channels with 1024
+            E.g. data of ``shape = (3, 2, 1024)`` has 3 x 2 channels with 1024
             frequency bins each.
         frequencies : array, double
             Frequencies of the data in Hz. The number of frequencies must match
             the size of the last dimension of data.
         fft_norm : str, optional
             The normalization of the Discrete Fourier Transform (DFT). Can be
-            'none', 'unitary', 'amplitude', 'rms', 'power', or 'psd'. See
-            :py:func:`pyfar.dsp.fft.normalization` and [#]_ for more
-            information. The default is 'none', which is typically used for
-            energy signals, such as impulse responses.
+            ``'none'``, ``'unitary'``, ``'amplitude'``, ``'rms'``, ``'power'``,
+            or ``'psd'``. See :py:func:`pyfar.dsp.fft.normalization` and [#]_
+            for more information. The default is ``'none'``, which is typically
+            used for energy signals, such as impulse responses.
         comment : str, optional
-            A comment related to the data. The default is None.
+            A comment related to the data. The default is ``'none'``.
         dtype : string, optional
-            Raw data type of the audio object. The default is float64.
+            Raw data type of the audio object. The default is `float64`.
 
         References
         ----------
@@ -565,28 +570,28 @@ class Signal(FrequencyData, TimeData):
         ----------
         data : ndarray, double
             Raw data of the signal in the time or frequency domain. The memory
-            layout of data is 'C'. E.g. data of shape (3, 2, 1024) has 3 x 2
-            channels with 1024 samples or frequency bins each. Frequency data
-            must be provided as single sided spectra, i.e., for all frequencies
-            between 0 Hz and half the sampling rate.
+            layout of data is 'C'. E.g. data of ``shape = (3, 2, 1024)`` has
+            3 x 2 channels with 1024 samples or frequency bins each. Frequency
+            data must be provided as single sided spectra, i.e., for all
+            frequencies between 0 Hz and half the sampling rate.
         sampling_rate : double
             Sampling rate in Hz
         n_samples : int, optional
-            Number of samples of the time signal. Required if domain is 'freq'.
-            The default is None, which assumes an even number of samples if the
-            data is provided in the frequency domain.
-        domain : 'time', 'freq', optional
-            Domain of data. The default is 'time'
+            Number of samples of the time signal. Required if domain is
+            ``'freq'``. The default is ``None``, which assumes an even number
+            of samples if the data is provided in the frequency domain.
+        domain : ``'time'``, ``'freq'``, optional
+            Domain of data. The default is ``'time'``
         fft_norm : str, optional
             The normalization of the Discrete Fourier Transform (DFT). Can be
-            'none', 'unitary', 'amplitude', 'rms', 'power', or 'psd'. See
-            :py:func:`pyfar.dsp.fft.normalization` and [#]_ for more
-            information. The default is 'none', which is typically used for
-            energy signals, such as impulse responses.
+            ``'none'``, ``'unitary'``, ``'amplitude'``, ``'rms'``, ``'power'``,
+            or ``'psd'``. See :py:func:`pyfar.dsp.fft.normalization` and [#]_
+            for more information. The default is ``'none'``, which is typically
+            used for energy signals, such as impulse responses.
         comment : str
-            A comment related to the data. The default is None.
+            A comment related to `data`. The default is ``None``.
         dtype : string, optional
-            Raw data type of the audio object. The default is float64
+            Raw data type of the audio object. The default is `float64`
 
         References
         ----------
@@ -772,8 +777,8 @@ class Signal(FrequencyData, TimeData):
     @property
     def signal_type(self):
         """
-        The signal type is 'energy' if the ``fft_norm`` is None and 'power'
-        otherwise.
+        The signal type is ``'energy'``  if the ``fft_norm = None`` and
+        ``'power'`` otherwise.
         """
         if self.fft_norm == 'none':
             stype = 'energy'
@@ -801,14 +806,14 @@ class Signal(FrequencyData, TimeData):
         return self.n_samples
 
     def __iter__(self):
-        """Iterator for Signal objects.
+        """Iterator for :py:func:`Signal` objects.
 
-        Iterate across the first dimension of a Signal object. The actual
+        Iterate across the first dimension of a :py:func:`Signal`. The actual
         iteration is handled through numpy's array iteration.
 
         Examples
         --------
-        Iterate channels of a Signal object
+        Iterate channels of a :py:func:`Signal`
 
         >>> import pyfar
         >>>
@@ -821,7 +826,7 @@ class Signal(FrequencyData, TimeData):
 
 
 class _SignalIterator(object):
-    """Iterator for signals
+    """Iterator for :py:func:`Signal`
     """
     def __init__(self, array_iterator, signal):
         self._array_iterator = array_iterator
@@ -847,27 +852,30 @@ class _SignalIterator(object):
 def add(data: tuple, domain='freq'):
     """Add pyfar audio objects, array likes, and scalars.
 
-    Pyfar audio objects are: Signal, TimeData, and FrequencyData.
+    Pyfar audio objects are: :py:func:`Signal`, :py:func:`TimeData`, and
+    :py:func:`FrequencyData`.
 
     Parameters
     ----------
-    data : tuple of the form (data_1, data_2, ..., data_N)
+    data : tuple of the form ``(data_1, data_2, ..., data_N)``
         Data to be added. Can contain pyfar audio objects, array likes, and
-        scalars. Pyfar audio objects can not be mixed, e.g., TimeData and
-        FrequencyData objects do not work together.
-    domain : 'time', 'freq', optional
+        scalars. Pyfar audio objects can not be mixed, e.g.,
+        :py:func:`TimeData` and :py:func:`FrequencyData` objects do not work
+        together.
+    domain : ``'time'``, ``'freq'``, optional
         Flag to indicate if the operation should be performed in the time or
         frequency domain. If working in the frequency domain, the FFT
         normalization is removed before the operation (See
-        :py:func:`pyfar.dsp.fft.normalization`. The default is 'freq'.
+        :py:func:`pyfar.dsp.fft.normalization`). The default is ``'freq'``.
 
     Returns
     -------
-    results : Signal, numpy array
+    results : Signal, TimeData, FrequencyData, numpy array
         Result of the operation as numpy array, if `data` contains only array
         likes and numbers. Result as pyfar audio object if `data` contains an
-        audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
-        Otherwise the first ``fft_norm`` that is not 'none' is used.
+        audio object. The `fft_norm` is ``'none'`` if all FFT norms are
+        ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
+        used.
 
     """
     return _arithmetic(data, domain, _add)
@@ -876,28 +884,31 @@ def add(data: tuple, domain='freq'):
 def subtract(data: tuple, domain='freq'):
     """Subtract pyfar audio objects, array likes, and scalars.
 
-    Pyfar audio objects are: Signal, TimeData, and FrequencyData.
+    Pyfar audio objects are: :py:func:`Signal`, :py:func:`TimeData`, and
+    :py:func:`FrequencyData`.
+
 
     Parameters
     ----------
     data : tuple of the form (data_1, data_2, ..., data_N)
         Data to be subtracted. Can contain pyfar audio objects, array likes,
-        and scalars. Pyfar audio objects can not be mixed, e.g., TimeData and
-        FrequencyData objects do not work together.
-    domain : 'time', 'freq', optional
+        and scalars. Pyfar audio objects can not be mixed, e.g.,
+        :py:func:`TimeData` and :py:func:`FrequencyData` objects do not work
+        together.
+    domain : ``'time'``, ``'freq'``, optional
         Flag to indicate if the operation should be performed in the time or
         frequency domain. If working in the frequency domain, the FFT
         normalization is removed before the operation (See
-        :py:func:`pyfar.dsp.fft.normalization`. The default is 'freq'.
+        :py:func:`pyfar.dsp.fft.normalization`). The default is ``'freq'``.
 
     Returns
     -------
-    results : Signal, numpy array
+    results : Signal, TimeData, FrequencyData, numpy array
         Result of the operation as numpy array, if `data` contains only array
         likes and numbers. Result as pyfar audio object if `data` contains an
-        audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
-        Otherwise the first ``fft_norm`` that is not 'none' is used.
-
+        audio object. The `fft_norm` is ``'none'`` if all FFT norms are
+        ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
+        used.
     """
     return _arithmetic(data, domain, _subtract)
 
@@ -905,28 +916,31 @@ def subtract(data: tuple, domain='freq'):
 def multiply(data: tuple, domain='freq'):
     """Multiply pyfar audio objects, array likes, and scalars.
 
-    Pyfar audio objects are: Signal, TimeData, and FrequencyData.
+    Pyfar audio objects are: :py:func:`Signal`, :py:func:`TimeData`, and
+    :py:func:`FrequencyData`.
+
 
     Parameters
     ----------
     data : tuple of the form (data_1, data_2, ..., data_N)
         Data to be multiplied. Can contain pyfar audio objects, array likes,
-        and scalars. Pyfar audio objects can not be mixed, e.g., TimeData and
-        FrequencyData objects do not work together.
-    domain : 'time', 'freq', optional
+        and scalars. Pyfar audio objects can not be mixed, e.g.,
+        :py:func:`TimeData` and :py:func:`FrequencyData` objects do not work
+        together.
+    domain : ``'time'``, ``'freq'``, optional
         Flag to indicate if the operation should be performed in the time or
         frequency domain. If working in the frequency domain, the FFT
         normalization is removed before the operation (See
-        :py:func:`pyfar.dsp.fft.normalization`. The default is 'freq'.
+        :py:func:`pyfar.dsp.fft.normalization`). The default is ``'freq'``.
 
     Returns
     -------
-    results : Signal, numpy array
+    results : Signal, TimeData, FrequencyData, numpy array
         Result of the operation as numpy array, if `data` contains only array
         likes and numbers. Result as pyfar audio object if `data` contains an
-        audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
-        Otherwise the first ``fft_norm`` that is not 'none' is used.
-
+        audio object. The `fft_norm` is ``'none'`` if all FFT norms are
+        ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
+        used.
     """
     return _arithmetic(data, domain, _multiply)
 
@@ -934,53 +948,61 @@ def multiply(data: tuple, domain='freq'):
 def divide(data: tuple, domain='freq'):
     """Divide pyfar audio objects, array likes, and scalars.
 
+    Pyfar audio objects are: :py:func:`Signal`, :py:func:`TimeData`, and
+    :py:func:`FrequencyData`.
+
     Parameters
     ----------
     data : tuple of the form (data_1, data_2, ..., data_N)
         Data to be divided. Can contain pyfar audio objects, array likes, and
-        scalars. Pyfar audio objects can not be mixed, e.g., TimeData and
-        FrequencyData objects do not work together.
-    domain : 'time', 'freq', optional
+        scalars. Pyfar audio objects can not be mixed, e.g.,
+        :py:func:`TimeData` and :py:func:`FrequencyData` objects do not work
+        together.
+    domain : ``'time'``, ``'freq'``, optional
         Flag to indicate if the operation should be performed in the time or
         frequency domain. If working in the frequency domain, the FFT
         normalization is removed before the operation (See
-        :py:func:`pyfar.dsp.fft.normalization`. The default is 'freq'.
+        :py:func:`pyfar.dsp.fft.normalization`). The default is ``'freq'``.
 
     Returns
     -------
-    results : Signal, numpy array
+    results : Signal, TimeData, FrequencyData, numpy array
         Result of the operation as numpy array, if `data` contains only array
         likes and numbers. Result as pyfar audio object if `data` contains an
-        audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
-        Otherwise the first ``fft_norm`` that is not 'none' is used.
-
-    """
+        audio object. The `fft_norm` is ``'none'`` if all FFT norms are
+        ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
+        used.
+   """
     return _arithmetic(data, domain, _divide)
 
 
 def power(data: tuple, domain='freq'):
     """Power of pyfar audio objects, array likes, and scalars.
 
+    Pyfar audio objects are: :py:func:`Signal`, :py:func:`TimeData`, and
+    :py:func:`FrequencyData`.
+
     Parameters
     ----------
     data : tuple of the form (data_1, data_2, ..., data_N)
         The base for which the power is calculated. Can contain pyfar audio
         objects, array likes, and scalars. Pyfar audio objects can not be
-        mixed, e.g., TimeData and FrequencyData objects do not work together.
-    domain : 'time', 'freq', optional
+        mixed, e.g., :py:func:`TimeData` and :py:func:`FrequencyData` objects
+        do not work together.
+    domain : ``'time'``, ``'freq'``, optional
         Flag to indicate if the operation should be performed in the time or
         frequency domain. If working in the frequency domain, the FFT
         normalization is removed before the operation (See
-        :py:func:`pyfar.dsp.fft.normalization`. The default is 'freq'.
+        :py:func:`pyfar.dsp.fft.normalization`). The default is ``'freq'``.
 
     Returns
     -------
-    results : Signal, numpy array
+    results : Signal, TimeData, FrequencyData, numpy array
         Result of the operation as numpy array, if `data` contains only array
         likes and numbers. Result as pyfar audio object if `data` contains an
-        audio object. The ``fft_norm`` is 'none' if all FFT norms are 'none'.
-        Otherwise the first ``fft_norm`` that is not 'none' is used.
-
+        audio object. The `fft_norm` is ``'none'`` if all FFT norms are
+        ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
+        used.
     """
     return _arithmetic(data, domain, _power)
 

--- a/pyfar/signal.py
+++ b/pyfar/signal.py
@@ -53,7 +53,7 @@ import pyfar.dsp.fft as fft
 from typing import Callable
 
 
-class _Audio(object):
+class _Audio():
     """Abstract class for audio objects.
 
     This class holds all the methods and properties that are common to its
@@ -124,9 +124,9 @@ class _Audio(object):
         reshaped : Signal
             reshaped copy of the signal.
 
-        Note
-        ----
-        The number of samples and frequency bin always remains the same.
+        Notes
+        -----
+        The number of samples and frequency bins always remains the same.
 
         """
 
@@ -159,8 +159,8 @@ class _Audio(object):
             Flattened copy of signal with
             `flat.cshape = np.prod(signal.cshape)`
 
-        Note
-        ----
+        Notes
+        -----
         The number of samples and frequency bins always remains the same, e.g.,
         a signal of `cshape=(4,3)` and `n_samples=512` will have
         `chsape=(12, )` and `n_samples=512` after flattening.
@@ -181,7 +181,7 @@ class _Audio(object):
         self._comment = 'none' if value is None else str(value)
 
     def copy(self):
-        """Return a deep copy of the Signal object."""
+        """Return a copy of the Signal object."""
         return deepcopy(self)
 
     def _return_item(self):
@@ -234,22 +234,21 @@ class TimeData(_Audio):
 
     """
     def __init__(self, data, times, comment=None, dtype=np.double):
-        """Init TimeData with data, and times.
+        """Create TimeData object with data, and times.
 
-        Attributes
+        Parameters
         ----------
         data : array, double
             Raw data in the time domain. The memory layout of data is 'C'.
             E.g. data of shape (3, 2, 1024) has 3 x 2 channels with
             1024 samples each.
         times : array, double
-            Times of the data in seconds. The number of times must match
-            the size of the last dimension of data.
-        comment : str
+            Times in seconds at which the data is sampled. The number of times
+            must match the size of the last dimension of data.
+        comment : str, optional
             A comment related to the data. The default is None.
         dtype : string, optional
             Raw data type of the signal. The default is float64
-
         """
 
         _Audio.__init__(self, 'time', comment, dtype)
@@ -283,7 +282,7 @@ class TimeData(_Audio):
 
     @property
     def n_samples(self):
-        """Number of samples."""
+        """The number of samples."""
         return self._n_samples
 
     @property
@@ -293,11 +292,12 @@ class TimeData(_Audio):
 
     @property
     def times(self):
-        """Time instances the signal is sampled at."""
+        """Time in seconds at which the signal is sampled."""
         return self._times
 
     def find_nearest_time(self, value):
-        """Returns the closest time index for a given time
+        """Returns the index that is closest to the query time.
+
         Parameters
         ----------
         value : float, array-like
@@ -367,7 +367,7 @@ class FrequencyData(_Audio):
                  dtype=complex):
         """Init FrequencyData with data, and frequencies.
 
-        Attributes
+        Parameters
         ----------
         data : array, double
             Raw data in the frequency domain. The memory layout of Data is 'C'.
@@ -536,7 +536,7 @@ class Signal(FrequencyData, TimeData):
             dtype=np.double):
         """Init Signal with data, and sampling rate.
 
-        Attributes
+        Parameters
         ----------
         data : ndarray, double
             Raw data of the signal in the frequency or time domain. The memory

--- a/tests/test_frequency_data.py
+++ b/tests/test_frequency_data.py
@@ -93,7 +93,7 @@ def test_reshape_exceptions():
         data_out = data_in.reshape([3, 2])
 
     # test assertion for wrong dimension
-    with pytest.raises(ValueError, match='Can not reshape signal of cshape'):
+    with pytest.raises(ValueError, match='Can not reshape audio object'):
         data_out = data_in.reshape((3, 4))
 
 

--- a/tests/test_signal.py
+++ b/tests/test_signal.py
@@ -338,7 +338,7 @@ def test_reshape_exceptions():
         signal_out = signal_in.reshape([3, 2])
 
     # test assertion for wrong dimension
-    with pytest.raises(ValueError, match='Can not reshape signal of cshape'):
+    with pytest.raises(ValueError, match='Can not reshape audio object'):
         signal_out = signal_in.reshape((3, 4))
 
 

--- a/tests/test_time_data.py
+++ b/tests/test_time_data.py
@@ -78,7 +78,7 @@ def test_reshape_exceptions():
         data_out = data_in.reshape([3, 2])
 
     # test assertion for wrong dimension
-    with pytest.raises(ValueError, match='Can not reshape signal of cshape'):
+    with pytest.raises(ValueError, match='Can not reshape audio object'):
         data_out = data_in.reshape((3, 4))
 
 


### PR DESCRIPTION
I suggest that you check the documentation in the html version after building it (see CONTRIBUTIONS.rst). Feel free to directly commit fixes for typos and minor issues.

I included inherited methods in the documentation and added documentation for magic methods `__iter__`, `__getitem__`, and `__setitem__`.

I touched one thing not related to the documentation
- made SignalIterator a private class