### PR TITLE
Revise testing for coordinates

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -544,7 +544,7 @@ class Coordinates():
                 f"Conversion for {convention} is not implemented.")
 
         # convert to degrees
-        if self._system['unit'] == 'deg':
+        if new_system['unit'] == 'deg':
             pts_1 = pts_1 / np.pi * 180
 
         # return points and convert internal state if desired

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1673,7 +1673,7 @@ class Coordinates():
 
         new = self.copy()
         # slice points
-        new._points = new._points[index]
+        new._points = np.atleast_2d(new._points[index])
         # slice weights
         if new._weights is not None:
             new._weights = new._weights[index]

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -273,19 +273,25 @@ class Coordinates():
                 y, z, x = sph2cart(pts[..., 0], pts[..., 1], pts[..., 2])
 
             else:
+                # Can not be tested. Will only be raised if a coordinate system
+                # is not fully implemented.
                 raise ValueError(
-                    f"Conversion for {self._system['convention']} \
-                    is not implemented.")
+                    (f"Conversion for {self._system['convention']} "
+                     "is not implemented."))
 
         # ... from cylindrical coordinate systems
         elif self._system['domain'] == 'cyl':
             if self._system['convention'] == 'top':
                 x, y, z = cyl2cart(pts[..., 0], pts[..., 1], pts[..., 2])
             else:
+                # Can not be tested. Will only be raised if a coordinate system
+                # is not fully implemented.
                 raise ValueError(
-                    f"Conversion for {self._system['convention']} \
-                    is not implemented.")
+                    (f"Conversion for {self._system['convention']} "
+                     "is not implemented."))
         else:
+            # Can not be tested. Will only be raised if a coordinate system
+            # is not fully implemented.
             raise ValueError(
                 f"Conversion for {convention} is not implemented.")
 
@@ -425,6 +431,8 @@ class Coordinates():
                 pts[..., 1], pts[..., 2], pts[..., 0])
 
         else:
+            # Can not be tested. Will only be raised if a coordinate system
+            # is not fully implemented.
             raise ValueError(
                 f"Conversion for {convention} is not implemented.")
 
@@ -540,6 +548,8 @@ class Coordinates():
                 pts[..., 0], pts[..., 1], pts[..., 2])
 
         else:
+            # Can not be tested. Will only be raised if a coordinate system
+            # is not fully implemented.
             raise ValueError(
                 f"Conversion for {convention} is not implemented.")
 
@@ -1016,7 +1026,7 @@ class Coordinates():
 
         """
 
-        # check if the coordinate  and unit
+        # check if the coordinate and unit exist
         domain, convention, index = self._exist_coordinate(coordinate, unit)
 
         # get type and range of coordinate
@@ -1443,11 +1453,11 @@ class Coordinates():
                     # return or raise ValueError
                     if unit in units:
                         return domain, convention, index
-                    else:
-                        raise ValueError(
-                            f"'{coordinate}' in '{unit}' does not exist. See "
-                            "self.systems() for a list of possible "
-                            "coordinates and units")
+
+        raise ValueError(
+            (f"'{coordinate}' in '{unit}' does not exist. See "
+             "self.systems() for a list of possible "
+             "coordinates and units"))
 
     def _make_system(self, domain=None, convention=None, unit=None):
         """

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -7,14 +7,15 @@ from pyfar import Coordinates
 import pyfar.classes.coordinates as coordinates
 
 
-# Test Coordinates() class ----------------------------------------------------
 def test_coordinates_init():
-    # get class instance
+    """Test initialization of empty coordinates object."""
     coords = Coordinates()
     assert isinstance(coords, Coordinates)
 
 
 def test__systems():
+    """Test completeness of internal representation of coordinate systems."""
+
     # get all coordinate systems
     coords = Coordinates()
     systems = coords._systems()
@@ -55,7 +56,7 @@ def test__systems():
 
 
 def test_coordinate_names():
-    # check if units agree across coordinates that appear more than once
+    """Test if units agree across coordinates that appear more than once"""
 
     # get all coordinate systems
     c = Coordinates()
@@ -90,7 +91,7 @@ def test_coordinate_names():
         units_ref, idx = np.unique(units[0], True)
         units_ref = units_ref[idx]
         for cc in range(1, len(units)):
