### PR TITLE
Remove keyword 'line' from shortcuts

### DIFF
--- a/pyfar/plot/_interaction.py
+++ b/pyfar/plot/_interaction.py
@@ -180,12 +180,12 @@ class PlotParameter(object):
         Parameters
         ----------
         plot : str
-            Defines the plot by module.plot_function, e.g., 'line.freq'
+            Defines the plot by module.plot_function, e.g., 'freq'
 
         """
 
         # set the axis, color map, and cycle, parameter for each plot
-        if plot == 'line.time':
+        if plot == 'time':
             # x-axis
             self._x_type = ['other']
             self._x_id = 0
@@ -200,7 +200,7 @@ class PlotParameter(object):
             # cycler type
             self._cycler_type = 'line'
 
-        elif plot == 'line.freq':
+        elif plot == 'freq':
             # x-axis
             self._x_type = ['freq', 'other']
             self._x_param = 'xscale'
@@ -217,7 +217,7 @@ class PlotParameter(object):
             # cycler type
             self._cycler_type = 'line'
 
-        elif plot == 'line.phase':
+        elif plot == 'phase':
             # x-axis
             self._x_type = ['freq', 'other']
             self._x_param = 'xscale'
@@ -235,7 +235,7 @@ class PlotParameter(object):
             # cycler type
             self._cycler_type = 'line'
 
-        elif plot == 'line.group_delay':
+        elif plot == 'group_delay':
             # x-axis
             self._x_type = ['freq', 'other']
             self._x_param = 'xscale'
@@ -252,7 +252,7 @@ class PlotParameter(object):
             # cycler type
             self._cycler_type = 'line'
 
-        elif plot == 'line.spectrogram':
+        elif plot == 'spectrogram':
             # x-axis
             self._x_type = ['other']
             self._x_id = 0
@@ -269,7 +269,7 @@ class PlotParameter(object):
             # cycler type
             self._cycler_type = 'signal'
 
-        elif plot == 'line.time_freq':
+        elif plot == 'time_freq':
             # same as time
             # (currently interaction uses only the axis of the top plot)
 
@@ -287,7 +287,7 @@ class PlotParameter(object):
             # cycler type
             self._cycler_type = 'line'
 
-        elif plot in ['line.freq_phase', 'line.freq_group_delay']:
+        elif plot in ['freq_phase', 'freq_group_delay']:
             # same as freq
             # (currently interaction uses only the axis of the top plot)
 
@@ -511,31 +511,31 @@ class Interaction(object):
             self.figure.clear()
             self.ax = None
 
-            if event.key in plot['line.time']:
-                self.params.update_axis_type('line.time')
+            if event.key in plot['time']:
+                self.params.update_axis_type('time')
                 self.ax = _line._time(
                     self.signal, prm.dB_time, prm.log_prefix,
                     prm.log_reference, self.ax, **self.kwargs)
 
-            elif event.key in plot['line.freq']:
-                self.params.update_axis_type('line.freq')
+            elif event.key in plot['freq']:
+                self.params.update_axis_type('freq')
                 self.ax = _line._freq(
                     self.signal, prm.dB_freq, prm.log_prefix,
                     prm.log_reference, prm.xscale, self.ax, **self.kwargs)
 
-            elif event.key in plot['line.phase']:
-                self.params.update_axis_type('line.phase')
+            elif event.key in plot['phase']:
+                self.params.update_axis_type('phase')
                 self.ax = _line._phase(
                     self.signal, prm.deg, prm.unwrap, prm.xscale,
                     self.ax, **self.kwargs)
 
-            elif event.key in plot['line.group_delay']:
-                self.params.update_axis_type('line.group_delay')
+            elif event.key in plot['group_delay']:
+                self.params.update_axis_type('group_delay')
                 self.ax = _line._group_delay(
                     self.signal, prm.unit, prm.xscale, self.ax, **self.kwargs)
 
-            elif event.key in plot['line.spectrogram']:
-                self.params.update_axis_type('line.spectrogram')
+            elif event.key in plot['spectrogram']:
+                self.params.update_axis_type('spectrogram')
                 ax = _line._spectrogram_cb(
                     self.signal[self.cycler.index], prm.dB_freq,
                     prm.log_prefix, prm.log_reference, prm.yscale, prm.unit,
@@ -543,23 +543,23 @@ class Interaction(object):
                     prm.cmap, self.ax, **self.kwargs)
                 self.ax = ax[0]
 
-            elif event.key in plot['line.time_freq']:
-                self.params.update_axis_type('line.time')
+            elif event.key in plot['time_freq']:
+                self.params.update_axis_type('time')
                 ax = _line._time_freq(
                     self.signal, prm.dB_time, prm.dB_freq, prm.log_prefix,
                     prm.log_reference, prm.xscale, self.ax, **self.kwargs)
                 self.ax = ax[0]
 
-            elif event.key in plot['line.freq_phase']:
-                self.params.update_axis_type('line.freq')
+            elif event.key in plot['freq_phase']:
+                self.params.update_axis_type('freq')
                 ax = _line._freq_phase(
                     self.signal, prm.dB_freq, prm.log_prefix,
                     prm.log_reference, prm.xscale, prm.deg, prm.unwrap,
                     self.ax, **self.kwargs)
                 self.ax = ax[0]
 
-            elif event.key in plot['line.freq_group_delay']:
-                self.params.update_axis_type('line.freq')
+            elif event.key in plot['freq_group_delay']:
+                self.params.update_axis_type('freq')
                 ax = _line._freq_group_delay(
                     self.signal, prm.dB_freq, prm.log_prefix,
                     prm.log_reference, prm.unit, prm.xscale,
@@ -765,7 +765,7 @@ class Interaction(object):
 
         # re-plot
         self.all_visible = False
-        self.toggle_plot(EventEmu(self.plot['line.spectrogram']))
+        self.toggle_plot(EventEmu(self.plot['spectrogram']))
 
     def write_current_channel_text(self):
 

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -67,7 +67,7 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit=None, ax=None,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.time', dB_time=dB, log_prefix=log_prefix,
+        'time', dB_time=dB, log_prefix=log_prefix,
         log_reference=log_reference)
     interaction = ia.Interaction(signal, ax, style, plot_parameter, **kwargs)
     ax.interaction = interaction
@@ -136,7 +136,7 @@ def freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.freq', dB_freq=dB, log_prefix=log_prefix,
+        'freq', dB_freq=dB, log_prefix=log_prefix,
         log_reference=log_reference, xscale=xscale)
     interaction = ia.Interaction(signal, ax, style, plot_parameter, **kwargs)
     ax.interaction = interaction
@@ -199,7 +199,7 @@ def phase(signal, deg=False, unwrap=False, xscale='log', ax=None,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.phase', deg=deg, unwrap=unwrap, xscale=xscale)
+        'phase', deg=deg, unwrap=unwrap, xscale=xscale)
     interaction = ia.Interaction(signal, ax, style, plot_parameter, **kwargs)
     ax.interaction = interaction
 
@@ -258,7 +258,7 @@ def group_delay(signal, unit=None, xscale='log', ax=None, style='light',
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.group_delay', unit=unit, xscale=xscale)
+        'group_delay', unit=unit, xscale=xscale)
     interaction = ia.Interaction(signal, ax, style, plot_parameter, **kwargs)
     ax.interaction = interaction
 
@@ -342,7 +342,7 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.spectrogram', dB_freq=dB, log_prefix=log_prefix,
+        'spectrogram', dB_freq=dB, log_prefix=log_prefix,
         log_reference=log_reference, yscale=yscale, unit=unit, window=window,
         window_length=window_length, window_overlap_fct=window_overlap_fct,
         cmap=cmap)
@@ -420,7 +420,7 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.time', dB_time=dB_time, log_prefix=log_prefix,
+        'time', dB_time=dB_time, log_prefix=log_prefix,
         log_reference=log_reference)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)
@@ -481,7 +481,7 @@ def freq_phase(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.freq', dB_freq=dB, log_prefix=log_prefix,
+        'freq', dB_freq=dB, log_prefix=log_prefix,
         log_reference=log_reference, xscale=xscale)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)
@@ -553,7 +553,7 @@ def freq_group_delay(signal, dB=True, log_prefix=20, log_reference=1,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'line.freq', dB_freq=dB, log_prefix=log_prefix,
+        'freq', dB_freq=dB, log_prefix=log_prefix,
         log_reference=log_reference, xscale=xscale)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)

--- a/pyfar/plot/shortcuts/shortcuts.json
+++ b/pyfar/plot/shortcuts/shortcuts.json
@@ -1,37 +1,37 @@
 {
 "plots": {
-    "line.time": {
+    "time": {
         "key": ["1", "T"],
         "key_verbose": ["1", "shift+t"],
-        "info": "line.time"},
-    "line.freq": {
+        "info": "time"},
+    "freq": {
         "key": ["2", "F"],
         "key_verbose": ["2", "shift+f"],
-        "info": "line.freq"},
-    "line.phase": {
+        "info": "freq"},
+    "phase": {
         "key": ["3", "P"],
         "key_verbose": ["3", "shift+p"],
-        "info": "line.phase"},
-    "line.group_delay": {
+        "info": "phase"},
+    "group_delay": {
         "key": ["4", "G"],
         "key_verbose": ["4", "shift+g"],
-        "info": "line.group_delay"},
-    "line.spectrogram": {
+        "info": "group_delay"},
+    "spectrogram": {
         "key": ["5", "S"],
         "key_verbose": ["5", "shift+s"],
-        "info": "line.spectrogram"},
-    "line.time_freq": {
+        "info": "spectrogram"},
+    "time_freq": {
         "key": ["6", "ctrl+T", "ctrl+F"],
         "key_verbose": ["6", "ctrl+shift+t", "ctrl+shift+f"],
-        "info": "line.time_freq"},
-    "line.freq_phase": {
+        "info": "time_freq"},
+    "freq_phase": {
         "key": ["7", "ctrl+P"],
         "key_verbose": ["7", "ctrl+shift+p"],
-        "info": "line.freq_phase"},
-    "line.freq_group_delay": {
+        "info": "freq_phase"},
+    "freq_group_delay": {
         "key": ["8", "ctrl+G"],
         "key_verbose": ["8", "ctrl+shift+g"],
-        "info": "line.freq_group_delay"}
+        "info": "freq_group_delay"}
     },
 "controls": {
     "move_left": {


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

None, general improvement

### Changes proposed in this pull request:
The shortcuts contained the keyword 'line'. I initially added this because I thought we would have different plots with the same name in sub-modules of plot. We do not have this and all plots are available to the user as plot.name and not plot.line.name. However the keyword line shows up in the shortcuts printed by `pyfar.plot.shortcuts()`, which will be confusing for the users.

- removed occurrences line. wherever it was related to shortcuts