### PR TITLE
Fix wrong path for external sampiling *.mat files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,6 @@ recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 
-recursive-include pyfar/spatial/external *.mat
+recursive-include pyfar/samplings/external *.mat
 recursive-include pyfar/plot/plotstyles *.mplstyle
 recursive-include pyfar/plot/shortcuts *.json


### PR DESCRIPTION
### Changes proposed in this pull request:

- Update MANIFEST.in to new folder of external samplings