-            # get nex entry for comparison
+            # get next entry for comparison
             units_test, idx = np.unique(units[cc], True)
             units_test = units_test[idx]
             # compare
@@ -103,6 +104,7 @@ def test_coordinate_names():
 
 
 def test_exist_systems():
+    """Test internal function for checking if a coordinate system exists."""
     # get class instance
     coords = Coordinates()
 
@@ -128,6 +130,7 @@ def test_exist_systems():
 
 
 def test_systems():
+    """Test if all possible function calls of Coordinates.systems() pass."""
     # get class instance
     coords = Coordinates()
 
@@ -136,14 +139,20 @@ def test_systems():
     coords.systems(brief=True)
     coords.systems('all')
     coords.systems('all', brief=True)
+    coords.systems('current')
+    coords.systems('current', brief=True)
+
+    with raises(ValueError, match="show must be 'current' or 'all'."):
+        coords.systems('what')
 
 
 def test_coordinates_init_val():
+    """Test initializing Coordinates with values of different type and size."""
 
     # test input: scalar
     c1 = 1
     # test input: 2 element vectors
-    c2 = [1, 2]                         # list
+    c2 = [1, 2]                        # list
     c3 = np.asarray(c2)                # flat np.array
     c4 = np.atleast_2d(c2)             # row vector np.array
     c5 = np.transpose(c4)              # column vector np.array
@@ -181,6 +190,7 @@ def test_coordinates_init_val():
 
 
 def test_coordinates_init_val_and_system():
+    """Test initialization with all available coordinate systems."""
     # get list of available coordinate systems
     coords = Coordinates()
     systems = coords._systems()
@@ -192,7 +202,8 @@ def test_coordinates_init_val_and_system():
                 Coordinates(0, 0, 0, domain, convention, unit[0][0:3])
 
 
-def test_coordinates_init_val_no_convention():
+def test_coordinates_init_default_convention():
+    """Test initialization with the default convention."""
     # get list of available coordinate systems
     coords = Coordinates()
     systems = coords._systems()
@@ -204,7 +215,8 @@ def test_coordinates_init_val_no_convention():
             Coordinates(0, 0, 0, domain, unit=unit[0][0:3])
 
 
-def test_coordinates_init_val_no_convention_no_unit():
+def test_coordinates_init_default_convention_and_unit():
+    """Test initialization with the default convention and untit."""
     # get list of available coordinate systems
     coords = Coordinates()
     systems = coords._systems()
@@ -214,10 +226,18 @@ def test_coordinates_init_val_no_convention_no_unit():
         Coordinates(0, 0, 0, domain)
 
 
+def test_coordinates_init_val_and_comment():
+    coords = Coordinates(1, 1, 1, comment='try this')
+    assert isinstance(coords, Coordinates)
+    assert coords.comment == 'try this'
+
+
 def test_coordinates_init_val_and_weights():
+    """Test initialization with weights."""
     # correct number of weights
     coords = Coordinates([1, 2], 0, 0, weights=[.5, .5])
     assert isinstance(coords, Coordinates)
+    npt.assert_allclose(coords.weights, [.5, .5])
 
     # incorrect number of weights
     with raises(AssertionError):
@@ -225,11 +245,14 @@ def test_coordinates_init_val_and_weights():
 
 
 def test_coordinates_init_sh_order():
+    """Test initialization with spherical harmonics order."""
     coords = Coordinates(sh_order=5)
     assert isinstance(coords, Coordinates)
+    assert coords.sh_order == 5
 
 
 def test_show():
+    """Test if possible calls of show() pass."""
     coords = Coordinates([-1, 0, 1], 0, 0)
     # show without mask
     coords.show()
@@ -242,7 +265,8 @@ def test_show():
         coords.show(np.array([1, 0], dtype=bool))
 
 
-def test_setter_and_getter_with():
+def test_setter_and_getter_with_conversion():
+    """Test conversion between coordinate systems using the default unit."""
     # get list of available coordinate systems
     coords = Coordinates()
     systems = coords._systems()
@@ -290,6 +314,7 @@ def test_setter_and_getter_with():
 
 
 def test_multiple_getter_with_conversion():
+    """Test output of 500 random sequential conversions."""
     # test N successive coordinate conversions
     N = 500
 
@@ -324,40 +349,51 @@ def test_multiple_getter_with_conversion():
         print(f"Tolerance met in iteration {ii}")
 
 
