### PR TITLE
Fix Matplotlib deprecated warning for scatter plot

### DIFF
--- a/pyfar/plot/spatial.py
+++ b/pyfar/plot/spatial.py
@@ -120,7 +120,7 @@ def _setup_axes(projection=Axes3D.name, ax=None,
         # (workaround for ax.set_aspect('equal', 'box'), which is currently not
         #  working for 3D axes.)
         plt.figure(figsize=plt.figaspect(1.))
-        ax = plt.gca(projection=projection)
+        ax = plt.axes(projection=projection)
 
     if 'Axes3D' not in ax.__str__():
         raise ValueError("Only three-dimensional axes supported.")


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

fixes warning starting with Matplotlib 3.4.1:

```
\pyfar\plot\spatial.py:123: MatplotlibDeprecationWarning: Calling gca() with keyword arguments was deprecated in Matplotlib 3.4. Starting two minor releases later, gca() will take no keyword arguments. The gca() function should only be used to get the current axes, or if no axes exist, create new axes with default keyword arguments. To create a new axes with non-default arguments, use plt.axes() or plt.subplot().
```

### Changes proposed in this pull request:

- used `pyplt.axes` to create axis instead of `pyplot.gca`
