### PR TITLE
Set required nbmake version

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 # Test examples notebook
 [testenv:examples]
 basepython = python
-deps = nbmake
+deps = nbmake>=0.7.0
 commands = pytest --nbmake examples/pyfar_demo.ipynb
 
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #213 

### Changes proposed in this pull request:

- require nbmake>=0.7.0