-def test_getter_weights():
-    coords = Coordinates([1, 2], 0, 0, weights=[.5, .5])
-    assert (coords.weights == np.array([.5, .5])).all()
+def test_getter_with_degrees():
+    """Test if getter return correct values also in degrees"""
+    coords = Coordinates(0, 1, 0)
+
+    sph = coords.get_sph(unit="deg")
+    npt.assert_allclose(sph, np.atleast_2d([90, 90, 1]))
+
+    cyl = coords.get_cyl(unit="deg")
+    npt.assert_allclose(cyl, np.atleast_2d([90, 0, 1]))
+
+
+def test_assertion_for_getter():
+    """Test assertion for empty Coordinates objects"""
+    coords = Coordinates()
+    with raises(ValueError, match="Object is empty"):
+        coords.get_cart()
+    with raises(ValueError, match="Object is empty"):
+        coords.get_sph()
+    with raises(ValueError, match="Object is empty"):
+        coords.get_cyl()
 
 
 def test_setter_weights():
+    """Test setting weights."""
     coords = Coordinates([1, 2], 0, 0)
     coords.weights = [.5, .5]
     assert (coords.weights == np.array([.5, .5])).all()
 
 
-def test_getter_sh_order():
-    coords = Coordinates(sh_order=10)
-    assert coords.sh_order == 10
-
-
 def test_setter_sh_order():
+    """Test setting the SH order."""
     coords = Coordinates()
     coords.sh_order = 10
     assert coords.sh_order == 10
 
 
-def test_getter_comment():
-    coords = Coordinates(1, 1, 1, comment='try this')
-    assert coords.comment == 'try this'
-
-
 def test_setter_comment():
+    """Test setting the comment."""
     coords = Coordinates()
     coords.comment = 'now this'
     assert coords.comment == 'now this'
 
 
 def test_cshape():
+    """Test the cshape attribute."""
     # empty
     coords = Coordinates()
     assert coords.cshape == (0,)
@@ -370,6 +406,7 @@ def test_cshape():
 
 
 def test_cdim():
+    """Test the csim attribute."""
     # empty
     coords = Coordinates()
     assert coords.cdim == 0
@@ -382,6 +419,7 @@ def test_cdim():
 
 
 def test_csize():
+    """Test the csize attribute."""
     # 0 points
     coords = Coordinates()
     assert coords.csize == 0
@@ -394,6 +432,7 @@ def test_csize():
 
 
 def test_getitem():
+    """Test getitem with different parameters."""
     # test without weights
     coords = Coordinates([1, 2], 0, 0)
     new = coords[0]
@@ -505,6 +544,11 @@ def test_get_nearest_sph():
     with raises(AssertionError):
         coords.get_nearest_sph(1, 0, 0, 181)
 
+    # test assertion for multiple radii
+    coords = Coordinates([1, 2], 0, 0)
+    with raises(ValueError, match="get_nearest_sph only works if"):
+        coords.get_nearest_sph(0, 0, 1, 1)
+
 
 def test_get_slice():
     # test only for self.cdim = 1.
@@ -529,6 +573,8 @@ def test_get_slice():
     # cyclic querry
     assert (c.get_slice('azimuth', 'deg', 0, 1) == np.array([0, 1, 1, 1, 0],
                                                             dtype=bool)).all()
+    assert (c.get_slice('azimuth', 'deg', 359, 2) == np.array([1, 1, 1, 1, 0],
+                                                            dtype=bool)).all()
     # non-cyclic querry
     assert (c.get_slice('azimuth', 'deg', 1, 1) == np.array([0, 0, 1, 1, 1],
                                                             dtype=bool)).all()
@@ -538,6 +584,9 @@ def test_get_slice():
 
     # there is no unique processing for cylindrical coordinates - they are thus
     # not tested here.
+
+    # test with show
+    c.get_slice('azimuth', 'deg', 1, 1, show=True)
 
 
 def test_rotation():
@@ -576,8 +625,10 @@ def test_rotation():
 
 
 def test_converters():
