### PR TITLE
import arithmetic functions to pyfar

### DIFF
--- a/pyfar/__init__.py
+++ b/pyfar/__init__.py
@@ -8,6 +8,7 @@ __version__ = '0.2.0'
 
 
 from .classes.audio import Signal, TimeData, FrequencyData
+from .classes.audio import add, subtract, multiply, divide, power
 from .classes.coordinates import Coordinates
 from .classes.orientations import Orientations
 from .classes.filter import FilterFIR, FilterIIR, FilterSOS
@@ -23,6 +24,11 @@ __all__ = [
     'Signal',
     'TimeData',
     'FrequencyData',
+    'add',
+    'subtract',
+    'multiply',
+    'divide',
+    'power',
     'Coordinates',
     'Orientations',
     'FilterFIR',

--- a/tests/test_signal_arithmetic.py
+++ b/tests/test_signal_arithmetic.py
@@ -2,6 +2,7 @@ import numpy as np
 import numpy.testing as npt
 from pytest import raises
 
+import pyfar as pf
 import pyfar.classes.audio as signal
 from pyfar import Signal, TimeData, FrequencyData
 
@@ -12,7 +13,7 @@ def test_add_two_signals_time():
     x = Signal([1, 0, 0], 44100)
 
     # time domain
-    y = signal.add((x, x), 'time')
+    y = pf.add((x, x), 'time')
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
     # check result
@@ -27,7 +28,7 @@ def test_add_two_signals_freq():
     x = Signal([1, 0, 0], 44100)
 
     # frequency domain
-    y = signal.add((x, x), 'freq')
+    y = pf.add((x, x), 'freq')
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
     # check result
@@ -40,7 +41,7 @@ def test_add_two_signals_freq():
 def test_add_three_signals():
     # generate and add signals
     x = Signal([1, 0, 0], 44100)
-    y = signal.add((x, x, x), 'time')
+    y = pf.add((x, x, x), 'time')
 
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -55,7 +56,7 @@ def test_add_three_signals():
 def test_add_signal_and_number():
     # generate and add signals
     x = Signal([1, 0, 0], 44100)
-    y = signal.add((x, 1), 'time')
+    y = pf.add((x, 1), 'time')
 
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -70,7 +71,7 @@ def test_add_signal_and_number():
 def test_add_number_and_signal():
     # generate and add signals
     x = Signal([1, 0, 0], 44100)
-    y = signal.add((1, x), 'time')
+    y = pf.add((1, x), 'time')
 
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -84,7 +85,7 @@ def test_add_number_and_signal():
 def test_add_time_data_and_number():
     # generate and add signals
     x = TimeData([1, 0, 0], [0, .1, .5])
-    y = signal.add((x, 1), 'time')
+    y = pf.add((x, 1), 'time')
 
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -99,7 +100,7 @@ def test_add_time_data_and_number():
 def test_add_time_data_and_time_data():
     # generate and add signals
     x = TimeData([1, 0, 0], [0, .1, .5])
-    y = signal.add((x, x), 'time')
+    y = pf.add((x, x), 'time')
 
     # check if old signal did not change
     npt.assert_allclose(x.time, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -115,7 +116,7 @@ def test_add_time_data_and_number_wrong_domain():
     # generate and add signals
     x = TimeData([1, 0, 0], [0, .1, .5])
     with raises(ValueError):
-        signal.add((x, 1), 'freq')
+        pf.add((x, 1), 'freq')
 
 
 def test_add_time_data_and_number_wrong_times():
@@ -123,15 +124,15 @@ def test_add_time_data_and_number_wrong_times():
     x = TimeData([1, 0, 0], [0, .1, .5])
     y = TimeData([1, 0, 0], [0, .1, .4])
     with raises(ValueError):
-        signal.add((x, y), 'time')
+        pf.add((x, y), 'time')
 
 
 def test_add_frequency_data_and_number():
     # generate and add signals
     x = FrequencyData([1, 0, 0], [0, .1, .5])
-    y = signal.add((x, 1), 'freq')
+    y = pf.add((x, 1), 'freq')
     with raises(ValueError):
-        signal.add((x, 1), 'time')
+        pf.add((x, 1), 'time')
 
     # check if old signal did not change
     npt.assert_allclose(x.freq, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -146,7 +147,7 @@ def test_add_frequency_data_and_number():
 def test_add_frequency_data_and_frequency_data():
     # generate and add signals
     x = FrequencyData([1, 0, 0], [0, .1, .5])
-    y = signal.add((x, x), 'freq')
+    y = pf.add((x, x), 'freq')
 
     # check if old signal did not change
     npt.assert_allclose(x.freq, np.atleast_2d([1, 0, 0]), atol=1e-15)
@@ -162,7 +163,7 @@ def test_add_frequency_data_and_number_wrong_domain():
     # generate and add signals
     x = FrequencyData([1, 0, 0], [0, .1, .5])
     with raises(ValueError):
-        signal.add((x, 1), 'time')
+        pf.add((x, 1), 'time')
 
 
 def test_add_frequency_data_and_number_wrong_frequencies():
@@ -170,7 +171,7 @@ def test_add_frequency_data_and_number_wrong_frequencies():
     x = FrequencyData([1, 0, 0], [0, .1, .5])
     y = FrequencyData([1, 0, 0], [0, .1, .4])
     with raises(ValueError):
-        signal.add((x, y), 'freq')
+        pf.add((x, y), 'freq')
 
 
 def test_add_frequency_data_and_number_wrong_fft_norm():
@@ -178,14 +179,14 @@ def test_add_frequency_data_and_number_wrong_fft_norm():
     x = FrequencyData([1, 0, 0], [0, .1, .5])
     y = FrequencyData([1, 0, 0], [0, .1, .5], fft_norm='rms')
     with raises(ValueError):
-        signal.add((x, y), 'freq')
+        pf.add((x, y), 'freq')
 
 
 def test_subtraction():
     # only test one case - everything else is tested below
     x = Signal([1, 0, 0], 44100)
     y = Signal([0, 1, 0], 44100)
-    z = signal.subtract((x, y), 'time')
+    z = pf.subtract((x, y), 'time')
 
     # check result
     npt.assert_allclose(z.time, np.atleast_2d([1, -1, 0]), atol=1e-15)
@@ -195,7 +196,7 @@ def test_multiplication():
     # only test one case - everything else is tested below
     x = Signal([1, 0, 0], 44100)
     y = Signal([0, 1, 0], 44100)
-    z = signal.multiply((x, y), 'time')
+    z = pf.multiply((x, y), 'time')
 
     # check result
     npt.assert_allclose(z.time, np.atleast_2d([0, 0, 0]), atol=1e-15)
@@ -205,7 +206,7 @@ def test_division():
     # only test one case - everything else is tested below
     x = Signal([1, 0, 0], 44100)
     y = Signal([2, 2, 2], 44100)
-    z = signal.divide((x, y), 'time')
+    z = pf.divide((x, y), 'time')
 
     # check result
     npt.assert_allclose(z.time, np.atleast_2d([0.5, 0, 0]), atol=1e-15)
@@ -215,7 +216,7 @@ def test_power():
     # only test one case - everything else is tested below
     x = Signal([2, 1, 0], 44100)
     y = Signal([2, 2, 2], 44100)
-    z = signal.power((x, y), 'time')
+    z = pf.power((x, y), 'time')
 
     # check result
     npt.assert_allclose(z.time, np.atleast_2d([4, 1, 0]), atol=1e-15)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Arithmetic functions were hard to use and only available from `pyfar.classes.audio.add`. This makes them available as `pyfar.add`

### Changes

- add imports
- use new import syntax in tests