### PR TITLE
allow negative frequencies in LogFormatter

### DIFF
--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -99,7 +99,7 @@ class LogFormatterITAToolbox(LogFormatter):
         if x == 0.0:  # Symlog
             return '0'
 
-        x = abs(x)
+        x = x
 
         vmin, vmax = self.axis.get_view_interval()
         vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Plot functions label negative frequencies with positive values, e.g., the label of '-100' Hz is '100'.

### Changes proposed in this pull request:

- Allow negative frequencies in the LogFormatter that is used to format frequency axis

Signals do not need this, but Frequency data could contain negative frequencies in case of analytical spectra.
I locally tested if this changes anything in the default behavior setting `compare = True` in *tests/test_plot.py* and everything was fine. Is there any reason for not allowing negative values?