### PR TITLE
Consistent arithmetics

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1032,6 +1032,8 @@ def _arithmetic(data: tuple, domain: str, operation: Callable):
     elif audio_type == TimeData:
         result = TimeData(result, times)
     elif audio_type == FrequencyData:
+        result = fft.normalization(result, n_samples, sampling_rate,
+                                   fft_norm)
         result = FrequencyData(result, frequencies, fft_norm)
 
     return result
@@ -1180,7 +1182,7 @@ def _get_arithmetic_data(data, n_samples, domain):
         elif domain == "freq":
             data_out = data.freq.copy()
 
-            if isinstance(data, Signal):
+            if isinstance(data, (Signal, FrequencyData)):
                 if data.fft_norm != 'none':
                     # remove current fft normalization
                     data_out = fft.normalization(


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Arithmetic operations handled FFT normalization differently for Signal and FrequencyData objects.

### Changes proposed in this pull request:

This pertains only frequency domain operations.
- For Signals, the FFT norm was removed before the operation
- For FrequencyData, the FFT norm was not removed before the operation

In any case, the result of an arithmetic operation has the FFT norm of the first Audio object that enters the arithmetic operation.

I think, removing the FFT norm before the operation is the only correct way that works for all operations and cases. The FFT norm that is applied after the operation is something that could be discussed. 

This is a draft, because I want to check the testing again. The changes I did not cause any error, which means testing was either wrong or incorrect.
