### PR TITLE
Bugfix for ignored channels during processing of multi-channel signals in filter classes

### DIFF
--- a/pyfar/dsp/classes.py
+++ b/pyfar/dsp/classes.py
@@ -186,13 +186,9 @@ class Filter(object):
         if reset is True:
             self.reset()
 
-        if self.size > 1:
-            filtered_signal_data = np.broadcast_to(
-                signal.time,
-                (self.shape[0], *signal.time.shape))
-            filtered_signal_data = filtered_signal_data.copy()
-        else:
-            filtered_signal_data = signal.time.copy()
+        filtered_signal_data = np.zeros(
+            (self.size, *signal.time.shape),
+            dtype=signal.time.dtype)
 
         if self.state is not None:
             for idx, (coeff, state) in enumerate(
@@ -202,12 +198,10 @@ class Filter(object):
         else:
             for idx, coeff in enumerate(self._coefficients):
                 filtered_signal_data[idx, ...] = self.filter_func(
-                    coeff, filtered_signal_data[idx, ...], zi=None)
+                    coeff, signal.time, zi=None)
 
         filtered_signal = deepcopy(signal)
-        if (signal.time.ndim == 2) and (signal.cshape[0] == 1):
-            filtered_signal_data = np.squeeze(filtered_signal_data)
-        filtered_signal.time = filtered_signal_data
+        filtered_signal.time = np.squeeze(filtered_signal_data)
 
         return filtered_signal
 

--- a/pyfar/dsp/classes.py
+++ b/pyfar/dsp/classes.py
@@ -209,8 +209,7 @@ class Filter(object):
         if self._state is not None:
             self._state = np.zeros_like(self._state)
         else:
-            warnings.warn(
-                "No previous state was set. Initialize a filter state first.")
+            self._state = None
 
     @property
     def comment(self):

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -119,6 +119,16 @@ def test_filter_iir_process_multi_dim_filt(impulse):
 
     npt.assert_allclose(res.time[:, :3], coeff[:, 0])
 
+    impulse.time = np.vstack((impulse.time, impulse.time))
+    filt = fo.FilterIIR(coeff, impulse.sampling_rate)
+    res = filt.process(impulse)
+
+    npt.assert_allclose(res.time[0, 0, :3], coeff[0, 0, :], atol=1e-16)
+    npt.assert_allclose(res.time[1, 0, :3], coeff[1, 0, :], atol=1e-16)
+
+    npt.assert_allclose(res.time[0, 1, :3], coeff[0, 0, :], atol=1e-16)
+    npt.assert_allclose(res.time[1, 1, :3], coeff[1, 0, :], atol=1e-16)
+
 
 def test_filter_fir_process_multi_dim_filt(impulse):
     coeff = np.array([
@@ -128,6 +138,16 @@ def test_filter_fir_process_multi_dim_filt(impulse):
     filt = fo.FilterFIR(coeff, impulse.sampling_rate)
     res = filt.process(impulse)
     npt.assert_allclose(res.time[:, :3], coeff)
+
+    impulse.time = np.vstack((impulse.time, impulse.time))
+    filt = fo.FilterFIR(coeff, impulse.sampling_rate)
+    res = filt.process(impulse)
+
+    npt.assert_allclose(res.time[0, 0, :3], coeff[0, :], atol=1e-16)
+    npt.assert_allclose(res.time[1, 0, :3], coeff[1, :], atol=1e-16)
+
+    npt.assert_allclose(res.time[0, 1, :3], coeff[0, :], atol=1e-16)
+    npt.assert_allclose(res.time[1, 1, :3], coeff[1, :], atol=1e-16)
 
 
 def test_filter_sos_process(impulse):

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -2,9 +2,7 @@ import pytest
 import numpy as np
 import numpy.testing as npt
 import pyfar.dsp.classes as fo
-from pyfar import Signal
 from scipy import signal as spsignal
-from unittest import mock
 
 
 def test_filter_init_empty_coefficients():

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -154,6 +154,16 @@ def test_filter_sos_process_multi_dim_filt(impulse):
 
     npt.assert_allclose(res.time[:, :3], coeff[:, 0])
 
+    impulse.time = np.vstack((impulse.time, impulse.time))
+    filt = fo.FilterSOS(sos, impulse.sampling_rate)
+    res = filt.process(impulse)
+
+    npt.assert_allclose(res.time[0, 0, :3], coeff[0, 0, :], atol=1e-16)
+    npt.assert_allclose(res.time[1, 0, :3], coeff[1, 0, :], atol=1e-16)
+
+    npt.assert_allclose(res.time[0, 1, :3], coeff[0, 0, :], atol=1e-16)
+    npt.assert_allclose(res.time[1, 1, :3], coeff[1, 0, :], atol=1e-16)
+
 
 def test_atleast_3d_first_dim():
     arr = np.array([1, 0, 0])


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #144 & #33 

### Changes proposed in this pull request:

- The `process` method of `Filter` objects iterates all channels
- If a `Filter` has more than one channel, a new dimension is added to the processed `Signal`
- Removed the empty state warning