### PR TITLE
Remove pyfftw and allow python=3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 python:
   - 3.7
   - 3.8
+  - 3.9
 
 # Command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -82,19 +82,9 @@ References
 
 """
 import multiprocessing
-import warnings
 
 import numpy as np
-
-try:
-    import pyfftw
-    pyfftw.config.NUM_THREADS = multiprocessing.cpu_count()
-    from pyfftw.interfaces import numpy_fft as fft_lib
-except ImportError:
-    warnings.warn(
-        "Using numpy FFT implementation.\
-        Install pyfftw for improved performance.")
-    from numpy import fft as fft_lib
+from scipy import fft
 
 
 def rfftfreq(n_samples, sampling_rate):
@@ -118,7 +108,7 @@ def rfftfreq(n_samples, sampling_rate):
         The positive discrete frequencies in Hz for which the FFT is
         calculated.
     """  # noqa: W605 (ignore \_ which is valid only in LaTex)
-    return fft_lib.rfftfreq(n_samples, d=1/sampling_rate)
+    return fft.rfftfreq(n_samples, d=1/sampling_rate)
 
 
 def rfft(data, n_samples, sampling_rate, fft_norm):
@@ -153,7 +143,8 @@ def rfft(data, n_samples, sampling_rate, fft_norm):
     """
 
     # DFT
-    spec = fft_lib.rfft(data, n=n_samples, axis=-1)
+    spec = fft.rfft(
+        data, n=n_samples, axis=-1, workers=multiprocessing.cpu_count())
     # Normalization
     spec = normalization(spec, n_samples, sampling_rate, fft_norm,
                          inverse=False, single_sided=True)
@@ -197,7 +188,8 @@ def irfft(spec, n_samples, sampling_rate, fft_norm):
     spec = normalization(spec, n_samples, sampling_rate, fft_norm,
                          inverse=True, single_sided=True)
     # Inverse DFT
-    data = fft_lib.irfft(spec, n=n_samples, axis=-1)
+    data = fft.irfft(
+        spec, n=n_samples, axis=-1, workers=multiprocessing.cpu_count())
 
     return data
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,6 @@ pytest-runner
 pytest-cov
 numpy>=1.14.0
 scipy>=1.5.0
-pyfftw
 matplotlib
 python-sofa>=0.2.0
 urllib3

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,5 +21,5 @@ exclude = .git, .tox, docs
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
+; collect_ignore = ['setup.py']
 norecursedirs = private

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'numpy>=1.14.0',
     'scipy>=1.5.0',
-    'pyfftw',
     'matplotlib',
     'python-sofa>=0.2.0',
     'urllib3',

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9'
     ],
     description="Project for data formats in acoustics.",
     install_requires=requirements,
@@ -61,5 +62,5 @@ setup(
     url='https://github.com/pyfar/pyfar',
     version='0.2.1',
     zip_safe=False,
-    python_requires='>=3.7,<3.9'
+    python_requires='>=3.7'
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 import os.path
+import scipy.fft
 import sofa
 import scipy.io.wavfile as wavfile
 
@@ -391,25 +392,6 @@ def frequency_data_one_point():
     """
     frequency_data = FrequencyData([2], [0])
     return frequency_data
-
-
-@pytest.fixture
-def fft_lib_np(monkeypatch):
-    """Set numpy.fft as fft library.
-    """
-    import pyfar.dsp.fft
-    monkeypatch.setattr(pyfar.dsp.fft, 'fft_lib', np.fft)
-    return np.fft.__name__
-
-
-@pytest.fixture
-def fft_lib_pyfftw(monkeypatch):
-    """Set pyfftw as fft library.
-    """
-    import pyfar.dsp.fft
-    from pyfftw.interfaces import numpy_fft as npi_fft
-    monkeypatch.setattr(pyfar.dsp.fft, 'fft_lib', npi_fft)
-    return npi_fft.__name__
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
 import numpy as np
 import os.path
