### PR TITLE
Hotfix/overloaded operators

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -372,17 +372,32 @@ class TimeData(_Audio):
     def __add__(self, data):
         return add((self, data), 'time')
 
+    def __radd__(self, data):
+        return add((data, self), 'time')
+
     def __sub__(self, data):
         return subtract((self, data), 'time')
+
+    def __rsub__(self, data):
+        return subtract((data, self), 'time')
 
     def __mul__(self, data):
         return multiply((self, data), 'time')
 
+    def __rmul__(self, data):
+        return multiply((data, self), 'time')
+
     def __truediv__(self, data):
         return divide((self, data), 'time')
 
+    def __rtruediv__(self, data):
+        return divide((data, self), 'time')
+
     def __pow__(self, data):
         return power((self, data), 'time')
+
+    def __rpow__(self, data):
+        return power((data, self), 'time')
 
 
 class FrequencyData(_Audio):
@@ -535,17 +550,32 @@ class FrequencyData(_Audio):
     def __add__(self, data):
         return add((self, data), 'freq')
 
+    def __radd__(self, data):
+        return add((data, self), 'freq')
+
     def __sub__(self, data):
         return subtract((self, data), 'freq')
+
+    def __rsub__(self, data):
+        return subtract((data, self), 'freq')
 
     def __mul__(self, data):
         return multiply((self, data), 'freq')
 
+    def __rmul__(self, data):
+        return multiply((data, self), 'freq')
+
     def __truediv__(self, data):
         return divide((self, data), 'freq')
 
+    def __rtruediv__(self, data):
+        return divide((data, self), 'freq')
+
     def __pow__(self, data):
         return power((self, data), 'freq')
+
+    def __rpow__(self, data):
+        return power((data, self), 'freq')
 
 
 class Signal(FrequencyData, TimeData):

--- a/tests/test_signal_arithmetic.py
+++ b/tests/test_signal_arithmetic.py
@@ -222,66 +222,102 @@ def test_power():
 
 
 def test_overloaded_operators_signal():
-    x = Signal([2, 1, 0], 44100, n_samples=5, domain='freq')
-    y = Signal([2, 2, 2], 44100, n_samples=5, domain='freq')
+    x = Signal([3, 2, 1], 44100, n_samples=5, domain='freq')
+    y_s = Signal([2, 2, 2], 44100, n_samples=5, domain='freq')
 
-    # addition
-    z = x + y
-    npt.assert_allclose(z.freq, np.array([4, 3, 2], ndmin=2), atol=1e-15)
-    # subtraction
-    z = x - y
-    npt.assert_allclose(z.freq, np.array([0, -1, -2], ndmin=2), atol=1e-15)
-    # multiplication
-    z = x * y
-    npt.assert_allclose(z.freq, np.array([4, 2, 0], ndmin=2), atol=1e-15)
-    # division
-    z = x / y
-    npt.assert_allclose(z.freq, np.array([1, .5, 0], ndmin=2), atol=1e-15)
-    # power
-    z = x**y
-    npt.assert_allclose(z.freq, np.array([4, 1, 0], ndmin=2), atol=1e-15)
+    for y in [y_s, 2]:
+        # addition
+        z = x + y
+        npt.assert_allclose(z.freq, np.array([5, 4, 3], ndmin=2), atol=1e-15)
+        z = y + x
+        npt.assert_allclose(z.freq, np.array([5, 4, 3], ndmin=2), atol=1e-15)
+        # subtraction
+        z = x - y
+        npt.assert_allclose(z.freq, np.array([1, 0, -1], ndmin=2), atol=1e-15)
+        z = y - x
+        npt.assert_allclose(z.freq, np.array([-1, 0, 1], ndmin=2), atol=1e-15)
+        # multiplication
+        z = x * y
+        npt.assert_allclose(z.freq, np.array([6, 4, 2], ndmin=2), atol=1e-15)
+        z = y * x
+        npt.assert_allclose(z.freq, np.array([6, 4, 2], ndmin=2), atol=1e-15)
+        # division
+        z = x / y
+        npt.assert_allclose(
+            z.freq, np.array([1.5, 1, .5], ndmin=2), atol=1e-15)
+        z = y / x
+        npt.assert_allclose(z.freq, np.array([2/3, 1, 2], ndmin=2), atol=1e-15)
+        # power
+        z = x**y
+        npt.assert_allclose(z.freq, np.array([9, 4, 1], ndmin=2), atol=1e-15)
+        z = y**x
+        npt.assert_allclose(z.freq, np.array([8, 4, 2], ndmin=2), atol=1e-15)
 
 
 def test_overloaded_operators_time_data():
-    x = TimeData([2, 1, 0], [0, 1, 2])
-    y = TimeData([2, 2, 2], [0, 1, 2])
+    x = TimeData([3, 2, 1], [0, 1, 2])
+    y_s = TimeData([2, 2, 2], [0, 1, 2])
 
