### PR TITLE
Fix broken links in doc summary tables generated by autodocsumm

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -33,7 +33,7 @@ import deepdiff
 import re
 from copy import deepcopy
 
-import pyfar
+import pyfar as pf
 
 
 class Coordinates():
@@ -723,14 +723,14 @@ class Coordinates():
 
         """
         if mask is None:
-            pyfar.plot.scatter(self)
+            pf.plot.scatter(self)
         else:
             mask = np.asarray(mask)
             assert mask.shape == self.cshape,\
                 "'mask.shape' must be self.cshape"
             colors = np.full(mask.shape, 'k')
             colors[mask] = 'r'
-            pyfar.plot.scatter(self, c=colors.flatten(), **kwargs)
+            pf.plot.scatter(self, c=colors.flatten(), **kwargs)
 
     def get_nearest_k(self, points_1, points_2, points_3, k=1,
                       domain='cart', convention='right', unit='met',

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -4,7 +4,7 @@ import warnings
 import numpy as np
 import scipy.signal as spsignal
 
-import pyfar
+import pyfar as pf
 from copy import deepcopy
 
 
@@ -189,7 +189,7 @@ class Filter(object):
         filtered : Signal
             A filtered copy of the input signal.
         """
-        if not isinstance(signal, pyfar.Signal):
+        if not isinstance(signal, pf.Signal):
             raise ValueError("The input needs to be a haiopy.Signal object.")
 
         if self.sampling_rate != signal.sampling_rate:

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -1,7 +1,7 @@
 from scipy.spatial.transform import Rotation
 import numpy as np
 
-import pyfar
+import pyfar as pf
 
 
 class Orientations(Rotation):
@@ -155,13 +155,13 @@ class Orientations(Rotation):
 
         ax = None
         if show_views:
-            ax = pyfar.plot.quiver(
+            ax = pf.plot.quiver(
                 positions, views, color=(1, 0, 0), **kwargs)
         if show_ups:
-            ax = pyfar.plot.quiver(
+            ax = pf.plot.quiver(
                 positions, ups, ax=ax, color=(0, 1, 0), **kwargs)
         if show_rights:
-            ax = pyfar.plot.quiver(
+            ax = pf.plot.quiver(
                 positions, rights, ax=ax, color=(0, 0, 1), **kwargs)
 
     def as_view_up_right(self):

--- a/pyfar/dsp/filter.py
+++ b/pyfar/dsp/filter.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 import scipy.signal as spsignal
 
-import pyfar
+import pyfar as pf
 
 from . import _audiofilter as iir
 
@@ -55,7 +55,7 @@ def butter(signal, N, frequency, btype='lowpass', sampling_rate=None):
     sos = spsignal.butter(N, frequency_norm, btype, analog=False, output='sos')
 
     # generate filter object
-    filt = pyfar.FilterSOS(sos, fs)
+    filt = pf.FilterSOS(sos, fs)
     filt.comment = (f"Butterworth {btype} of order {N}. "
                     f"Cut-off frequency {frequency} Hz.")
 
@@ -119,7 +119,7 @@ def cheby1(signal, N, ripple, frequency, btype='lowpass', sampling_rate=None):
                           output='sos')
 
     # generate filter object
-    filt = pyfar.FilterSOS(sos, fs)
+    filt = pf.FilterSOS(sos, fs)
     filt.comment = (f"Chebychev Type I {btype} of order {N}. "
                     f"Cut-off frequency {frequency} Hz. "
                     f"Pass band ripple {ripple} dB.")
@@ -185,7 +185,7 @@ def cheby2(signal, N, attenuation, frequency, btype='lowpass',
                           output='sos')
 
     # generate filter object
-    filt = pyfar.FilterSOS(sos, fs)
+    filt = pf.FilterSOS(sos, fs)
     filt.comment = (f"Chebychev Type II {btype} of order {N}. "
                     f"Cut-off frequency {frequency} Hz. "
                     f"Stop band attenuation {attenuation} dB.")
@@ -253,7 +253,7 @@ def ellip(signal, N, ripple, attenuation, frequency, btype='lowpass',
                          analog=False, output='sos')
 
     # generate filter object
-    filt = pyfar.FilterSOS(sos, fs)
+    filt = pf.FilterSOS(sos, fs)
     filt.comment = (f"Elliptic (Cauer) {btype} of order {N}. "
                     f"Cut-off frequency {frequency} Hz. "
                     f"Pass band ripple {ripple} dB. "
@@ -339,7 +339,7 @@ def bessel(signal, N, frequency, btype='lowpass', norm='phase',
                           output='sos', norm=norm)
 
     # generate filter object
-    filt = pyfar.FilterSOS(sos, fs)
+    filt = pf.FilterSOS(sos, fs)
     filt.comment = (f"Bessel/Thomson {btype} of order {N} and '{norm}' "
                     f"normalization. Cut-off frequency {frequency} Hz.")
 
@@ -428,7 +428,7 @@ blob/master/filter_design/audiofilter.py
     ba[1] = a
 
     # generate filter object
-    filt = pyfar.FilterIIR(ba, fs)
+    filt = pf.FilterIIR(ba, fs)
     filt.comment = ("Second order parametric equalizer (PEQ) "
                     f"of type {peq_type} with {gain} dB gain at "
                     f"{center_frequency} Hz (Quality = {quality}).")
@@ -632,7 +632,7 @@ def crossover(signal, N, frequency, sampling_rate=None):
         SOS[np.arange(1, freq.size + 1, 2), 0, 0:3] *= -1
 
     # generate filter object
-    filt = pyfar.FilterSOS(SOS, fs)
+    filt = pf.FilterSOS(SOS, fs)
     freq_list = [str(f) for f in np.array(frequency, ndmin=1)]
     filt.comment = (f"Linkwitz-Riley cross over network of order {N*2} at "
                     f"{', '.join(freq_list)} Hz.")
@@ -686,7 +686,7 @@ def _shelve(signal, frequency, gain, order, shelve_type, sampling_rate, kind):
     ba[1] = a
 
     # generate filter object
-    filt = pyfar.FilterIIR(ba, fs)
+    filt = pf.FilterIIR(ba, fs)
     kind = "High" if kind == "high" else "Low"
     filt.comment = (f"{kind}-shelve of order {order} and type "
                     f"{shelve_type} with {gain} dB gain at {frequency} Hz.")
@@ -896,7 +896,7 @@ def fractional_octave_bands(
         sampling_rate=fs, num_fractions=num_fractions,
         freq_range=freq_range, order=order)
 
-    filt = pyfar.FilterSOS(sos, fs)
+    filt = pf.FilterSOS(sos, fs)
     filt.comment = (
         "Second order section 1/{num_fractions} fractional octave band"
         "filter of order {order}")
@@ -968,7 +968,7 @@ def _coefficients_fractional_octave_bands(
             Wn = Wn[0]
             btype = 'highpass'
             sos_hp = spsignal.butter(order, Wn, btype=btype, output='sos')
-            sos_coeff = pyfar.classes.filter.extend_sos_coefficients(
+            sos_coeff = pf.classes.filter.extend_sos_coefficients(
                 sos_hp, order)
         else:
             btype = 'bandpass'


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #166

### Changes proposed in this pull request:

change `import pyfar` to `import pyfar as pf` everywhere. The links were broken due to a bug in Sphinx. I could find the workaround with the help of Chilipp from autodocsumm, who also was so kind to make a detailed issue at Sphinx: https://github.com/sphinx-doc/sphinx/issues/9069