-    # test if converterts can handle numbers
-    # (correctness of the rotation is tested in test_setter_and_getter)
+    """
+    Test if converterts can handle numbers (correctness of theconversion is
+    tested in test_setter_and_getter_with_conversion)
+    """
     coordinates.cart2sph(0, 0, 1)
     coordinates.sph2cart(0, 0, 1)
     coordinates.cart2cyl(0, 0, 1)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -437,14 +437,14 @@ def test_getitem():
     coords = Coordinates([1, 2], 0, 0)
     new = coords[0]
     assert isinstance(new, Coordinates)
-    assert (new.get_cart().flatten() == np.array([1, 0, 0])).all()
+    npt.assert_allclose(new.get_cart(), np.atleast_2d([1, 0, 0]))
 
     # test with weights
     coords = Coordinates([1, 2], 0, 0, weights=[.1, .9])
     new = coords[0]
     assert isinstance(new, Coordinates)
-    assert (new.get_cart().flatten() == np.array([1, 0, 0])).all()
-    assert new.weights.flatten() == np.array(.1)
+    npt.assert_allclose(new.get_cart(), np.atleast_2d([1, 0, 0]))
+    assert new.weights == np.array(.1)
 
     # test with 3D array
     coords = Coordinates([[1, 2, 3, 4, 5], [2, 3, 4, 5, 6]], 0, 0)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -227,6 +227,7 @@ def test_coordinates_init_default_convention_and_unit():
 
 
 def test_coordinates_init_val_and_comment():
+    """Test initialization with comment."""
     coords = Coordinates(1, 1, 1, comment='try this')
     assert isinstance(coords, Coordinates)
     assert coords.comment == 'try this'

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -461,38 +461,39 @@ def test_getitem():
 
 
 def test_get_nearest_k():
+    """Test returns of get_nearest_k"""
     # 1D cartesian, nearest point
     x = np.arange(6)
     coords = Coordinates(x, 0, 0)
     d, i, m = coords.get_nearest_k(1, 0, 0)
     assert d == 0.
     assert i == 1
-    assert (m == np.array([0, 1, 0, 0, 0, 0], dtype=bool)).all()
+    npt.assert_allclose(m, np.array([0, 1, 0, 0, 0, 0]))
 
     # 1D spherical, nearest point
     d, i, m = coords.get_nearest_k(0, 0, 1, 1, 'sph', 'top_elev', 'deg')
     assert d == 0.
     assert i == 1
-    assert (m == np.array([0, 1, 0, 0, 0, 0], dtype=bool)).all()
+    npt.assert_allclose(m, np.array([0, 1, 0, 0, 0, 0]))
 
     # 1D cartesian, two nearest points
     d, i, m = coords.get_nearest_k(1.2, 0, 0, 2)
     npt.assert_allclose(d, [.2, .8], atol=1e-15)
-    assert (i == np.array([1, 2])).all()
-    assert (m == np.array([0, 1, 1, 0, 0, 0], dtype=bool)).all()
+    npt.assert_allclose(i, np.array([1, 2]))
+    npt.assert_allclose(m, np.array([0, 1, 1, 0, 0, 0]))
 
-    # 1D cartesian querry two points
+    # 1D cartesian query two points
     d, i, m = coords.get_nearest_k([1, 2], 0, 0)
     npt.assert_allclose(d, [0, 0], atol=1e-15)
     npt.assert_allclose(i, [1, 2])
-    assert (m == np.array([0, 1, 1, 0, 0, 0], dtype=bool)).all()
+    npt.assert_allclose(m, np.array([0, 1, 1, 0, 0, 0]))
 
     # 2D cartesian, nearest point
     coords = Coordinates(x.reshape(2, 3), 0, 0)
     d, i, m = coords.get_nearest_k(1, 0, 0)
     assert d == 0.
     assert i == 1
-    assert (m == np.array([[0, 1, 0], [0, 0, 0]], dtype=bool)).all()
+    npt.assert_allclose(m, np.array([[0, 1, 0], [0, 0, 0]]))
 
     # test with plot
     coords = Coordinates(x, 0, 0)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -570,17 +570,20 @@ def test_get_slice():
     # spherical grid
     d = [358, 359, 0, 1, 2]
     c = Coordinates(d, 0, 1, 'sph', 'top_elev', 'deg')
-    # cyclic querry
+    # cyclic query
     assert (c.get_slice('azimuth', 'deg', 0, 1) == np.array([0, 1, 1, 1, 0],
                                                             dtype=bool)).all()
     assert (c.get_slice('azimuth', 'deg', 359, 2) == np.array([1, 1, 1, 1, 0],
                                                             dtype=bool)).all()
