### PR TITLE
Automatically include code from plots in the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,10 @@ extensions = [
 # package
 autodoc_default_options = {'autosummary': True}
 
+# show the code of plots that follows the command .. plot:: based on the
+# package matplotlib.sphinxext.plot_directive
+plot_include_source = True
+
 imgmath_latex_preamble = r'\usepackage{array}'
 
 # Add any paths that contain templates here, relative to this directory.

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -816,7 +816,6 @@ class Signal(FrequencyData, TimeData):
         Iterate channels of a :py:func:`Signal`
 
         >>> import pyfar as pf
-        >>>
         >>> signal = pf.signals.impulse(2, amplitude=[1, 1, 1])
         >>> for idx, channel in enumerate(signal):
         >>>     channel.time *= idx

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -214,8 +214,8 @@ class _Audio():
         --------
         Get the first channel of a multi channel audio object
 
-        >>> import pyfar
-        >>> signal = pyfar.signals.noise(10, rms=[1, 1])
+        >>> import pyfar as pf
+        >>> signal = pf.signals.noise(10, rms=[1, 1])
         >>> first_channel = signal[0]
 
 
@@ -239,9 +239,9 @@ class _Audio():
         --------
         Set the first channel of a multi channel audio object
 
-        >>> import pyfar
-        >>> signal = pyfar.signals.noise(10, rms=[1, 1])
-        >>> signal[0] = pyfar.signals.noise(10, rms=2)
+        >>> import pyfar as pf
+        >>> signal = pf.signals.noise(10, rms=[1, 1])
+        >>> signal[0] = pf.signals.noise(10, rms=2)
         """
         self._assert_matching_meta_data(value)
         if isinstance(key, (int, slice)):
@@ -815,9 +815,9 @@ class Signal(FrequencyData, TimeData):
         --------
         Iterate channels of a :py:func:`Signal`
 
-        >>> import pyfar
+        >>> import pyfar as pf
         >>>
-        >>> signal = pyfar.signals.impulse(2, amplitude=[1, 1, 1])
+        >>> signal = pf.signals.impulse(2, amplitude=[1, 1, 1])
         >>> for idx, channel in enumerate(signal):
         >>>     channel.time *= idx
         >>>     signal[idx] = channel

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1099,8 +1099,8 @@ class Coordinates():
 
         Get a coordinates object
 
-        >>> import pyfar
-        >>> coordinates = pyfar.spatial.samplings.sph_gaussian(sh_order=3)
+        >>> import pyfar as pf
+        >>> coordinates = pf.samplings.sph_gaussian(sh_order=3)
 
         Rotate 45 degrees about the y-axis using
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -797,10 +797,6 @@ class Coordinates():
 
         Get frontal point from a spherical coordinate system
 
-        >>> import pyfar
-        >>> coords = pyfar.samplings.sph_lebedev(sh_order=10)
-        >>> result = coords.get_nearest_k(1, 0, 0, show=True)
-
         .. plot::
 
             import pyfar
@@ -870,10 +866,6 @@ class Coordinates():
         --------
 
         Get frontal points within a distance of 0.5 meters
-
-        >>> import pyfar
-        >>> coords = pyfar.samplings.sph_lebedev(sh_order=10)
-        >>> result = coords.get_nearest_cart(1, 0, 0, 0.5, show=True)
 
         .. plot::
 
@@ -945,10 +937,6 @@ class Coordinates():
 
         Get top points within a distance of 45 degrees
 
-        >>> import pyfar
-        >>> coords = pyfar.samplings.sph_lebedev(sh_order=10)
-        >>> result = coords.get_nearest_sph(0, 0, 1, 45, show=True)
-
         .. plot::
 
             import pyfar
@@ -1013,10 +1001,6 @@ class Coordinates():
 
         Get horizontal slice of spherical coordinate system within a ring of
         +/- 10 degrees
-
-        >>> import pyfar
-        >>> coords = pyfar.spatial.samplings.sph_lebedev(sh_order=10)
-        >>> result = coords.get_slice('elevation', 'deg', 0, 10, show=True)
 
         .. plot::
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -799,9 +799,9 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar as pf
-            coords = pf.samplings.sph_lebedev(sh_order=10)
-            result = coords.get_nearest_k(1, 0, 0, show=True)
+            >>> import pyfar as pf
+            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> result = coords.get_nearest_k(1, 0, 0, show=True)
         """
 
         # check the input
@@ -869,9 +869,9 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar as pf
-            coords = pf.samplings.sph_lebedev(sh_order=10)
-            result = coords.get_nearest_cart(1, 0, 0, 0.5, show=True)
+            >>> import pyfar as pf
+            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> result = coords.get_nearest_cart(1, 0, 0, 0.5, show=True)
 
         """
 
@@ -939,9 +939,9 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar as pf
-            coords = pf.samplings.sph_lebedev(sh_order=10)
-            result = coords.get_nearest_sph(0, 0, 1, 45, show=True)
+            >>> import pyfar as pf
+            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> result = coords.get_nearest_sph(0, 0, 1, 45, show=True)
         """
 
         # check the input
@@ -1004,9 +1004,9 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar as pf
-            coords = pf.samplings.sph_lebedev(sh_order=10)
-            result = coords.get_slice('elevation', 'deg', 0, 10, show=True)
+            >>> import pyfar as pf
+            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> result = coords.get_slice('elevation', 'deg', 0, 10, show=True)
 
         """
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -799,8 +799,8 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar
-            coords = pyfar.samplings.sph_lebedev(sh_order=10)
+            import pyfar as pf
+            coords = pf.samplings.sph_lebedev(sh_order=10)
             result = coords.get_nearest_k(1, 0, 0, show=True)
         """
 
@@ -869,8 +869,8 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar
-            coords = pyfar.samplings.sph_lebedev(sh_order=10)
+            import pyfar as pf
+            coords = pf.samplings.sph_lebedev(sh_order=10)
             result = coords.get_nearest_cart(1, 0, 0, 0.5, show=True)
 
         """
@@ -939,8 +939,8 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar
-            coords = pyfar.samplings.sph_lebedev(sh_order=10)
+            import pyfar as pf
+            coords = pf.samplings.sph_lebedev(sh_order=10)
             result = coords.get_nearest_sph(0, 0, 1, 45, show=True)
         """
 
@@ -1004,8 +1004,8 @@ class Coordinates():
 
         .. plot::
 
-            import pyfar
-            coords = pyfar.samplings.sph_lebedev(sh_order=10)
+            import pyfar as pf
+            coords = pf.samplings.sph_lebedev(sh_order=10)
             result = coords.get_slice('elevation', 'deg', 0, 10, show=True)
 
         """

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -424,16 +424,6 @@ def time_window(signal, interval, window='hann', shape='symmetric',
 
     Options for parameter `shape`.
 
-    >>> import pyfar
-    >>> import numpy as np
-    >>>
-    >>> signal = pyfar.Signal(np.ones(100), 44100)
-    >>> for shape in ['symmetric', 'symmetric_zero', 'left', 'right']:
-    >>>     signal_windowed = pyfar.dsp.time_window(
-    >>>         signal, interval=[25,45], shape=shape)
-    >>>     ax = pyfar.plot.time(signal_windowed, label=shape)
-    >>> ax.legend(loc='right')
-
     .. plot::
 
         import pyfar
@@ -447,14 +437,6 @@ def time_window(signal, interval, window='hann', shape='symmetric',
         ax.legend(loc='right')
 
     Window with fade-in and fade-out defined by four values in `interval`.
-
-    >>> import pyfar
-    >>> import numpy as np
-    >>>
-    >>> signal = pyfar.Signal(np.ones(100), 44100)
-    >>> signal_windowed = pyfar.dsp.time_window(
-    >>>         signal, interval=[25, 40, 60, 90], window='hann')
-    >>> pyfar.plot.time(signal_windowed)
 
     .. plot::
 
@@ -896,47 +878,17 @@ class InterpolateSpectrum():
 
     Examples
     --------
-    Interpolate magnitude only and add artificial linear phase.
-
-
-    >>> import pyfar as pf
-    >>> data = pf.FrequencyData([1, 0], [5e3, 20e3])
-    >>> interpolator = pf.dsp.InterpolateSpectrum(
-    >>>     data, 'magnitude', ('nearest', 'linear', 'nearest'))
-    >>> signal = interpolator(64, 44100)
-    >>> signal = pf.dsp.linear_phase(signal, 32)
-
-    Inspect the data in the time and frequency domain. Note that a similar plot
-    can also be created by the interpolator object by
+    Interpolate magnitude add artificial linear phase and inspect the results.
+    Note that a similar plot can also be created by the interpolator object by
     ``signal = interpolator(64, 44100, show=True)``
-
-    >>> import pyfar as pf
-    >>> import matplotlib.pyplot as plt
-    >>> import numpy as np
-    >>> with pf.plot.context():
-    >>>     _, ax = plt.subplots(2, 2)
-    >>>     # time plot (linear and logarithmic amplitude)
-    >>>     pf.plot.time(signal, ax=ax[0, 0])
-    >>>     pf.plot.time(signal, ax=ax[1, 0], dB=True)
-    >>>     # frequency plot (linear x-axis)
-    >>>     pf.plot.freq(signal, dB=False, xscale="linear", ax=ax[0, 1])
-    >>>     pf.plot.freq(data, dB=False, xscale="linear",
-    ...                  ax=ax[0, 1], c='r', ls='', marker='.')
-    >>>     ax[0, 1].set_xlim(0, signal.sampling_rate/2)
-    >>>     # frequency plot (log x-axis)
-    >>>     pf.plot.freq(signal, dB=False, ax=ax[1, 1], label='input')
-    >>>     pf.plot.freq(data, dB=False, ax=ax[1, 1],
-    ...                  c='r', ls='', marker='.', label='output')
-    >>>     min_freq = np.min([signal.sampling_rate / signal.n_samples,
-    ...                        data.frequencies[0]])
-    >>>     ax[1, 1].set_xlim(min_freq, signal.sampling_rate/2)
-    >>>     ax[1, 1].legend(loc='best')
 
     .. plot::
 
         import pyfar as pf
         import matplotlib.pyplot as plt
         import numpy as np
+
+        # generate data
         data = pf.FrequencyData([1, 0], [5e3, 20e3])
         interpolator = pf.dsp.InterpolateSpectrum(
             data, 'magnitude', ('nearest', 'linear', 'nearest'))
@@ -1218,23 +1170,15 @@ def minimum_phase(
 
     Minmum-phase version of an ideal impulse with a group delay of 64 samples
 
-    >>> import pyfar as pf
-    >>> import matplotlib.pyplot as plt
-    >>> impulse_linear_phase = pf.signals.impulse(129, delay=64)
-    >>> impulse_minmum_phase = pf.dsp.minimum_phase(
-    ...     impulse_linear_phase, method='homomorphic')
-    >>> plt.figure(figsize=(8, 2))
-    >>> pf.plot.group_delay(impulse_linear_phase, label='Linear phase')
-    >>> pf.plot.group_delay(impulse_minmum_phase, label='Minmum phase')
-    >>> plt.legend()
-
     .. plot::
 
         import pyfar as pf
         import matplotlib.pyplot as plt
+
         impulse_linear_phase = pf.signals.impulse(129, delay=64)
         impulse_minmum_phase = pf.dsp.minimum_phase(
             impulse_linear_phase, method='homomorphic')
+
         plt.figure(figsize=(8, 2))
         pf.plot.group_delay(impulse_linear_phase, label='Linear phase')
         pf.plot.group_delay(impulse_minmum_phase, label='Minmum phase')
@@ -1242,36 +1186,19 @@ def minimum_phase(
 
     Create a minimum phase equivalent of a linear phase FIR low-pass filter
 
-    >>> import pyfar as pf
-    >>> import numpy as np
-    >>> from scipy.signal import remez
-    >>> import matplotlib.pyplot as plt
-    >>> freq = [0, 0.2, 0.3, 1.0]
-    >>> desired = [1, 0]
-    >>> h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
-    >>> h_min_hom = pf.dsp.minimum_phase(h_linear, method='homomorphic')
-    >>> h_min_hil = pf.dsp.minimum_phase(h_linear, method='hilbert')
-    >>> fig, axs = plt.subplots(3, figsize=(8, 6))
-    >>> for h, style in zip(
-    ...         (h_linear, h_min_hom, h_min_hil),
-    ...         ('-', '-.', '--')):
-    ...     pf.plot.time(h, linestyle=style, ax=axs[0])
-    ...     axs[0].grid(True)
-    ...     pf.plot.freq(h, linestyle=style, ax=axs[1])
-    ...     pf.plot.group_delay(h, linestyle=style, ax=axs[2])
-    >>> axs[1].legend(['Linear', 'Homomorphic', 'Hilbert'])
-
     .. plot::
 
         import pyfar as pf
         import numpy as np
         from scipy.signal import remez
         import matplotlib.pyplot as plt
+
         freq = [0, 0.2, 0.3, 1.0]
         desired = [1, 0]
         h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
         h_min_hom = pf.dsp.minimum_phase(h_linear, method='homomorphic')
         h_min_hil = pf.dsp.minimum_phase(h_linear, method='hilbert')
+
         fig, axs = plt.subplots(3, figsize=(8, 6))
         for h, style in zip(
                 (h_linear, h_min_hom, h_min_hil),
@@ -1286,27 +1213,13 @@ def minimum_phase(
     and indicate frequencies where the linear phase filter exhibits small
     amplitudes.
 
-    >>> h_minimum, ratio = pf.dsp.minimum_phase(h_linear,
-    ...     method='homomorphic', return_magnitude_ratio=True)
-    >>> fig, axs = plt.subplots(2, figsize=(8, 4))
-    >>> pf.plot.freq(h_linear, linestyle='-', ax=axs[0])
-    >>> pf.plot.freq(h_minimum, linestyle='--', ax=axs[0])
-    >>> pf.plot.freq(ratio, linestyle='-', ax=axs[1])
-    >>> mask = np.abs(h_linear.freq) < 10**(-60/20)
-    >>> ratio_masked = pf.FrequencyData(
-    ...     ratio.freq[mask], ratio.frequencies[mask[0]])
-    >>> pf.plot.freq(ratio_masked, color='k', linestyle='--', ax=axs[1])
-    >>> axs[1].set_ylabel('Log error in dB')
-    >>> axs[0].legend(['Linear phase', 'Minimum phase'])
-    >>> axs[1].legend(['Broadband', 'Linear-phase < -60 dB'])
-    >>> axs[1].set_ylim((-5, 105))
-
     .. plot::
 
         import pyfar as pf
         import numpy as np
         from scipy.signal import remez
         import matplotlib.pyplot as plt
+
         freq = [0, 0.2, 0.3, 1.0]
         desired = [1, 0]
         h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
@@ -1453,31 +1366,17 @@ def time_shift(signal, shift, unit='samples'):
     Examples
     --------
     Individually shift a set of ideal impulses stored in three different
-    channels
-
-    >>> import pyfar as pf
-    >>> import matplotlib.pyplot as plt
-    >>> impulse = pf.signals.impulse(
-    ...     32, amplitude=(1, 1.5, 1), delay=(14, 15, 16))
-    >>> shifted = pf.dsp.time_shift(impulse, [-2, 0, 2])
-
-    Plot the resulting signals
-
-    >>> pf.plot.use('light')
-    >>> _, axs = plt.subplots(2, 1)
-    >>> pf.plot.time(impulse, ax=axs[0])
-    >>> pf.plot.time(shifted, ax=axs[1])
-    >>> axs[0].set_title('Original signals')
-    >>> axs[1].set_title('Shifted signals')
-    >>> plt.tight_layout()
+    channels and plot the resulting signals
 
     .. plot::
 
         import pyfar as pf
         import matplotlib.pyplot as plt
+
         impulse = pf.signals.impulse(
             32, amplitude=(1, 1.5, 1), delay=(14, 15, 16))
         shifted = pf.dsp.time_shift(impulse, [-2, 0, 2])
+
         pf.plot.use('light')
         _, axs = plt.subplots(2, 1)
         pf.plot.time(impulse, ax=axs[0])

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -426,27 +426,25 @@ def time_window(signal, interval, window='hann', shape='symmetric',
 
     .. plot::
 
-        import pyfar as pf
-        import numpy as np
-
-        signal = pf.Signal(np.ones(100), 44100)
-        for shape in ['symmetric', 'symmetric_zero', 'left', 'right']:
-            signal_windowed = pf.dsp.time_window(
-                signal, interval=[25,45], shape=shape)
-            ax = pf.plot.time(signal_windowed, label=shape)
-        ax.legend(loc='right')
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> signal = pf.Signal(np.ones(100), 44100)
+        >>> for shape in ['symmetric', 'symmetric_zero', 'left', 'right']:
+        >>>     signal_windowed = pf.dsp.time_window(
+        ...         signal, interval=[25,45], shape=shape)
+        >>>     ax = pf.plot.time(signal_windowed, label=shape)
+        >>> ax.legend(loc='right')
 
     Window with fade-in and fade-out defined by four values in `interval`.
 
     .. plot::
 
-        import pyfar as pf
-        import numpy as np
-
-        signal = pf.Signal(np.ones(100), 44100)
-        signal_windowed = pf.dsp.time_window(
-                signal, interval=[25, 40, 60, 90], window='hann')
-        pf.plot.time(signal_windowed)
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> signal = pf.Signal(np.ones(100), 44100)
+        >>> signal_windowed = pf.dsp.time_window(
+        ...         signal, interval=[25, 40, 60, 90], window='hann')
+        >>> pf.plot.time(signal_windowed)
 
 
     """
@@ -884,37 +882,34 @@ class InterpolateSpectrum():
 
     .. plot::
 
-        import pyfar as pf
-        import matplotlib.pyplot as plt
-        import numpy as np
-
-        # generate data
-        data = pf.FrequencyData([1, 0], [5e3, 20e3])
-        interpolator = pf.dsp.InterpolateSpectrum(
-            data, 'magnitude', ('nearest', 'linear', 'nearest'))
-        signal = interpolator(64, 44100)
-        signal = pf.dsp.linear_phase(signal, 32)
-
-        # plot input and output data
-        with pf.plot.context():
-            _, ax = plt.subplots(2, 2)
-            # time signal (linear amplitude)
-            pf.plot.time(signal, ax=ax[0, 0])
-            # time signal (log amplitude)
-            pf.plot.time(signal, ax=ax[1, 0], dB=True)
-            # frequency plot (linear x-axis)
-            pf.plot.freq(signal, dB=False, xscale="linear", ax=ax[0, 1])
-            pf.plot.freq(data, dB=False, xscale="linear",
-                         ax=ax[0, 1], c='r', ls='', marker='.')
-            ax[0, 1].set_xlim(0, signal.sampling_rate/2)
-            # frequency plot (log x-axis)
-            pf.plot.freq(signal, dB=False, ax=ax[1, 1], label='input')
-            pf.plot.freq(data, dB=False, ax=ax[1, 1],
-                         c='r', ls='', marker='.', label='output')
-            min_freq = np.min([signal.sampling_rate / signal.n_samples,
-                               data.frequencies[0]])
-            ax[1, 1].set_xlim(min_freq, signal.sampling_rate/2)
-            ax[1, 1].legend(loc='best')
+        >>> import pyfar as pf
+        >>> import matplotlib.pyplot as plt
+        >>> import numpy as np
+        >>> # generate data
+        >>> data = pf.FrequencyData([1, 0], [5e3, 20e3])
+        >>> interpolator = pf.dsp.InterpolateSpectrum(
+        ...     data, 'magnitude', ('nearest', 'linear', 'nearest'))
+        >>> signal = interpolator(64, 44100)
+        >>> signal = pf.dsp.linear_phase(signal, 32)
+        >>> # plot input and output data
+        >>> with pf.plot.context():
+        >>>     _, ax = plt.subplots(2, 2)
+        >>>     # time signal (linear and logarithmic amplitude)
+        >>>     pf.plot.time(signal, ax=ax[0, 0])
+        >>>     pf.plot.time(signal, ax=ax[1, 0], dB=True)
+        >>>     # frequency plot (linear x-axis)
+        >>>     pf.plot.freq(signal, dB=False, xscale="linear", ax=ax[0, 1])
+        >>>     pf.plot.freq(data, dB=False, xscale="linear",
+        ...                  ax=ax[0, 1], c='r', ls='', marker='.')
+        >>>     ax[0, 1].set_xlim(0, signal.sampling_rate/2)
+        >>>     # frequency plot (log x-axis)
+        >>>     pf.plot.freq(signal, dB=False, ax=ax[1, 1], label='input')
+        >>>     pf.plot.freq(data, dB=False, ax=ax[1, 1],
+        ...                  c='r', ls='', marker='.', label='output')
+        >>>     min_freq = np.min([signal.sampling_rate / signal.n_samples,
+        ...                        data.frequencies[0]])
+        >>>     ax[1, 1].set_xlim(min_freq, signal.sampling_rate/2)
+        >>>     ax[1, 1].legend(loc='best')
 
     """
 
@@ -1172,42 +1167,42 @@ def minimum_phase(
 
     .. plot::
 
-        import pyfar as pf
-        import matplotlib.pyplot as plt
-
-        impulse_linear_phase = pf.signals.impulse(129, delay=64)
-        impulse_minmum_phase = pf.dsp.minimum_phase(
-            impulse_linear_phase, method='homomorphic')
-
-        plt.figure(figsize=(8, 2))
-        pf.plot.group_delay(impulse_linear_phase, label='Linear phase')
-        pf.plot.group_delay(impulse_minmum_phase, label='Minmum phase')
-        plt.legend()
+        >>> import pyfar as pf
+        >>> import matplotlib.pyplot as plt
+        >>> # create linear and minimum phase signal
+        >>> impulse_linear_phase = pf.signals.impulse(129, delay=64)
+        >>> impulse_minmum_phase = pf.dsp.minimum_phase(
+        ...     impulse_linear_phase, method='homomorphic')
+        >>> # plot the group delay
+        >>> plt.figure(figsize=(8, 2))
+        >>> pf.plot.group_delay(impulse_linear_phase, label='Linear phase')
+        >>> pf.plot.group_delay(impulse_minmum_phase, label='Minmum phase')
+        >>> plt.legend()
 
     Create a minimum phase equivalent of a linear phase FIR low-pass filter
 
     .. plot::
 
-        import pyfar as pf
-        import numpy as np
-        from scipy.signal import remez
-        import matplotlib.pyplot as plt
-
-        freq = [0, 0.2, 0.3, 1.0]
-        desired = [1, 0]
-        h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
-        h_min_hom = pf.dsp.minimum_phase(h_linear, method='homomorphic')
-        h_min_hil = pf.dsp.minimum_phase(h_linear, method='hilbert')
-
-        fig, axs = plt.subplots(3, figsize=(8, 6))
-        for h, style in zip(
-                (h_linear, h_min_hom, h_min_hil),
-                ('-', '-.', '--')):
-            pf.plot.time(h, linestyle=style, ax=axs[0])
-            axs[0].grid(True)
-            pf.plot.freq(h, linestyle=style, ax=axs[1])
-            pf.plot.group_delay(h, linestyle=style, ax=axs[2])
-        axs[1].legend(['Linear', 'Homomorphic', 'Hilbert'])
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> from scipy.signal import remez
+        >>> import matplotlib.pyplot as plt
+        >>> # create minimum phase signals with different methods
+        >>> freq = [0, 0.2, 0.3, 1.0]
+        >>> desired = [1, 0]
+        >>> h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
+        >>> h_min_hom = pf.dsp.minimum_phase(h_linear, method='homomorphic')
+        >>> h_min_hil = pf.dsp.minimum_phase(h_linear, method='hilbert')
+        >>> # plot the results
+        >>> fig, axs = plt.subplots(3, figsize=(8, 6))
+        >>> for h, style in zip(
+        ...         (h_linear, h_min_hom, h_min_hil),
+        ...         ('-', '-.', '--')):
+        >>>     pf.plot.time(h, linestyle=style, ax=axs[0])
+        >>>     axs[0].grid(True)
+        >>>     pf.plot.freq(h, linestyle=style, ax=axs[1])
+        >>>     pf.plot.group_delay(h, linestyle=style, ax=axs[2])
+        >>> axs[1].legend(['Linear', 'Homomorphic', 'Hilbert'])
 
     Return the magnitude ratios between the minimum and linear phase filters
     and indicate frequencies where the linear phase filter exhibits small
@@ -1215,30 +1210,29 @@ def minimum_phase(
 
     .. plot::
 
-        import pyfar as pf
-        import numpy as np
-        from scipy.signal import remez
-        import matplotlib.pyplot as plt
-
-        freq = [0, 0.2, 0.3, 1.0]
-        desired = [1, 0]
-        h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
-        h_minimum, ratio = pf.dsp.minimum_phase(h_linear,
-            method='homomorphic', return_magnitude_ratio=True)
-
-        fig, axs = plt.subplots(2, figsize=(8, 4))
-        pf.plot.freq(h_linear, linestyle='-', ax=axs[0])
-        pf.plot.freq(h_minimum, linestyle='--', ax=axs[0])
-        pf.plot.freq(ratio, linestyle='-', ax=axs[1])
-        mask = np.abs(h_linear.freq) < 10**(-60/20)
-        ratio_masked = pf.FrequencyData(
-            ratio.freq[mask], ratio.frequencies[mask[0]])
-        pf.plot.freq(ratio_masked, color='k', linestyle='--', ax=axs[1])
-
-        axs[1].set_ylabel('Magnitude error in dB')
-        axs[0].legend(['Linear phase', 'Minimum phase'])
-        axs[1].legend(['Broadband', 'Linear-phase < -60 dB'])
-        axs[1].set_ylim((-5, 105))
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> from scipy.signal import remez
+        >>> import matplotlib.pyplot as plt
+        >>> # generate linear and minimum phase signal
+        >>> freq = [0, 0.2, 0.3, 1.0]
+        >>> desired = [1, 0]
+        >>> h_linear = pf.Signal(remez(151, freq, desired, Hz=2.), 44100)
+        >>> h_minimum, ratio = pf.dsp.minimum_phase(h_linear,
+        ...     method='homomorphic', return_magnitude_ratio=True)
+        >>> # plot signals and difference between them
+        >>> fig, axs = plt.subplots(2, figsize=(8, 4))
+        >>> pf.plot.freq(h_linear, linestyle='-', ax=axs[0])
+        >>> pf.plot.freq(h_minimum, linestyle='--', ax=axs[0])
+        >>> pf.plot.freq(ratio, linestyle='-', ax=axs[1])
+        >>> mask = np.abs(h_linear.freq) < 10**(-60/20)
+        >>> ratio_masked = pf.FrequencyData(
+        ...     ratio.freq[mask], ratio.frequencies[mask[0]])
+        >>> pf.plot.freq(ratio_masked, color='k', linestyle='--', ax=axs[1])
+        >>> axs[1].set_ylabel('Magnitude error in dB')
+        >>> axs[0].legend(['Linear phase', 'Minimum phase'])
+        >>> axs[1].legend(['Broadband', 'Linear-phase < -60 dB'])
+        >>> axs[1].set_ylim((-5, 105))
 
 
     """
@@ -1370,20 +1364,20 @@ def time_shift(signal, shift, unit='samples'):
 
     .. plot::
 
-        import pyfar as pf
-        import matplotlib.pyplot as plt
-
-        impulse = pf.signals.impulse(
-            32, amplitude=(1, 1.5, 1), delay=(14, 15, 16))
-        shifted = pf.dsp.time_shift(impulse, [-2, 0, 2])
-
-        pf.plot.use('light')
-        _, axs = plt.subplots(2, 1)
-        pf.plot.time(impulse, ax=axs[0])
-        pf.plot.time(shifted, ax=axs[1])
-        axs[0].set_title('Original signals')
-        axs[1].set_title('Shifted signals')
-        plt.tight_layout()
+        >>> import pyfar as pf
+        >>> import matplotlib.pyplot as plt
+        >>> # generate and shift the impulses
+        >>> impulse = pf.signals.impulse(
+        ...     32, amplitude=(1, 1.5, 1), delay=(14, 15, 16))
+        >>> shifted = pf.dsp.time_shift(impulse, [-2, 0, 2])
+        >>> # time domain plot
+        >>> pf.plot.use('light')
+        >>> _, axs = plt.subplots(2, 1)
+        >>> pf.plot.time(impulse, ax=axs[0])
+        >>> pf.plot.time(shifted, ax=axs[1])
+        >>> axs[0].set_title('Original signals')
+        >>> axs[1].set_title('Shifted signals')
+        >>> plt.tight_layout()
 
     """
     shift = np.atleast_1d(shift)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1299,9 +1299,9 @@ def pad_zeros(signal, pad_width, mode='after'):
 
     Examples
     --------
-    >>> import pyfar
-    >>> impulse = pyfar.signals.impulse(512, amplitude=1)
-    >>> impulse_padded = pyfar.dsp.pad_zeros(impulse, 128, mode='after')
+    >>> import pyfar as pf
+    >>> impulse = pf.signals.impulse(512, amplitude=1)
+    >>> impulse_padded = pf.dsp.pad_zeros(impulse, 128, mode='after')
 
     """
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -426,27 +426,27 @@ def time_window(signal, interval, window='hann', shape='symmetric',
 
     .. plot::
 
-        import pyfar
+        import pyfar as pf
         import numpy as np
 
-        signal = pyfar.Signal(np.ones(100), 44100)
+        signal = pf.Signal(np.ones(100), 44100)
         for shape in ['symmetric', 'symmetric_zero', 'left', 'right']:
-            signal_windowed = pyfar.dsp.time_window(
+            signal_windowed = pf.dsp.time_window(
                 signal, interval=[25,45], shape=shape)
-            ax = pyfar.plot.time(signal_windowed, label=shape)
+            ax = pf.plot.time(signal_windowed, label=shape)
         ax.legend(loc='right')
 
     Window with fade-in and fade-out defined by four values in `interval`.
 
     .. plot::
 
-        import pyfar
+        import pyfar as pf
         import numpy as np
 
-        signal = pyfar.Signal(np.ones(100), 44100)
-        signal_windowed = pyfar.dsp.time_window(
+        signal = pf.Signal(np.ones(100), 44100)
+        signal_windowed = pf.dsp.time_window(
                 signal, interval=[25, 40, 60, 90], window='hann')
-        pyfar.plot.time(signal_windowed)
+        pf.plot.time(signal_windowed)
 
 
     """

--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -47,30 +47,29 @@ spectrum, e.g., according to the RMS value.
 
 .. plot::
 
-    import numpy as np
-    from pyfar.dsp import fft
-    import matplotlib.pyplot as plt
-
-    fft_normalization = "rms"
-
-    n_samples = 1024
-    sampling_rate = 48e3
-    frequency = 100
-    times = np.linspace(0, 10, n_samples)
-    freqs = fft.rfftfreq(n_samples, 48e3)
-
-    sine = np.sin(times * 2*np.pi * frequency)
-    spec = fft.rfft(sine, n_samples, sampling_rate, fft_normalization)
-
-    plt.subplot(1, 2, 1)
-    plt.plot(times, sine)
-    ax = plt.gca()
-    ax.set_xlabel('Time in s')
-    plt.subplot(1, 2, 2)
-    plt.plot(freqs, np.abs(spec))
-    ax = plt.gca()
-    ax.set_xlabel('Frequency in Hz')
-    plt.show()
+    >>> import numpy as np
+    >>> from pyfar.dsp import fft
+    >>> import matplotlib.pyplot as plt
+    >>> # properties
+    >>> fft_normalization = "rms"
+    >>> n_samples = 1024
+    >>> sampling_rate = 48e3
+    >>> frequency = 100
+    >>> times = np.linspace(0, 10, n_samples)
+    >>> freqs = fft.rfftfreq(n_samples, 48e3)
+    >>> # generate data
+    >>> sine = np.sin(times * 2*np.pi * frequency)
+    >>> spec = fft.rfft(sine, n_samples, sampling_rate, fft_normalization)
+    >>> # plot time and frequency data
+    >>> plt.subplot(1, 2, 1)
+    >>> plt.plot(times, sine)
+    >>> ax = plt.gca()
+    >>> ax.set_xlabel('Time in s')
+    >>> plt.subplot(1, 2, 2)
+    >>> plt.plot(freqs, np.abs(spec))
+    >>> ax = plt.gca()
+    >>> ax.set_xlabel('Frequency in Hz')
+    >>> plt.show()
 
 
 References

--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -45,27 +45,23 @@ of the spectrum (cf. [1]_, Eq. 8). The coresponding normalization is
 ``'unitary'``. Additional normalizations can be applied to further scale the
 spectrum, e.g., according to the RMS value.
 
->>> import numpy as np
->>> from pyfar.dsp import fft
->>> import matplotlib.pyplot as plt
->>> frequency = 100
->>> sampling_rate = 1000
->>> n_samples = 1024
->>> sampling_rate = 48e3
->>> sine = np.sin(np.linspace(0, 2*np.pi*frequency/sampling_rate, n_samples))
->>> spectrum = fft.rfft(sine, n_samples, sampling_rate, 'rms')
-
 .. plot::
 
     import numpy as np
     from pyfar.dsp import fft
     import matplotlib.pyplot as plt
+
+    fft_normalization = "rms"
+
     n_samples = 1024
     sampling_rate = 48e3
+    frequency = 100
     times = np.linspace(0, 10, n_samples)
-    sine = np.sin(times * 2*np.pi * 100)
-    spec = fft.rfft(sine, n_samples, sampling_rate, 'rms')
     freqs = fft.rfftfreq(n_samples, 48e3)
+
+    sine = np.sin(times * 2*np.pi * frequency)
+    spec = fft.rfft(sine, n_samples, sampling_rate, fft_normalization)
+
     plt.subplot(1, 2, 1)
     plt.plot(times, sine)
     ax = plt.gca()

--- a/pyfar/dsp/filter.py
+++ b/pyfar/dsp/filter.py
@@ -903,26 +903,18 @@ def fractional_octave_bands(
     Filter an impulse into octave bands. The summed energy of all bands equals
     the energy of the input signal.
 
-    >>> import pyfar as pf
-    >>> import numpy as np
-    >>> x = pf.signals.impulse(2**17)
-    >>> y = pf.dsp.filter.fractional_octave_bands(x, 1, freq_range=(20, 8e3))
-    >>> y_sum = pf.FrequencyData(np.sum(np.abs(y.freq)**2, 0), y.frequencies)
-    >>> pf.plot.freq(y)
-    >>> ax = pf.plot.freq(y_sum, color='k', log_prefix=10, linestyle='--')
-    >>> ax.set_title("Filter bands and the sum of their squared magnitudes")
-
     .. plot::
 
         import pyfar as pf
         import numpy as np
+
         x = pf.signals.impulse(2**17)
         y = pf.dsp.filter.fractional_octave_bands(x, 1, freq_range=(20, 8e3))
         y_sum = pf.FrequencyData(np.sum(np.abs(y.freq)**2, 0), y.frequencies)
+
         pf.plot.freq(y)
         ax = pf.plot.freq(y_sum, color='k', log_prefix=10, linestyle='--')
         ax.set_title("Filter bands and the sum of their squared magnitudes")
-        plt.tight_layout()
 
     """
     # check input
@@ -1088,25 +1080,6 @@ def reconstructing_fractional_octave_bands(
     --------
 
     Filter and re-synthesize impulse signal
-
-    >>> import pyfar as pf
-    >>> import numpy as np
-    >>> import matplotlib.pyplot as plt
-    >>>
-    >>> x = pf.signals.impulse(2**12)
-    >>> y, f = pf.dsp.filter.reconstructing_fractional_octave_bands(x)
-    >>> y_sum = pf.Signal(np.sum(y.time, 0), y.sampling_rate)
-    >>>
-    >>> ax = pf.plot.time_freq(y_sum, color='k')
-    >>> pf.plot.time(x, ax=ax[0])
-    >>> ax[0].set_xlim(-5, 2**12/44100 * 1e3 + 5)
-    >>> ax[0].set_title("Original (blue) and reconstructed pulse (black)")
-    >>>
-    >>> pf.plot.freq(y_sum, color='k', ax=ax[1])
-    >>> pf.plot.freq(y, ax=ax[1])
-    >>> ax[1].set_title("Reconstructed (black) and filtered impulse (colored)")
-    >>>
-    >>> plt.tight_layout(h_pad=.6)
 
     .. plot::
 

--- a/pyfar/dsp/filter.py
+++ b/pyfar/dsp/filter.py
@@ -905,16 +905,21 @@ def fractional_octave_bands(
 
     .. plot::
 
-        import pyfar as pf
-        import numpy as np
-
-        x = pf.signals.impulse(2**17)
-        y = pf.dsp.filter.fractional_octave_bands(x, 1, freq_range=(20, 8e3))
-        y_sum = pf.FrequencyData(np.sum(np.abs(y.freq)**2, 0), y.frequencies)
-
-        pf.plot.freq(y)
-        ax = pf.plot.freq(y_sum, color='k', log_prefix=10, linestyle='--')
-        ax.set_title("Filter bands and the sum of their squared magnitudes")
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> # generate the data
+        >>> x = pf.signals.impulse(2**17)
+        >>> y = pf.dsp.filter.fractional_octave_bands(
+        ...     x, 1, freq_range=(20, 8e3))
+        >>> # frequency domain plot
+        >>> y_sum = pf.FrequencyData(
+        ...     np.sum(np.abs(y.freq)**2, 0), y.frequencies)
+        >>> pf.plot.freq(y)
+        >>> ax = pf.plot.freq(y_sum, color='k', log_prefix=10, linestyle='--')
+        >>> ax.set_title(
+        ...     "Filter bands and the sum of their squared magnitudes")
+        >>> plt.tight_layout()
 
     """
     # check input
@@ -1083,24 +1088,24 @@ def reconstructing_fractional_octave_bands(
 
     .. plot::
 
-        import pyfar as pf
-        import numpy as np
-        import matplotlib.pyplot as plt
-
-        x = pf.signals.impulse(2**12)
-        y, f = pf.dsp.filter.reconstructing_fractional_octave_bands(x)
-        y_sum = pf.Signal(np.sum(y.time, 0), y.sampling_rate)
-
-        ax = pf.plot.time_freq(y_sum, color='k')
-        pf.plot.time(x, ax=ax[0])
-        ax[0].set_xlim(-5, 2**12/44100 * 1e3 + 5)
-        ax[0].set_title("Original (blue) and reconstructed pulse (black)")
-
-        pf.plot.freq(y_sum, color='k', ax=ax[1])
-        pf.plot.freq(y, ax=ax[1])
-        ax[1].set_title("Reconstructed (black) and filtered impulse (colored)")
-
-        plt.tight_layout(h_pad=.6)
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> import matplotlib.pyplot as plt
+        >>> # generate data
+        >>> x = pf.signals.impulse(2**12)
+        >>> y, f = pf.dsp.filter.reconstructing_fractional_octave_bands(x)
+        >>> y_sum = pf.Signal(np.sum(y.time, 0), y.sampling_rate)
+        >>> # time domain plot
+        >>> ax = pf.plot.time_freq(y_sum, color='k')
+        >>> pf.plot.time(x, ax=ax[0])
+        >>> ax[0].set_xlim(-5, 2**12/44100 * 1e3 + 5)
+        >>> ax[0].set_title("Original (blue) and reconstructed pulse (black)")
+        >>> # frequency domain plot
+        >>> pf.plot.freq(y_sum, color='k', ax=ax[1])
+        >>> pf.plot.freq(y, ax=ax[1])
+        >>> ax[1].set_title(
+        ...     "Reconstructed (black) and filtered impulse (colored)")
+        >>> plt.tight_layout()
     """
 
     # check input

--- a/pyfar/plot/__init__.py
+++ b/pyfar/plot/__init__.py
@@ -15,11 +15,10 @@ This is an example for customizing the line color and axis limits:
 
 .. plot::
 
-    import pyfar as pf
-
-    noise = pf.signals.noise(2**14)
-    ax = pf.plot.freq(noise, color=(.3, .3, .3))
-    ax.set_ylim(-60, -20)
+    >>> import pyfar as pf
+    >>> noise = pf.signals.noise(2**14)
+    >>> ax = pf.plot.freq(noise, color=(.3, .3, .3))
+    >>> ax.set_ylim(-60, -20)
 """
 
 from .line import (

--- a/pyfar/plot/__init__.py
+++ b/pyfar/plot/__init__.py
@@ -15,10 +15,10 @@ This is an example for customizing the line color and axis limits:
 
 .. plot::
 
-    import pyfar
+    import pyfar as pf
 
-    noise = pyfar.signals.noise(2**14)
-    ax = pyfar.plot.freq(noise, color=(.3, .3, .3))
+    noise = pf.signals.noise(2**14)
+    ax = pf.plot.freq(noise, color=(.3, .3, .3))
     ax.set_ylim(-60, -20)
 """
 

--- a/pyfar/plot/__init__.py
+++ b/pyfar/plot/__init__.py
@@ -13,12 +13,6 @@ of plots. In addition most plot functions pass keyword arguments to Matplotlib.
 
 This is an example for customizing the line color and axis limits:
 
->>> import pyfar
->>>
->>> noise = pyfar.signals.noise(2**14)
->>> ax = pyfar.plot.freq(noise, color=(.3, .3, .3))
->>> ax.set_ylim(-60, -20)
-
 .. plot::
 
     import pyfar

--- a/pyfar/plot/_interaction.py
+++ b/pyfar/plot/_interaction.py
@@ -34,13 +34,13 @@ Debugging is a bit tricky because you do not see errors in the terminal. It can
 be done this way
 
 >>> # %% plot something
->>> import pyfar
+>>> import pyfar as pf
 >>> import numpy as np
 >>> from pyfar.plot._interaction import EventEmu as EventEmu
 >>> %matplotlib qt
 >>>
->>> sig = pyfar.Signal(np.random.normal(0, 1, 2**16), 48e3)
->>> ax = pyfar.plot.time(sig)
+>>> sig = pf.Signal(np.random.normal(0, 1, 2**16), 48e3)
+>>> ax = pf.plot.time(sig)
 >>>
 >>> # %% debug this cell
 >>> # EventEmu can be used to simulate pressing a key

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -48,16 +48,11 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit=None, ax=None,
     Examples
     --------
 
-    >>> import pyfar
-    >>>
-    >>> sine = pyfar.signals.sine(100, 4410)
-    >>> pyfar.plot.time(sine)
-
     .. plot::
 
-        import pyfar
-        sine = pyfar.signals.sine(100, 4410)
-        pyfar.plot.time(sine)
+        import pyfar as pf
+        sine = pf.signals.sine(100, 4410)
+        pf.plot.time(sine)
     """
 
     with context(style):
@@ -117,16 +112,11 @@ def freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
     Example
     -------
 
-    >>> import pyfar
-    >>>
-    >>> sine = pyfar.signals.sine(100, 4410)
-    >>> pyfar.plot.freq(sine)
-
     .. plot::
 
-        import pyfar
-        sine = pyfar.signals.sine(100, 4410)
-        pyfar.plot.freq(sine)
+        import pyfar as pf
+        sine = pf.signals.sine(100, 4410)
+        pf.plot.freq(sine)
     """
 
     with context(style):
@@ -181,16 +171,11 @@ def phase(signal, deg=False, unwrap=False, xscale='log', ax=None,
     Example
     -------
 
-    >>> import pyfar
-    >>>
-    >>> impulse = pyfar.signals.impulse(100, 10)
-    >>> pyfar.plot.phase(impulse, unwrap=True)
-
     .. plot::
 
-        import pyfar
-        impulse = pyfar.signals.impulse(100, 10)
-        pyfar.plot.phase(impulse, unwrap=True)
+        import pyfar as pf
+        impulse = pf.signals.impulse(100, 10)
+        pf.plot.phase(impulse, unwrap=True)
     """
 
     with context(style):
@@ -240,16 +225,11 @@ def group_delay(signal, unit=None, xscale='log', ax=None, style='light',
     Examples
     --------
 
-    >>> import pyfar
-    >>>
-    >>> impulse = pyfar.signals.impulse(100, 10)
-    >>> pyfar.plot.group_delay(impulse, unit='samples')
-
     .. plot::
 
-        import pyfar
-        impulse = pyfar.signals.impulse(100, 10)
-        pyfar.plot.group_delay(impulse, unit='samples')
+        import pyfar as pf
+        impulse = pf.signals.impulse(100, 10)
+        pf.plot.group_delay(impulse, unit='samples')
     """
 
     with context(style):
@@ -319,16 +299,11 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
     Example
     -------
 
-    >>> import pyfar
-    >>>
-    >>> sweep = pyfar.signals.linear_sweep(2**14, [0, 22050])
-    >>> pyfar.plot.spectrogram(sweep)
-
     .. plot::
 
-        import pyfar
-        sweep = pyfar.signals.linear_sweep(2**14, [0, 22050])
-        pyfar.plot.spectrogram(sweep)
+        import pyfar as pf
+        sweep = pf.signals.linear_sweep(2**14, [0, 22050])
+        pf.plot.spectrogram(sweep)
     """
     if not isinstance(signal, Signal):
         raise TypeError('Input data has to be of type: Signal.')
@@ -401,16 +376,11 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
     Examples
     --------
 
-    >>> import pyfar
-    >>>
-    >>> sine = pyfar.signals.sine(100, 4410)
-    >>> pyfar.plot.time_freq(sine)
-
     .. plot::
 
-        import pyfar
-        sine = pyfar.signals.sine(100, 4410)
-        pyfar.plot.time_freq(sine)
+        import pyfar as pf
+        sine = pf.signals.sine(100, 4410)
+        pf.plot.time_freq(sine)
     """
 
     with context(style):
@@ -534,16 +504,11 @@ def freq_group_delay(signal, dB=True, log_prefix=20, log_reference=1,
     Examples
     --------
 
-    >>> import pyfar
-    >>>
-    >>> impulse = pyfar.signals.impulse(100, 10)
-    >>> pyfar.plot.freq_group_delay(impulse, unit='samples')
-
     .. plot::
 
-        import pyfar
-        impulse = pyfar.signals.impulse(100, 10)
-        pyfar.plot.freq_group_delay(impulse, unit='samples')
+        import pyfar as pf
+        impulse = pf.signals.impulse(100, 10)
+        pf.plot.freq_group_delay(impulse, unit='samples')
     """
 
     with context(style):
@@ -595,20 +560,13 @@ def custom_subplots(signal, plots, ax=None, style='light', **kwargs):
 
     Generate a two by two subplot layout
 
-    >>> import pyfar
-    >>>
-    >>> impulse = pyfar.signals.impulse(100, 10)
-    >>> plots = [[pyfar.plot.time, pyfar.plot.phase],
-    ...          [pyfar.plot.freq, pyfar.plot.group_delay]]
-    >>> pyfar.plot.custom_subplots(impulse, plots)
-
     .. plot::
 
-        import pyfar
-        impulse = pyfar.signals.impulse(100, 10)
-        plots = [[pyfar.plot.time, pyfar.plot.phase],
-                 [pyfar.plot.freq, pyfar.plot.group_delay]]
-        pyfar.plot.custom_subplots(impulse, plots)
+        import pyfar as pf
+        impulse = pf.signals.impulse(100, 10)
+        plots = [[pf.plot.time, pf.plot.phase],
+                 [pf.plot.freq, pf.plot.group_delay]]
+        pf.plot.custom_subplots(impulse, plots)
 
     """
 

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -50,9 +50,10 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit=None, ax=None,
 
     .. plot::
 
-        import pyfar as pf
-        sine = pf.signals.sine(100, 4410)
-        pf.plot.time(sine)
+        >>> import pyfar as pf
+        >>> sine = pf.signals.sine(100, 4410)
+        >>> pf.plot.time(sine)
+
     """
 
     with context(style):
@@ -114,9 +115,9 @@ def freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
 
     .. plot::
 
-        import pyfar as pf
-        sine = pf.signals.sine(100, 4410)
-        pf.plot.freq(sine)
+        >>> import pyfar as pf
+        >>> sine = pf.signals.sine(100, 4410)
+        >>> pf.plot.freq(sine)
     """
 
     with context(style):
@@ -173,9 +174,9 @@ def phase(signal, deg=False, unwrap=False, xscale='log', ax=None,
 
     .. plot::
 
-        import pyfar as pf
-        impulse = pf.signals.impulse(100, 10)
-        pf.plot.phase(impulse, unwrap=True)
+        >>> import pyfar as pf
+        >>> impulse = pf.signals.impulse(100, 10)
+        >>> pf.plot.phase(impulse, unwrap=True)
     """
 
     with context(style):
@@ -227,9 +228,9 @@ def group_delay(signal, unit=None, xscale='log', ax=None, style='light',
 
     .. plot::
 
-        import pyfar as pf
-        impulse = pf.signals.impulse(100, 10)
-        pf.plot.group_delay(impulse, unit='samples')
+        >>> import pyfar as pf
+        >>> impulse = pf.signals.impulse(100, 10)
+        >>> pf.plot.group_delay(impulse, unit='samples')
     """
 
     with context(style):
@@ -301,9 +302,9 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
 
     .. plot::
 
-        import pyfar as pf
-        sweep = pf.signals.linear_sweep(2**14, [0, 22050])
-        pf.plot.spectrogram(sweep)
+        >>> import pyfar as pf
+        >>> sweep = pf.signals.linear_sweep(2**14, [0, 22050])
+        >>> pf.plot.spectrogram(sweep)
     """
     if not isinstance(signal, Signal):
         raise TypeError('Input data has to be of type: Signal.')
@@ -378,9 +379,9 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
 
     .. plot::
 
-        import pyfar as pf
-        sine = pf.signals.sine(100, 4410)
-        pf.plot.time_freq(sine)
+        >>> import pyfar as pf
+        >>> sine = pf.signals.sine(100, 4410)
+        >>> pf.plot.time_freq(sine)
     """
 
     with context(style):
@@ -506,9 +507,9 @@ def freq_group_delay(signal, dB=True, log_prefix=20, log_reference=1,
 
     .. plot::
 
-        import pyfar as pf
-        impulse = pf.signals.impulse(100, 10)
-        pf.plot.freq_group_delay(impulse, unit='samples')
+        >>> import pyfar as pf
+        >>> impulse = pf.signals.impulse(100, 10)
+        >>> pf.plot.freq_group_delay(impulse, unit='samples')
     """
 
     with context(style):
@@ -562,11 +563,11 @@ def custom_subplots(signal, plots, ax=None, style='light', **kwargs):
 
     .. plot::
 
-        import pyfar as pf
-        impulse = pf.signals.impulse(100, 10)
-        plots = [[pf.plot.time, pf.plot.phase],
-                 [pf.plot.freq, pf.plot.group_delay]]
-        pf.plot.custom_subplots(impulse, plots)
+        >>> import pyfar as pf
+        >>> impulse = pf.signals.impulse(100, 10)
+        >>> plots = [[pf.plot.time, pf.plot.phase],
+        ...          [pf.plot.freq, pf.plot.group_delay]]
+        >>> pf.plot.custom_subplots(impulse, plots)
 
     """
 

--- a/pyfar/plot/utils.py
+++ b/pyfar/plot/utils.py
@@ -81,7 +81,7 @@ def context(style='light', after_reset=False):
     >>>
     >>> with pf.plot.context():
     >>>     fig, ax = plt.subplots(2, 1)
-    >>>     pf.plot.time(pyfar.Signal([0, 1, 0, -1], 44100), ax=ax[0])
+    >>>     pf.plot.time(pf.Signal([0, 1, 0, -1], 44100), ax=ax[0])
     """
 
     # get pyfar plotstyle if desired

--- a/pyfar/plot/utils.py
+++ b/pyfar/plot/utils.py
@@ -78,7 +78,6 @@ def context(style='light', after_reset=False):
 
     >>> import pyfar as pf
     >>> import matplotlib.pyplot as plt
-    >>>
     >>> with pf.plot.context():
     >>>     fig, ax = plt.subplots(2, 1)
     >>>     pf.plot.time(pf.Signal([0, 1, 0, -1], 44100), ax=ax[0])
@@ -135,7 +134,6 @@ def use(style="light"):
 
     >>> import pyfar as pf
     >>> import matplotlib.pyplot as plt
-    >>>
     >>> pf.plot.utils.use()
     >>> fig, ax = plt.subplots(2, 1)
     >>> pf.plot.time(pf.Signal([0, 1, 0, -1], 44100), ax=ax[0])

--- a/pyfar/plot/utils.py
+++ b/pyfar/plot/utils.py
@@ -76,12 +76,12 @@ def context(style='light', after_reset=False):
 
     Generate customizable subplots with the default pyfar plot style
 
-    >>> import pyfar
+    >>> import pyfar as pf
     >>> import matplotlib.pyplot as plt
     >>>
-    >>> with pyfar.plot.context():
+    >>> with pf.plot.context():
     >>>     fig, ax = plt.subplots(2, 1)
-    >>>     pyfar.plot.time(pyfar.Signal([0, 1, 0, -1], 44100), ax=ax[0])
+    >>>     pf.plot.time(pyfar.Signal([0, 1, 0, -1], 44100), ax=ax[0])
     """
 
     # get pyfar plotstyle if desired
@@ -133,12 +133,12 @@ def use(style="light"):
 
     Permanently use the pyfar default plot style
 
-    >>> import pyfar
+    >>> import pyfar as pf
     >>> import matplotlib.pyplot as plt
     >>>
-    >>> pyfar.plot.utils.use()
+    >>> pf.plot.utils.use()
     >>> fig, ax = plt.subplots(2, 1)
-    >>> pyfar.plot.time(pyfar.Signal([0, 1, 0, -1], 44100), ax=ax[0])
+    >>> pf.plot.time(pf.Signal([0, 1, 0, -1], 44100), ax=ax[0])
 
     """
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #179

### Changes proposed in this pull request:

- add option to include code from plots in the docstrings and removed redundant code (see #179)
- unified import of pyfar in the docstring examples to `import pyfar as pf`