-    # addition
-    z = x + y
-    npt.assert_allclose(z.time, np.array([4, 3, 2], ndmin=2), atol=1e-15)
-    # subtraction
-    z = x - y
-    npt.assert_allclose(z.time, np.array([0, -1, -2], ndmin=2), atol=1e-15)
-    # multiplication
-    z = x * y
-    npt.assert_allclose(z.time, np.array([4, 2, 0], ndmin=2), atol=1e-15)
-    # division
-    z = x / y
-    npt.assert_allclose(z.time, np.array([1, .5, 0], ndmin=2), atol=1e-15)
-    # power
-    z = x**y
-    npt.assert_allclose(z.time, np.array([4, 1, 0], ndmin=2), atol=1e-15)
+    for y in [y_s, 2]:
+        # addition
+        z = x + y
+        npt.assert_allclose(z.time, np.array([5, 4, 3], ndmin=2), atol=1e-15)
+        z = y + x
+        npt.assert_allclose(z.time, np.array([5, 4, 3], ndmin=2), atol=1e-15)
+        # subtraction
+        z = x - y
+        npt.assert_allclose(z.time, np.array([1, 0, -1], ndmin=2), atol=1e-15)
+        z = y - x
+        npt.assert_allclose(z.time, np.array([-1, 0, 1], ndmin=2), atol=1e-15)
+        # multiplication
+        z = x * y
+        npt.assert_allclose(z.time, np.array([6, 4, 2], ndmin=2), atol=1e-15)
+        z = y * x
+        npt.assert_allclose(z.time, np.array([6, 4, 2], ndmin=2), atol=1e-15)
+        # division
+        z = x / y
+        npt.assert_allclose(
+            z.time, np.array([1.5, 1, .5], ndmin=2), atol=1e-15)
+        z = y / x
+        npt.assert_allclose(z.time, np.array([2/3, 1, 2], ndmin=2), atol=1e-15)
+        # power
+        z = x**y
+        npt.assert_allclose(z.time, np.array([9, 4, 1], ndmin=2), atol=1e-15)
+        z = y**x
+        npt.assert_allclose(z.time, np.array([8, 4, 2], ndmin=2), atol=1e-15)
 
 
 def test_overloaded_operators_frequency_data():
-    x = FrequencyData([2, 1, 0], [0, 1, 2])
-    y = FrequencyData([2, 2, 2], [0, 1, 2])
+    x = FrequencyData([3, 2, 1], [0, 1, 2])
+    y_s = FrequencyData([2, 2, 2], [0, 1, 2])
 
-    # addition
-    z = x + y
-    npt.assert_allclose(z.freq, np.array([4, 3, 2], ndmin=2), atol=1e-15)
-    # subtraction
-    z = x - y
-    npt.assert_allclose(z.freq, np.array([0, -1, -2], ndmin=2), atol=1e-15)
-    # multiplication
-    z = x * y
-    npt.assert_allclose(z.freq, np.array([4, 2, 0], ndmin=2), atol=1e-15)
-    # division
-    z = x / y
-    npt.assert_allclose(z.freq, np.array([1, .5, 0], ndmin=2), atol=1e-15)
-    # power
-    z = x**y
-    npt.assert_allclose(z.freq, np.array([4, 1, 0], ndmin=2), atol=1e-15)
+    for y in [y_s, 2]:
+        # addition
+        z = x + y
+        npt.assert_allclose(z.freq, np.array([5, 4, 3], ndmin=2), atol=1e-15)
+        z = y + x
+        npt.assert_allclose(z.freq, np.array([5, 4, 3], ndmin=2), atol=1e-15)
+        # subtraction
+        z = x - y
+        npt.assert_allclose(z.freq, np.array([1, 0, -1], ndmin=2), atol=1e-15)
+        z = y - x
+        npt.assert_allclose(z.freq, np.array([-1, 0, 1], ndmin=2), atol=1e-15)
+        # multiplication
+        z = x * y
+        npt.assert_allclose(z.freq, np.array([6, 4, 2], ndmin=2), atol=1e-15)
+        z = y * x
+        npt.assert_allclose(z.freq, np.array([6, 4, 2], ndmin=2), atol=1e-15)
+        # division
+        z = x / y
+        npt.assert_allclose(
+            z.freq, np.array([1.5, 1, .5], ndmin=2), atol=1e-15)
+        z = y / x
+        npt.assert_allclose(z.freq, np.array([2/3, 1, 2], ndmin=2), atol=1e-15)
+        # power
+        z = x**y
+        npt.assert_allclose(z.freq, np.array([9, 4, 1], ndmin=2), atol=1e-15)
+        z = y**x
+        npt.assert_allclose(z.freq, np.array([8, 4, 2], ndmin=2), atol=1e-15)
 
 
 def test_assert_match_for_arithmetic():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

The overloaded arithmetic operations only work if the audio object is the first operand (e.g, signal*2), but a `TypeError: unsupported operand type(s)...` for is thrown for the different order (2*signal) due to missing __r*__ methods

### Changes proposed in this pull request:

- added _radd__, __rsub__, __rmul__, __rtruediv__ and __rpow__ to TimeData and FrequencyData
- modified tests with different order of operands