-import scipy.fft
 import sofa
 import scipy.io.wavfile as wavfile
 

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -50,16 +50,19 @@ def test_group_delay_single_channel(impulse_group_delay):
 
     grp = dsp.group_delay(signal, method='scipy')
     assert grp.shape == (signal.n_bins, )
-    npt.assert_allclose(grp, impulse_group_delay[1].flatten(), rtol=1e-10)
+    npt.assert_allclose(
+        grp, impulse_group_delay[1].flatten(), rtol=1e-10, atol=1e-10)
 
     grp = dsp.group_delay(signal, method='fft')
     assert grp.shape == (signal.n_bins, )
-    npt.assert_allclose(grp, impulse_group_delay[1].flatten(), rtol=1e-10)
+    npt.assert_allclose(
+        grp, impulse_group_delay[1].flatten(), rtol=1e-10, atol=1e-10)
 
     grp = dsp.group_delay(
         signal, method='fft')
     assert grp.shape == (signal.n_bins, )
-    npt.assert_allclose(grp, impulse_group_delay[1].flatten(), rtol=1e-10)
+    npt.assert_allclose(
+        grp, impulse_group_delay[1].flatten(), rtol=1e-10, atol=1e-10)
 
 
 def test_group_delay_two_channel(impulse_group_delay_two_channel):
@@ -95,7 +98,8 @@ def test_group_delay_custom_frequencies(impulse_group_delay):
     frequency_idx = np.abs(signal.frequencies-frequency).argmin()
     grp = dsp.group_delay(signal, frequency, method='scipy')
     assert grp.shape == ()
-    npt.assert_allclose(grp, impulse_group_delay[1][0, frequency_idx])
+    npt.assert_allclose(
+        grp, impulse_group_delay[1][0, frequency_idx], atol=1e-10)
 
     # Multiple frequencies
     frequency = np.array([1000, 2000])
@@ -103,7 +107,8 @@ def test_group_delay_custom_frequencies(impulse_group_delay):
         signal.frequencies-frequency[..., np.newaxis]).argmin(axis=-1)
     grp = dsp.group_delay(signal, frequency, method='scipy')
     assert grp.shape == (2,)
-    npt.assert_allclose(grp, impulse_group_delay[1][0, frequency_idx])
+    npt.assert_allclose(
+        grp, impulse_group_delay[1][0, frequency_idx], atol=1e-10)
 
 
 def test_linear_phase():

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -2,7 +2,6 @@ import numpy as np
 import numpy.testing as npt
 
 from pytest import raises