-    # non-cyclic querry
+    # non-cyclic query
     assert (c.get_slice('azimuth', 'deg', 1, 1) == np.array([0, 0, 1, 1, 1],
                                                             dtype=bool)).all()
-    # out of range querry
+    # out of range query
     with raises(AssertionError):
         c.get_slice('azimuth', 'deg', -1, 1)
+    # non existing coordinate query
+    with raises(ValueError, match="'elevation' in 'ged' does not exist"):
+        c.get_slice('elevation', 'ged', 1, 1)
 
     # there is no unique processing for cylindrical coordinates - they are thus
     # not tested here.

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -551,45 +551,49 @@ def test_get_nearest_sph():
 
 
 def test_get_slice():
+    """Test different queries for get slice."""
     # test only for self.cdim = 1.
     # self.get_slice uses KDTree, which is tested with N-dimensional arrays
     # in test_get_nearest_k()
 
     # cartesian grid
     d = np.linspace(-2, 2, 5)
+
     c = Coordinates(d, 0, 0)
-    assert (c.get_slice('x', 'met', 0, 1) == np.array([0, 1, 1, 1, 0],
-                                                      dtype=bool)).all()
+    npt.assert_allclose(
+        c.get_slice('x', 'met', 0, 1), np.array([0, 1, 1, 1, 0]))
+
     c = Coordinates(0, d, 0)
-    assert (c.get_slice('y', 'met', 0, 1) == np.array([0, 1, 1, 1, 0],
-                                                      dtype=bool)).all()
+    npt.assert_allclose(
+        c.get_slice('y', 'met', 0, 1), np.array([0, 1, 1, 1, 0]))
+
     c = Coordinates(0, 0, d)
-    assert (c.get_slice('z', 'met', 0, 1) == np.array([0, 1, 1, 1, 0],
-                                                      dtype=bool)).all()
+    npt.assert_allclose(
+        c.get_slice('z', 'met', 0, 1), np.array([0, 1, 1, 1, 0]))
 
     # spherical grid
     d = [358, 359, 0, 1, 2]
     c = Coordinates(d, 0, 1, 'sph', 'top_elev', 'deg')
-    # cyclic query
-    assert (c.get_slice('azimuth', 'deg', 0, 1) == np.array([0, 1, 1, 1, 0],
-                                                            dtype=bool)).all()
-    assert (c.get_slice('azimuth', 'deg', 359, 2) == np.array([1, 1, 1, 1, 0],
-                                                            dtype=bool)).all()
+    # cyclic query for lower bound
+    npt.assert_allclose(
+        c.get_slice('azimuth', 'deg', 0, 1), np.array([0, 1, 1, 1, 0]))
+    # cyclic query for upper bound
+    npt.assert_allclose(
+        c.get_slice('azimuth', 'deg', 359, 2), np.array([1, 1, 1, 1, 0]))
     # non-cyclic query
-    assert (c.get_slice('azimuth', 'deg', 1, 1) == np.array([0, 0, 1, 1, 1],
-                                                            dtype=bool)).all()
+    npt.assert_allclose(
+        c.get_slice('azimuth', 'deg', 1, 1), np.array([0, 0, 1, 1, 1]))
     # out of range query
     with raises(AssertionError):
         c.get_slice('azimuth', 'deg', -1, 1)
     # non existing coordinate query
     with raises(ValueError, match="'elevation' in 'ged' does not exist"):
         c.get_slice('elevation', 'ged', 1, 1)
+    # test with show
+    c.get_slice('azimuth', 'deg', 1, 1, show=True)
 
     # there is no unique processing for cylindrical coordinates - they are thus
     # not tested here.
-
-    # test with show
-    c.get_slice('azimuth', 'deg', 1, 1, show=True)
 
 
 def test_rotation():


### PR DESCRIPTION
### Changes proposed in this pull request:

- Unified use of numpy testing
- Removed tests that were not needed
- Added parameterization for one case
- Minor bugdixes:
    - `Coordinates.get_cyl()` did not convert to degrees
    - ValueError was not raised in `Coordinates.get_slice()` if a non existing coordinate was passed
    - `Coordinates.__getitem__` did not maintain the correct shape of the coordinate points if only one coordinate was left