### PR TITLE
Rename and deprecate get_nearest* methods of Coordinates class

### DIFF
--- a/examples/pyfar_demo.ipynb
+++ b/examples/pyfar_demo.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
    "source": [
     "# Welcome\n",
     "\n",
@@ -46,10 +47,10 @@
     "\n",
     "Lets start with importing pyfar and numpy:"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "# Getting started<a class=\"anchor\" id=\"getting_started\"></a>\n",
     "\n",
@@ -59,10 +60,11 @@
     "\n",
     "After this go to your Python editor of choice and import pyfar"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
    "source": [
     "# import packages\n",
     "import pyfar\n",
@@ -71,12 +73,11 @@
     "from pyfar import Orientations  # managing orientation vectors\n",
     "import numpy as np"
    ],
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "# Handling audio data<a class=\"anchor\" id=\"handling_audio_data\"></a>\n",
     "\n",
@@ -86,14 +87,11 @@
     "\n",
     "`Signals` are stored along with information about the sampling rate, the domain (`time`, or `freq`), the FFT type and an optional comment. Lets go ahead and create a single channel signal:"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# create a dirac signal with a sampling rate of 44.1 kHz\n",
     "fs = 44100\n",
@@ -103,74 +101,77 @@
     "\n",
     "# show information\n",
     "x_energy"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## FFT Normalization<a class=\"anchor\" id=\"fft_normalization\"></a>\n",
     "\n",
     "Different FFT normalization are available that scale the spectrum of a Signal. Pyfar knows six normalizations: `'amplitude'`, `'rms'`, `'power'`, and `'psd'` from [Ahrens, et al. 2020](http://www.aes.org/e-lib/browse.cfm?elib=20838), `'unitary'` (only applies weights for single sided spectra as in Eq. 8 in [Ahrens, et al. 2020](http://www.aes.org/e-lib/browse.cfm?elib=20838)), and `'none'` (applies no normalization). The default normalization is `'none'`, which is usefull for **energy signals**, i.e., signals with finite energy such as impulse responses. The other FFT normalizations are intended for **power signals**, i.e., samples of signals with infinite energy, such as noise or sine signals. Let's create a signal with a different normalization"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x = np.sin(2 * np.pi * 1000 * np.arange(441) / fs)\n",
     "x_power = Signal(x, fs, fft_norm='rms')\n",
     "x_power"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "The normalization can be changed. In this case the spectral data of the signal is converted internally using `pyfar.fft.normalization()`"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x_power.fft_norm = 'amplitude'\n",
     "x_power"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Energy and power signals<a class=\"energy_and_power_signals\" id=\"signals\"></a>\n",
     "\n",
     "You might have realized that pyfar distinguishes between energy and power signals, which is required for some operations. Signals with the FFT normalization `'none'` are considered as energy signals while all other FFT normalizations result in power signals."
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Accessing Signal data<a class=\"accessing_signal_data\" id=\"signals\"></a>\n",
     "\n",
     "You can access the data, i.e., the audio signal, inside a Signal object in the time and frequency domain by simply using"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "time_data = x_power.time\n",
     "freq_data = x_power.freq"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "Two things are important here:\n",
     "\n",
@@ -178,21 +179,18 @@
     "\n",
     "2. The frequency data of signals depends on the Signal's `fft_norm`."
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "`Signals` and some other pyfar objects support slicing. Let's illustrate that for a two channel signal"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# generate two channel time data\n",
     "time = np.zeros((2, 4))\n",
@@ -201,61 +199,61 @@
     "\n",
     "x_two_channels = Signal(time, 44100)\n",
     "x_first_channel = x_two_channels[0]"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "`x_first_channel` is a `Signal` object itself, which contains the first channel of `x_two_channels`:"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x_first_channel.time"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "A third option to access `Signals` is to copy it"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x_copy = x_two_channels.copy()"
-   ]
-  },
-  {
-   "source": [
-    "It is important to note that his return an independent copy of `x_two_channels`. Note that `x_copy = x_two_channels` might not be wanted. In this case changes to `x_copy` will also change `x_two_channels`. The `copy()` operation is available for all pyfar object."
    ],
-   "cell_type": "markdown",
+   "outputs": [],
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "It is important to note that his return an independent copy of `x_two_channels`. Note that `x_copy = x_two_channels` might not be wanted. In this case changes to `x_copy` will also change `x_two_channels`. The `copy()` operation is available for all pyfar object."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "## Iterating Signals<a class=\"signal_meta_data\" id=\"accessing_signal_data\"></a>\n",
     "\n",
     "It is the aim of pyfar that all operations work on N-dimensional `signals`. Nevertheless, you can also iterate `signals` if you need to apply operations depending on the channel. Lets look at a simple example"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "signal = Signal([[0, 0, 0], [1, 1, 1]], 44100)  # 2-channel signal\n",
     "\n",
@@ -269,16 +267,19 @@
     "\n",
     "# q.e.d.\n",
     "print(f\"\\nNew signal time data:\\n{signal.time}\")"
-   ]
-  },
-  {
-   "source": [
-    "`Signal` uses the standard `numpy` iterator which always iterates the first dimension. In case of a 2-D array as in the example above these are the channels."
    ],
-   "cell_type": "markdown",
+   "outputs": [],
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "`Signal` uses the standard `numpy` iterator which always iterates the first dimension. In case of a 2-D array as in the example above these are the channels."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "## Signal meta data<a class=\"signal_meta_data\" id=\"signals\"></a>\n",
     "\n",
@@ -290,100 +291,100 @@
     "- `Signal.freqs`: The frequencies of `Signal.freq` in Hz\n",
     "- `Signal.comment`: A comment for documenting the signal content\n"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Arithmetic operations<a class=\"arithmetic_operations\" id=\"signals\"></a>\n",
     "\n",
     "The arithmetic operations `add`, `subtract`, `multiply`, `divide`, and `power` are available for `Signal` (time or frequency domain operations) as well as for `TimeData` and `FrequencyData`. The operations work on arbitrary numbers of Signals and array likes. Lets check out simple examples"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
    "source": [
     "# add two signals energy signals\n",
     "x_sum = pyfar.classes.audio.add((x_energy, x_energy), 'time')\n",
     "x_sum.time\n",
     "\n"
    ],
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "In this case, `x_sum` is also an energy Signal. However, if any power Signal is involved in an arithmetic operation, the result will be a power Signal. The FFT normalization of the result is obtained from the first (power) Signal in the input data. You can also apply arithmetic operations on a `Signal` and a vector. Under the hood, the operations use numpy's [array broadcasting](https://numpy.org/doc/stable/user/basics.broadcasting.html?highlight=broadcast#module-numpy.doc.broadcasting). This means you can add scalars, vectors, and matrixes to a signal. Lets have a frequency domain example for this"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x_sum = pyfar.classes.audio.add((x_energy, 1), 'freq')\n",
     "x_sum.time"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "The Python operators `+`, `-`, `*`, `/`, and `**` are overloaded with the **frequency domain** arithmetic functions for `Signal` and `FrequencyData`. For `TimeData` they correspond to time domain operations. Thus, the example above can also be shortened to"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "x_sum = x_energy + 1\n",
+    "x_sum = x_energy + 1\r\n",
     "x_sum.time"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Plotting<a class=\"anchor\" id=\"plotting\"></a>\n",
     "\n",
     "Inspecting signals can be done with the `pyfar.plot` module, which uses common plot functions based on `Matplotlib`. For example a plot of the magnitude spectrum"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "pyfar.plot.freq(x_power)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "We set the FFT normalization to 'amplitude' before. The plot thus shows the Amplitude (1, or 0 dB) of our sine wave contained in `x_power`. We can also plot the RMS ($1/\\sqrt(2)$, or $\\approx-3$ dB)"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "x_power.fft_norm = 'rms'\n",
+    "x_power.fft_norm = 'rms'\r\n",
     "pyfar.plot.line.freq(x_power)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "### Interactive plots<a class=\"anchor\" id=\"#interactive_plots\"></a>\n",
     "\n",
@@ -397,177 +398,177 @@
     "\n",
     "in your code. These are the available keyboard short cuts"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "shortcuts = pyfar.plot.shortcuts()"
-   ]
-  },
-  {
-   "source": [
-    "Note that additional controls are available through Matplotlib's [interactive navigation](https://matplotlib.org/3.1.1/users/navigation_toolbar.html)."
    ],
-   "cell_type": "markdown",
+   "outputs": [],
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "Note that additional controls are available through Matplotlib's [interactive navigation](https://matplotlib.org/3.1.1/users/navigation_toolbar.html)."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "### Manipulating plots<a class=\"anchor\" id=\"#manipulating_plots\"></a>\n",
     "\n",
     "In many cases, the layout of the plot should be adjusted, which can be done using Matplotlib and the axes handle that is returned by all plot functions. For example, the range of the x-axis can be changed."
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "ax = pyfar.plot.time(x_power)\n",
+    "ax = pyfar.plot.time(x_power)\r\n",
     "ax.set_xlim(0, 2)"
-   ]
-  },
-  {
-   "source": [
-    "Note: For an easy use of the pyfar plotstyle (available as 'light' and 'dark' theme) wrappers for Matplotlib's `use` and `context` are available as `pyfar.plot.use` and `pyfar.plot.context`."
    ],
-   "cell_type": "markdown",
+   "outputs": [],
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "Note: For an easy use of the pyfar plotstyle (available as 'light' and 'dark' theme) wrappers for Matplotlib's `use` and `context` are available as `pyfar.plot.use` and `pyfar.plot.context`."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "# Coordinates<a class=\"anchor\" id=\"coordinates\"></a>\n",
     "\n",
     "The `Coordinates()` class is designed for storing, manipulating, and accessing coordinate points. It supports a large variety of different coordinate conventions and the conversion between them. Examples for data that can be stored are microphone positions of a spherical microphone array and loudspeaker positions of a sound field synthesis system. Lets create an empty `Coordinates` object and look at the implemented conventions first:"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "c = Coordinates()\n",
+    "c = Coordinates()\r\n",
     "c.systems()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Entering coordinate points<a class=\"anchor\" id=\"coordinates_enter\"></a>\n",
     "\n",
     "Coordinate points can be entered manually or by using one of the available sampling schemes contained in `pyfar.samplings`. We will do the latter using an equal angle sampling and look at the information provided by the coordinates object:"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "c = pyfar.samplings.sph_equal_angle((20, 10))\n",
-    "# show general information\n",
-    "print(c)\n",
-    "# plot the sampling points\n",
+    "c = pyfar.samplings.sph_equal_angle((20, 10))\r\n",
+    "# show general information\r\n",
+    "print(c)\r\n",
+    "# plot the sampling points\r\n",
     "c.show()"
-   ]
-  },
-  {
-   "source": [
-    "Inside the `Coordinates` object, the points are stored in an N-dimensional array of size `[..., 3]` where - in this case - the last dimension holds the azimuth, colatitude, and radius. Information about coordinate array can be obtained by `c.cshape`, `c.csize`, and `c.cdim`. These properties are similar to numpy's `shape`, `size`, and `dim` but ignore the last dimension, which is always 3."
    ],
-   "cell_type": "markdown",
+   "outputs": [],
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "Inside the `Coordinates` object, the points are stored in an N-dimensional array of size `[..., 3]` where - in this case - the last dimension holds the azimuth, colatitude, and radius. Information about coordinate array can be obtained by `c.cshape`, `c.csize`, and `c.cdim`. These properties are similar to numpy's `shape`, `size`, and `dim` but ignore the last dimension, which is always 3."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "## Retrieving coordinate points<a class=\"anchor\" id=\"coordinates_retrieve\"></a>\n",
     "\n",
     "There are different ways to retrieve points from a `Coordinates` object. All points can be obtained in cartesian, spherical, and cylindrical coordinates using the getter functions `c.get_cart()`, `c.get_sph()` and `c.get_cyl()`, e.g.:"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "cartesian_coordinates = c.get_cart()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "Different methods are available for obtaining a specific subset of coordinates. For example the nearest point(s) can be obtained by"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "c_out = c.get_nearest_k(\n",
+    "c_out = c.find_nearest_k(\r\n",
     "    270, 90, 1, k=1, domain='sph', convention='top_colat', unit='deg', show=True)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
-   "source": [
-    "To obtain all points within a specified euclidean distance or arc distance, you can use `c.get_nearest_cart()` and `c.get_nearest_sph()`. To obtain more complicated subsets of any coordinate, e.g., the horizontal plane with `colatitude=90` degree, you can use"
-   ],
    "cell_type": "markdown",
+   "source": [
+    "To obtain all points within a specified euclidean distance or arc distance, you can use `c.find_nearest_cart()` and `c.find_nearest_sph()`. To obtain more complicated subsets of any coordinate, e.g., the horizontal plane with `colatitude=90` degree, you can use"
+   ],
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "mask_hor = c.get_slice('colatitude', 'deg', 90, show=True)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Rotating coordinates<a class=\"anchor\" id=\"coordinates_rotate\"></a>\n",
     "\n",
     "You can apply rotations using quaternions, rotation vectors/matrixes and euler angles with  `c.rotate()`, which is a wrapper for `scipy.spatial.transform.Rotation`. For example rotating around the y-axis by 45 degrees can be done with"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "c.rotate('y', 45)\n",
+    "c.rotate('y', 45)\r\n",
     "c.show()"
-   ]
-  },
-  {
-   "source": [
-    "Note that this changes the points inside the `Coordinates` object, which means that you have to be carefull not to apply the rotation multiple times, i.e., when evaluationg cells during debugging."
    ],
-   "cell_type": "markdown",
+   "outputs": [],
    "metadata": {}
   },
   {
+   "cell_type": "markdown",
+   "source": [
+    "Note that this changes the points inside the `Coordinates` object, which means that you have to be carefull not to apply the rotation multiple times, i.e., when evaluationg cells during debugging."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
    "source": [
     "# Orientations<a class=\"anchor\" id=\"orientations\"></a>\n",
     "\n",
@@ -577,14 +578,11 @@
     "\n",
     "Lets go ahead and create an object and show the result"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "views = [[0,  1, 0],\n",
     "         [1,  0, 0],\n",
@@ -592,86 +590,89 @@
     "up = [0, 0, 1]\n",
     "orientations = Orientations.from_view_up(views, up)\n",
     "orientations.show(show_rights=False)\n"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "It is also possible to enter `Orientations` from `Coordinates` object or mixtures of `Coordinates` objects and array likes. This is equivalent to the example above"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "views_c = Coordinates([90, 0, 270], 0, 1,\n",
     "                      domain='sph', convention='top_elev', unit='deg')\n",
     "\n",
     "orientations = Orientations.from_view_up(views_c, up)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Retrieving orientations<a class=\"anchor\" id=\"retrieving_orientations\"></a>\n",
     "\n",
     "Orientaions can be retrieved as view, up, and right-vectors and in any format supported by `scipy.spatial.transform.Rotation`. They can also be converted into any coordinate convention supported by pyfar by putting them into a `Coordinates` object. Lets only check out one way for now "
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "views, ups, right, = orientations.as_view_up_right()\n",
     "views"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "## Rotating orientations<a class=\"anchor\" id=\"rotating_orientations\"></a>\n",
     "\n",
     "Rotations can be done using the methods inherited from `scipy.spatial.transform.Rotation`. You can for example rotate around the y-axis this way"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
    "source": [
     "rotation = Orientations.from_euler('y', 30, degrees=True)\n",
     "orientations_rot = orientations * rotation\n",
     "orientations_rot.show(show_rights=False)"
    ],
-   "cell_type": "code",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "# Signals<a class=\"signals\" id=\"dsp\"></a>\n",
     "\n",
     "The `pyfar.signals` module contains a variety of common audio signals including sine signals, sweeps, noise and pulsed noise. For brevity, lets have only one example\n"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "sweep = pyfar.signals.exponential_sweep_time(2**12, [100, 22050])\n",
     "pyfar.plot.time_freq(sweep)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "# DSP<a class=\"dsp\" id=\"dsp\"></a>\n",
     "\n",
@@ -693,20 +694,20 @@
     "\n",
     "They can all be assessed in a similar manner, like this one\n"
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "x_filter = pyfar.dsp.filter.peq(x_energy, center_frequency=1e3, gain=10, quality=2)\n",
     "pyfar.plot.line.freq(x_filter)"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
+   "cell_type": "markdown",
    "source": [
     "# In'n'out<a class=\"in_and_out\" id=\"signals\"></a>\n",
     "\n",
@@ -738,15 +739,14 @@
     "\n",
     "`read_sofa` is a wrapper for `python_sofa`, which can be used to write SOFA files or access more meta data contained in SOFA files."
    ],
-   "cell_type": "markdown",
    "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "source": [],
    "outputs": [],
-   "source": []
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -32,6 +32,7 @@ from scipy.spatial.transform import Rotation as sp_rot
 import deepdiff
 import re
 from copy import deepcopy
+import warnings
 
 import pyfar as pf
 
@@ -741,6 +742,66 @@ class Coordinates():
             colors = np.full(mask.shape, pf.plot.color('b'))
             colors[mask] = pf.plot.color('r')
             pf.plot.scatter(self, c=colors.flatten(), **kwargs)
+
+    def get_nearest_k(self, points_1, points_2, points_3, k=1,
+                      domain='cart', convention='right', unit='met',
+                      show=False):
+        """
+        This function will be deprecated in pyfar 0.5.0. See
+        :py:func:`~Coordinates.find_nearest_k`.
+
+        .. note::
+            This functions returns the parameters in the order `distance`,
+            `index`, `mask`, which is different in `find_nearest_k()`
+        """
+
+        warnings.warn((
+            "This function will be deprecated in pyfar 0.5.0 in favor "
+            "of Coordinates.find_nearest_k."),
+                  PendingDeprecationWarning)
+
+        index, mask, distance = self.find_nearest_k(
+            points_1, points_2, points_3, k, domain, convention, unit, show)
+
+        return distance, index, mask
+
+    def get_nearest_cart(self, points_1, points_2, points_3, distance,
+                         domain='cart', convention='right', unit='met',
+                         show=False, atol=1e-15):
+        """
+        This function will be deprecated in pyfar 0.5.0. See
+        :py:func:`~Coordinates.find_nearest_cart`.
+        """
+
+        warnings.warn((
+            "This function will be deprecated in pyfar 0.5.0 in favor "
+            "of Coordinates.find_nearest_cart."),
+                  PendingDeprecationWarning)
+
+        index, mask = self.find_nearest_cart(
+            points_1, points_2, points_3, distance, domain, convention, unit,
+            show, atol)
+
+        return index, mask
+
+    def get_nearest_sph(self, points_1, points_2, points_3, distance,
+                        domain='sph', convention='top_colat', unit='rad',
+                        show=False, atol=1e-15):
+        """
+        This function will be deprecated in pyfar 0.5.0. See
+        :py:func:`~Coordinates.find_nearest_sph`.
+        """
+
+        warnings.warn((
+            "This function will be deprecated in pyfar 0.5.0 in favor "
+            "of Coordinates.find_nearest_sph."),
+                  PendingDeprecationWarning)
+
+        index, mask = self.find_nearest_sph(
+            points_1, points_2, points_3, distance, domain, convention,
+            unit, show, atol)
+
+        return index, mask
 
     def find_nearest_k(self, points_1, points_2, points_3, k=1,
                        domain='cart', convention='right', unit='met',

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -464,106 +464,106 @@ def test_getitem():
     npt.assert_allclose(coords.get_cart()[0], np.array([0, 0, 0]))
 
 
-def test_get_nearest_k():
-    """Test returns of get_nearest_k"""
+def test_find_nearest_k():
+    """Test returns of find_nearest_k"""
     # 1D cartesian, nearest point
     x = np.arange(6)
     coords = Coordinates(x, 0, 0)
-    d, i, m = coords.get_nearest_k(1, 0, 0)
+    i, m, d = coords.find_nearest_k(1, 0, 0)
     assert d == 0.
     assert i == 1
     npt.assert_allclose(m, np.array([0, 1, 0, 0, 0, 0]))
 
     # 1D spherical, nearest point
-    d, i, m = coords.get_nearest_k(0, 0, 1, 1, 'sph', 'top_elev', 'deg')
+    i, m, d = coords.find_nearest_k(0, 0, 1, 1, 'sph', 'top_elev', 'deg')
     assert d == 0.
     assert i == 1
     npt.assert_allclose(m, np.array([0, 1, 0, 0, 0, 0]))
 
     # 1D cartesian, two nearest points
-    d, i, m = coords.get_nearest_k(1.2, 0, 0, 2)
+    i, m, d = coords.find_nearest_k(1.2, 0, 0, 2)
     npt.assert_allclose(d, [.2, .8], atol=1e-15)
     npt.assert_allclose(i, np.array([1, 2]))
     npt.assert_allclose(m, np.array([0, 1, 1, 0, 0, 0]))
 
     # 1D cartesian query two points
-    d, i, m = coords.get_nearest_k([1, 2], 0, 0)
+    i, m, d = coords.find_nearest_k([1, 2], 0, 0)
     npt.assert_allclose(d, [0, 0], atol=1e-15)
     npt.assert_allclose(i, [1, 2])
     npt.assert_allclose(m, np.array([0, 1, 1, 0, 0, 0]))
 
     # 2D cartesian, nearest point
     coords = Coordinates(x.reshape(2, 3), 0, 0)
-    d, i, m = coords.get_nearest_k(1, 0, 0)
+    i, m, d = coords.find_nearest_k(1, 0, 0)
     assert d == 0.
     assert i == 1
     npt.assert_allclose(m, np.array([[0, 1, 0], [0, 0, 0]]))
 
     # test with plot
     coords = Coordinates(x, 0, 0)
-    coords.get_nearest_k(1, 0, 0, show=True)
+    coords.find_nearest_k(1, 0, 0, show=True)
 
     # test object with a single point
     coords = Coordinates(1, 0, 0)
-    coords.get_nearest_k(1, 0, 0, show=True)
+    coords.find_nearest_k(1, 0, 0, show=True)
 
     # test out of range parameters
     with raises(AssertionError):
-        coords.get_nearest_k(1, 0, 0, -1)
+        coords.find_nearest_k(1, 0, 0, -1)
 
     plt.close("all")
 
 
-def test_get_nearest_cart():
-    """Tests returns of get_nearest_cart."""
-    # test only 1D case since most of the code from self.get_nearest_k is used
+def test_find_nearest_cart():
+    """Tests returns of find_nearest_cart."""
+    # test only 1D case since most of the code from self.find_nearest_k is used
     x = np.arange(6)
     coords = Coordinates(x, 0, 0)
-    i, m = coords.get_nearest_cart(2.5, 0, 0, 1.5)
+    i, m = coords.find_nearest_cart(2.5, 0, 0, 1.5)
     npt.assert_allclose(i, np.array([1, 2, 3, 4]))
     npt.assert_allclose(m, np.array([0, 1, 1, 1, 1, 0]))
 
     # test search with empty results
-    i, m = coords.get_nearest_cart(2.5, 0, 0, .1)
+    i, m = coords.find_nearest_cart(2.5, 0, 0, .1)
     assert len(i) == 0
     npt.assert_allclose(m, np.array([0, 0, 0, 0, 0, 0]))
 
     # test out of range parameters
     with raises(AssertionError):
-        coords.get_nearest_cart(1, 0, 0, -1)
+        coords.find_nearest_cart(1, 0, 0, -1)
 
 
-def test_get_nearest_sph():
-    """Tests returns of get_nearest_sph."""
-    # test only 1D case since most of the code from self.get_nearest_k is used
+def test_find_nearest_sph():
+    """Tests returns of find_nearest_sph."""
+    # test only 1D case since most of the code from self.find_nearest_k is used
     az = np.linspace(0, 40, 5)
     coords = Coordinates(az, 0, 1, 'sph', 'top_elev', 'deg')
-    i, m = coords.get_nearest_sph(25, 0, 1, 5, 'sph', 'top_elev', 'deg')
+    i, m = coords.find_nearest_sph(25, 0, 1, 5, 'sph', 'top_elev', 'deg')
     npt.assert_allclose(i, np.array([2, 3]))
     npt.assert_allclose(m, np.array([0, 0, 1, 1, 0]))
 
     # test search with empty results
-    i, m = coords.get_nearest_sph(25, 0, 1, 1, 'sph', 'top_elev', 'deg')
+    i, m = coords.find_nearest_sph(25, 0, 1, 1, 'sph', 'top_elev', 'deg')
     assert len(i) == 0
     npt.assert_allclose(m, np.array([0, 0, 0, 0, 0]))
 
     # test out of range parameters
     with raises(AssertionError):
-        coords.get_nearest_sph(1, 0, 0, -1)
+        coords.find_nearest_sph(1, 0, 0, -1)
     with raises(AssertionError):
-        coords.get_nearest_sph(1, 0, 0, 181)
+        coords.find_nearest_sph(1, 0, 0, 181)
 
     # test assertion for multiple radii
     coords = Coordinates([1, 2], 0, 0)
-    with raises(ValueError, match="get_nearest_sph only works if"):
-        coords.get_nearest_sph(0, 0, 1, 1)
+    with raises(ValueError, match="find_nearest_sph only works if"):
+        coords.find_nearest_sph(0, 0, 1, 1)
 
 
 def test_get_slice():
     """Test different queries for get slice."""
     # test only for self.cdim = 1.
     # self.get_slice uses KDTree, which is tested with N-dimensional arrays
-    # in test_get_nearest_k()
+    # in test_find_nearest_k()
 
     # cartesian grid
     d = np.linspace(-2, 2, 5)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -3,7 +3,9 @@ import numpy.testing as npt
 import pytest
 from pytest import raises
 import matplotlib.pyplot as plt
+from packaging import version
 
+import pyfar as pf
 from pyfar import Coordinates
 import pyfar.classes.coordinates as coordinates
 
@@ -557,6 +559,41 @@ def test_find_nearest_sph():
     coords = Coordinates([1, 2], 0, 0)
     with raises(ValueError, match="find_nearest_sph only works if"):
         coords.find_nearest_sph(0, 0, 1, 1)
+
+
+def test_get_nearest_deprecations():
+    coords = Coordinates(np.arange(6), 0, 0)
+
+    # nearest_k
+    with pytest.warns(PendingDeprecationWarning,
+                      match="This function will be deprecated"):
+        coords.get_nearest_k(1, 0, 0)
+
+    if version.parse(pf.__version__) >= version.parse('0.5.0'):
+        with pytest.raises(AttributeError):
+            # remove get_nearest_k() from pyfar 0.5.0!
+            coords.get_nearest_k(1, 0, 0)
+
+    # nearest_cart
+    with pytest.warns(PendingDeprecationWarning,
+                      match="This function will be deprecated"):
+        coords.get_nearest_cart(2.5, 0, 0, 1.5)
+
+    if version.parse(pf.__version__) >= version.parse('0.5.0'):
+        with pytest.raises(AttributeError):
+            # remove get_nearest_k() from pyfar 0.5.0!
+            coords.get_nearest_cart(2.5, 0, 0, 1.5)
+
+    # nearest_sph
+    coords = Coordinates([1, 0, -1, 0], [0, 1, 0, -1], 0)
+    with pytest.warns(PendingDeprecationWarning,
+                      match="This function will be deprecated"):
+        coords.get_nearest_sph(0, 0, 1, 1)
+
+    if version.parse(pf.__version__) >= version.parse('0.5.0'):
+        with pytest.raises(AttributeError):
+            # remove get_nearest_k() from pyfar 0.5.0!
+            coords.get_nearest_sph(0, 0, 1, 1)
 
 
 def test_get_slice():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #207 

### Changes proposed in this pull request:

- rename `get_nearest*` to `find_nearest*`
- change order of return parameters in `get_nearest_k` to be consistent with `get_nearest_cart` and `get_nearest_sph`
- add versions of `get_nearest*` functions that throw deprecation warnings
- test deprecation warnings