-import pytest
 
 from pyfar.dsp import fft
 

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -21,10 +21,7 @@ def test_n_bins_odd():
     assert n_bins == truth
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_orthogonality_sine_even(sine_stub, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_orthogonality_sine_even(sine_stub):
     signal_spec = fft.rfft(
         sine_stub.time, sine_stub.n_samples, sine_stub.sampling_rate,
         sine_stub.fft_norm)
@@ -36,10 +33,7 @@ def test_fft_orthogonality_sine_even(sine_stub, fft_lib, request):
         rtol=1e-10, atol=10*np.finfo(float).eps)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_orthogonality_sine_odd(sine_stub_odd, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_orthogonality_sine_odd(sine_stub_odd):
     signal_spec = fft.rfft(
         sine_stub_odd.time, sine_stub_odd.n_samples,
         sine_stub_odd.sampling_rate, sine_stub_odd.fft_norm)
@@ -51,10 +45,7 @@ def test_fft_orthogonality_sine_odd(sine_stub_odd, fft_lib, request):
         rtol=1e-10, atol=10*np.finfo(float).eps)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_orthogonality_noise_even(noise_stub, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_orthogonality_noise_even(noise_stub):
     signal_spec = fft.rfft(
         noise_stub.time, noise_stub.n_samples, noise_stub.sampling_rate,
         noise_stub.fft_norm)
@@ -66,10 +57,7 @@ def test_fft_orthogonality_noise_even(noise_stub, fft_lib, request):
         rtol=1e-10, atol=10*np.finfo(float).eps)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_orthogonality_noise_odd(noise_stub_odd, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_orthogonality_noise_odd(noise_stub_odd):
     signal_spec = fft.rfft(
         noise_stub_odd.time, noise_stub_odd.n_samples,
         noise_stub_odd.sampling_rate, noise_stub_odd.fft_norm)
@@ -81,10 +69,7 @@ def test_fft_orthogonality_noise_odd(noise_stub_odd, fft_lib, request):
         rtol=1e-10, atol=10*np.finfo(float).eps)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_parseval_theorem_sine_even(sine_stub, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_parseval_theorem_sine_even(sine_stub):
     signal_spec = fft.rfft(
         sine_stub.time, sine_stub.n_samples,
         sine_stub.sampling_rate, sine_stub.fft_norm)
@@ -95,10 +80,7 @@ def test_fft_parseval_theorem_sine_even(sine_stub, fft_lib, request):
     npt.assert_allclose(e_freq, e_time, rtol=1e-10)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_parseval_theorem_sine_odd(sine_stub_odd, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_parseval_theorem_sine_odd(sine_stub_odd):
     signal_spec = fft.rfft(
         sine_stub_odd.time, sine_stub_odd.n_samples,
         sine_stub_odd.sampling_rate, sine_stub_odd.fft_norm)
@@ -109,10 +91,7 @@ def test_fft_parseval_theorem_sine_odd(sine_stub_odd, fft_lib, request):
     npt.assert_allclose(e_freq, e_time, rtol=1e-10)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_parseval_theorem_noise_even(noise_stub, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_parseval_theorem_noise_even(noise_stub):
     signal_spec = fft.rfft(
         noise_stub.time, noise_stub.n_samples, noise_stub.sampling_rate,
         noise_stub.fft_norm)
@@ -123,10 +102,7 @@ def test_fft_parseval_theorem_noise_even(noise_stub, fft_lib, request):
     npt.assert_allclose(e_freq, e_time, rtol=1e-10)
 
 
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_parseval_theorem_noise_odd(noise_stub_odd, fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
+def test_fft_parseval_theorem_noise_odd(noise_stub_odd):
     signal_spec = fft.rfft(
         noise_stub_odd.time, noise_stub_odd.n_samples,
         noise_stub_odd.sampling_rate, noise_stub_odd.fft_norm)
@@ -384,18 +360,3 @@ def test_rfft_normalization_sine(sine_stub):
     npt.assert_allclose(
         signal_spec, sine_stub.freq,
         rtol=1e-10, atol=1e-10)
-
-
-@pytest.mark.parametrize('fft_lib', ['fft_lib_np', 'fft_lib_pyfftw'])
-def test_fft_mock(fft_lib, request):
-    # getting the fixture value is required to apply the monkeypatch
-    request.getfixturevalue(fft_lib)
-    assert fft.fft_lib.__name__ == request.getfixturevalue(fft_lib)
-
-
-def test_fft_mock_numpy(fft_lib_np):
-    assert 'numpy.fft' in fft_lib_np
-
-
-def test_fft_mock_pyfftw(fft_lib_pyfftw):
-    assert 'pyfftw' in fft_lib_pyfftw

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist = py37, py38, flake8, examples, build, wheel
+envlist = py37, py38, py39, flake8, examples, build, wheel
 
 [travis]
 python =
+    3.9: py39, examples, build, wheel
     3.8: py38, examples, build, wheel, flake8
     3.7: py37, examples, build, wheel
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #129 

### Changes proposed in this pull request:

- Remove pyfftw in favor of scipy fft
- Remove requirement of python < 3.9

I propose to do a patch release after this has been merged.
