### PR TITLE
Feature/match fft norm

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1286,9 +1286,9 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
 
     # check if fft_norms are type string
     if isinstance(fft_norm_1, str) is False:
-        raise ValueError("Parameter fft_norm_1 must be type str.")
+        raise TypeError("Parameter fft_norm_1 must be type str.")
     if isinstance(fft_norm_2, str) is False:
-        raise ValueError("Parameter fft_norm_2 must be type str.")
+        raise TypeError("Parameter fft_norm_2 must be type str.")
 
     # check if fft_norms are valid
     valid_fft_norms = ['none', 'unitary', 'amplitude', 'rms', 'power', 'psd']
@@ -1303,7 +1303,7 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
 
     # check if parameter division is type bool
     if isinstance(division, bool) is False:
-        raise ValueError("Parameter division must be type bool.")
+        raise TypeError("Parameter division must be type bool.")
 
     if division is False:
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1317,7 +1317,7 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
                              "fft_norms must be the same, but they are ",
                              f"{fft_norm_1} and {fft_norm_2}.")
 
-    elif division is True:
+    else:
 
         if fft_norm_2 == 'none':
             fft_norm_result = fft_norm_1

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1249,3 +1249,81 @@ def _divide(a, b):
 
 def _power(a, b):
     return a**b
+
+
+def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
+    """
+    Helper function to determine the fft_norm resulting from an
+    arithmetic operation of two signals.
+
+    For addition, subtraction and multiplication:
+    Either: one signal has fft_norm ``'none'`` , the results gets the other
+    norm.
+    Or: both have the same fft_norm. Other combinations raise an error.
+
+    For division:
+    ###  more discussion needed  ###
+
+    Parameters
+    ----------
+    fft_norm_1 : str, ``'none'``, ``'unitary'``, ``'amplitude'``, ``'rms'``,
+    ``'power'`` or ``'psd'``
+        First fft_norm for matching.
+    fft_norm_2 : str, ``'none'``, ``'unitary'``, ``'amplitude'``, ``'rms'``,
+    ``'power'`` or ``'psd'``
+        Second fft_norm for matching.
+    division : bool
+        ``True`` if arithmetic operation is addition, subtraction or
+        multiplication;
+        ``False`` if arithmetic operation is division.
+
+    Returns
+    -------
+    fft_norm_result : str, ``'none'``, ``'unitary'``, ``'amplitude'``,
+    ``'rms'``, ``'power'`` or ``'psd'``
+        The fft_norm resulting from arithmetic operation.
+    """
+
+    # check if fft_norms are type string
+    if isinstance(fft_norm_1, str) is False:
+        raise ValueError("Parameter fft_norm_1 must be type str.")
+    if isinstance(fft_norm_2, str) is False:
+        raise ValueError("Parameter fft_norm_2 must be type str.")
+
+    # check if fft_norms are valid
+    valid_fft_norms = ['none', 'unitary', 'amplitude', 'rms', 'power', 'psd']
+    if fft_norm_1 not in valid_fft_norms:
+        raise ValueError("Parameter fft_norm_1 is not a valid fft_norm.\n" +
+                         f"valid fft_norms: {valid_fft_norms}\n" +
+                         f"found: {fft_norm_1}")
+    if fft_norm_2 not in valid_fft_norms:
+        raise ValueError("Parameter fft_norm_2 is not a valid fft_norm.\n" +
+                         f"valid fft_norms: {valid_fft_norms}\n" +
+                         f"found: {fft_norm_2}")
+
+    # check if parameter division is type bool
+    if isinstance(division, bool) is False:
+        raise ValueError("Parameter division must be type bool.")
+
+    if division is False:
+
+        if fft_norm_1 == fft_norm_2:
+            fft_norm_result = fft_norm_1
+
+        elif fft_norm_1 == 'none':
+            fft_norm_result = fft_norm_2
+
+        elif fft_norm_2 == 'none':
+            fft_norm_result = fft_norm_1
+
+        else:
+            raise ValueError("Either one fft_norm has to be 'none' or both ",
+                             "fft_norms must be the same,\nbut they are ",
+                             f"{fft_norm_1} and {fft_norm_2}.")
+
+    elif division is True:
+
+        # more discussion needed
+        pass
+
+    return fft_norm_result

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1259,13 +1259,14 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     For addition, subtraction and multiplication:
     Either: one signal has fft_norm ``'none'`` , the results gets the other
     norm.
-    Or: both have the same fft_norm. Other combinations raise an error.
+    Or: both have the same fft_norm, the results gets the same norm.
+    Other combinations raise an error.
 
     For division:
     Either: the denominator (fft_norm_2) is ``'none'``, the result gets the
     fft_norm of the numerator (fft_norm_1).
-    Or:
-    ###  more discussion needed  ###
+    Or: both have the same fft_norm, the results gets the fft_norm ``'none'``.
+    Other combinations raise an error.
 
     Parameters
     ----------
@@ -1322,11 +1323,11 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
             fft_norm_result = fft_norm_1
 
         elif fft_norm_1 == fft_norm_2:
-            # more discussion needed
-            pass
+            fft_norm_result = 'none'
 
         else:
-            # more discussion needed
-            pass
+            raise ValueError("Either fft_norm_2 (denominator) has to be ",
+                             "'none' or both fft_norms must be the same, but ",
+                             f"they are {fft_norm_1} and {fft_norm_2}.")
 
     return fft_norm_result

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1254,7 +1254,7 @@ def _power(a, b):
 def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     """
     Helper function to determine the fft_norm resulting from an
-    arithmetic operation of two signals.
+    arithmetic operation of two audio objects.
 
     For addition, subtraction and multiplication:
     Either: one signal has fft_norm ``'none'`` , the results gets the other

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1251,7 +1251,7 @@ def _power(a, b):
     return a**b
 
 
-def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
+def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     """
     Helper function to determine the fft_norm resulting from an
     arithmetic operation of two signals.
@@ -1287,22 +1287,14 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
         The fft_norm resulting from arithmetic operation.
     """
 
-    # check if fft_norms are type string
-    if isinstance(fft_norm_1, str) is False:
-        raise TypeError("Parameter fft_norm_1 must be type str.")
-    if isinstance(fft_norm_2, str) is False:
-        raise TypeError("Parameter fft_norm_2 must be type str.")
-
     # check if fft_norms are valid
     valid_fft_norms = ['none', 'unitary', 'amplitude', 'rms', 'power', 'psd']
     if fft_norm_1 not in valid_fft_norms:
-        raise ValueError("Parameter fft_norm_1 is not a valid fft_norm.\n" +
-                         f"valid fft_norms: {valid_fft_norms}\n" +
-                         f"found: {fft_norm_1}")
+        raise ValueError(f"fft_norm_1 is {fft_norm_1} but must be in ",
+                         f"{', '.join(valid_fft_norms)}")
     if fft_norm_2 not in valid_fft_norms:
-        raise ValueError("Parameter fft_norm_2 is not a valid fft_norm.\n" +
-                         f"valid fft_norms: {valid_fft_norms}\n" +
-                         f"found: {fft_norm_2}")
+        raise ValueError(f"fft_norm_2 is {fft_norm_2} but must be in ",
+                         f"{', '.join(valid_fft_norms)}")
 
     # check if parameter division is type bool
     if isinstance(division, bool) is False:
@@ -1321,7 +1313,7 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
 
         else:
             raise ValueError("Either one fft_norm has to be 'none' or both ",
-                             "fft_norms must be the same,\nbut they are ",
+                             "fft_norms must be the same, but they are ",
                              f"{fft_norm_1} and {fft_norm_2}.")
 
     elif division is True:

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1276,9 +1276,9 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     ``'power'`` or ``'psd'``
         Second fft_norm for matching.
     division : bool
-        ``True`` if arithmetic operation is addition, subtraction or
+        ``False`` if arithmetic operation is addition, subtraction or
         multiplication;
-        ``False`` if arithmetic operation is division.
+        ``True`` if arithmetic operation is division.
 
     Returns
     -------

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1298,7 +1298,7 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
                          f"{', '.join(valid_fft_norms)}")
 
     # check if parameter division is type bool
-    if isinstance(division, bool) is False:
+    if not isinstance(division, bool):
         raise TypeError("Parameter division must be type bool.")
 
     if division is False:

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1301,7 +1301,7 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     if not isinstance(division, bool):
         raise TypeError("Parameter division must be type bool.")
 
-    if division is False:
+    if not division:
 
         if fft_norm_1 == fft_norm_2:
             fft_norm_result = fft_norm_1

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1262,6 +1262,9 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     Or: both have the same fft_norm. Other combinations raise an error.
 
     For division:
+    Either: the denominator (fft_norm_2) is ``'none'``, the result gets the
+    fft_norm of the numerator (fft_norm_1).
+    Or:
     ###  more discussion needed  ###
 
     Parameters
@@ -1323,7 +1326,15 @@ def match_fft_norm(fft_norm_1, fft_norm_2, division=False):
 
     elif division is True:
 
-        # more discussion needed
-        pass
+        if fft_norm_2 == 'none':
+            fft_norm_result = fft_norm_1
+
+        elif fft_norm_1 == fft_norm_2:
+            # more discussion needed
+            pass
+
+        else:
+            # more discussion needed
+            pass
 
     return fft_norm_result

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -19,108 +19,100 @@ def test_input_division_type():
         _match_fft_norm('none', 'none', 'invalid')
 
 
-def test_result_no_division():
+@pytest.mark.parametrize("fft_norm_1, fft_norm_2, result",
+                         [['none',       'none',         'none'],
+                          ['none',       'unitary',      'unitary'],
+                          ['none',       'amplitude',    'amplitude'],
+                          ['none',       'power',        'power'],
+                          ['none',       'psd',          'psd'],
+                          ['unitary',    'none',         'unitary'],
+                          ['amplitude',  'none',         'amplitude'],
+                          ['rms',        'none',         'rms'],
+                          ['power',      'none',         'power'],
+                          ['psd',        'none',         'psd'],
+                          ['unitary',    'unitary',      'unitary'],
+                          ['amplitude',  'amplitude',    'amplitude'],
+                          ['rms',        'rms',          'rms'],
+                          ['power',      'power',        'power'],
+                          ['psd',        'psd',          'psd']])
+def test_result_no_division(fft_norm_1, fft_norm_2, result):
     """Test the returned fft_norm for arithmetic operation by passing
     valid combinations of fft_norms"""
-    #             fft_norm_1,   fft_norm_2,     result
-    fft_norms = [['none',       'none',         'none'],
-                 ['none',       'unitary',      'unitary'],
-                 ['none',       'amplitude',    'amplitude'],
-                 ['none',       'power',        'power'],
-                 ['none',       'psd',          'psd'],
-                 ['unitary',    'none',         'unitary'],
-                 ['amplitude',  'none',         'amplitude'],
-                 ['rms',        'none',         'rms'],
-                 ['power',      'none',         'power'],
-                 ['psd',        'none',         'psd'],
-                 ['unitary',    'unitary',      'unitary'],
-                 ['amplitude',  'amplitude',    'amplitude'],
-                 ['rms',        'rms',          'rms'],
-                 ['power',      'power',        'power'],
-                 ['psd',        'psd',          'psd']]
-    for fft_norm in fft_norms:
-        assert _match_fft_norm(fft_norm[0], fft_norm[1]) == fft_norm[2]
+    assert _match_fft_norm(fft_norm_1, fft_norm_2) == result
 
 
-def test_assertion_no_division():
+@pytest.mark.parametrize("fft_norm_1, fft_norm_2",
+                         [['unitary',    'amplitude'],
+                          ['unitary',    'rms'],
+                          ['unitary',    'power'],
+                          ['unitary',    'psd'],
+                          ['amplitude',  'unitary'],
+                          ['amplitude',  'rms'],
+                          ['amplitude',  'power'],
+                          ['amplitude',  'psd'],
+                          ['rms',        'unitary'],
+                          ['rms',        'amplitude'],
+                          ['rms',        'power'],
+                          ['rms',        'psd'],
+                          ['power',      'unitary'],
+                          ['power',      'amplitude'],
+                          ['power',      'rms'],
+                          ['power',      'psd'],
+                          ['psd',        'unitary'],
+                          ['psd',        'amplitude'],
+                          ['psd',        'rms'],
+                          ['psd',        'power']])
+def test_assertion_no_division(fft_norm_1, fft_norm_2):
     """Test assertion by passing invalid combinations of fft_norms"""
-    #           fft_norm_1,     fft_norm_2
-    fft_norms = [['unitary',    'amplitude'],
-                 ['unitary',    'rms'],
-                 ['unitary',    'power'],
-                 ['unitary',    'psd'],
-                 ['amplitude',  'unitary'],
-                 ['amplitude',  'rms'],
-                 ['amplitude',  'power'],
-                 ['amplitude',  'psd'],
-                 ['rms',        'unitary'],
-                 ['rms',        'amplitude'],
-                 ['rms',        'power'],
-                 ['rms',        'psd'],
-                 ['power',      'unitary'],
-                 ['power',      'amplitude'],
-                 ['power',      'rms'],
-                 ['power',      'psd'],
-                 ['psd',        'unitary'],
-                 ['psd',        'amplitude'],
-                 ['psd',        'rms'],
-                 ['psd',        'power']]
-    for fft_norm in fft_norms:
-        with pytest.raises(ValueError,
-                           match="Either one fft_norm has to be "):
-            _match_fft_norm(fft_norm[0], fft_norm[1])
+    with pytest.raises(ValueError, match="Either one fft_norm has to be "):
+        _match_fft_norm(fft_norm_1, fft_norm_2)
 
 
-def test_result_division():
+@pytest.mark.parametrize("fft_norm_1, fft_norm_2, result",
+                         [['none',       'none',         'none'],
+                          ['unitary',    'none',         'unitary'],
+                          ['amplitude',  'none',         'amplitude'],
+                          ['rms',        'none',         'rms'],
+                          ['power',      'none',         'power'],
+                          ['psd',        'none',         'psd'],
+                          ['unitary',    'unitary',      'none'],
+                          ['amplitude',  'amplitude',    'none'],
+                          ['rms',        'rms',          'none'],
+                          ['power',      'power',        'none'],
+                          ['psd',        'psd',          'none']])
+def test_result_division(fft_norm_1, fft_norm_2, result):
     """Test the returned fft_norm for arithmetic operation by passing
     valid combinations of fft_norms, with division=True"""
-    #             fft_norm_1,   fft_norm_2,     result
-    fft_norms = [['none',       'none',         'none'],
-                 ['unitary',    'none',         'unitary'],
-                 ['amplitude',  'none',         'amplitude'],
-                 ['rms',        'none',         'rms'],
-                 ['power',      'none',         'power'],
-                 ['psd',        'none',         'psd'],
-                 ['unitary',    'unitary',      'none'],
-                 ['amplitude',  'amplitude',    'none'],
-                 ['rms',        'rms',          'none'],
-                 ['power',      'power',        'none'],
-                 ['psd',        'psd',          'none']]
-    for fft_norm in fft_norms:
-        assert _match_fft_norm(fft_norm[0],
-                               fft_norm[1],
-                               division=True) == fft_norm[2]
+    assert _match_fft_norm(fft_norm_1, fft_norm_2, division=True) == result
 
 
-def test_assertion_division():
+@pytest.mark.parametrize("fft_norm_1, fft_norm_2",
+                         [['none',       'unitary'],
+                          ['none',       'amplitude'],
+                          ['none',       'power'],
+                          ['none',       'psd'],
+                          ['unitary',    'amplitude'],
+                          ['unitary',    'rms'],
+                          ['unitary',    'power'],
+                          ['unitary',    'psd'],
+                          ['amplitude',  'unitary'],
+                          ['amplitude',  'rms'],
+                          ['amplitude',  'power'],
+                          ['amplitude',  'psd'],
+                          ['rms',        'unitary'],
+                          ['rms',        'amplitude'],
+                          ['rms',        'power'],
+                          ['rms',        'psd'],
+                          ['power',      'unitary'],
+                          ['power',      'amplitude'],
+                          ['power',      'rms'],
+                          ['power',      'psd'],
+                          ['psd',        'unitary'],
+                          ['psd',        'amplitude'],
+                          ['psd',        'rms'],
+                          ['psd',        'power']])
+def test_assertion_division(fft_norm_1, fft_norm_2):
     """Test assertion by passing invalid combinations of fft_norms,
     with division=True"""
-    #             fft_norm_1,   fft_norm_2
-    fft_norms = [['none',       'unitary'],
-                 ['none',       'amplitude'],
-                 ['none',       'power'],
-                 ['none',       'psd'],
-                 ['unitary',    'amplitude'],
-                 ['unitary',    'rms'],
-                 ['unitary',    'power'],
-                 ['unitary',    'psd'],
-                 ['amplitude',  'unitary'],
-                 ['amplitude',  'rms'],
-                 ['amplitude',  'power'],
-                 ['amplitude',  'psd'],
-                 ['rms',        'unitary'],
-                 ['rms',        'amplitude'],
-                 ['rms',        'power'],
-                 ['rms',        'psd'],
-                 ['power',      'unitary'],
-                 ['power',      'amplitude'],
-                 ['power',      'rms'],
-                 ['power',      'psd'],
-                 ['psd',        'unitary'],
-                 ['psd',        'amplitude'],
-                 ['psd',        'rms'],
-                 ['psd',        'power']]
-    for fft_norm in fft_norms:
-        with pytest.raises(ValueError,
-                           match="Either fft_norm_2 "):
-            _match_fft_norm(fft_norm[0], fft_norm[1], division=True)
+    with pytest.raises(ValueError, match="Either fft_norm_2 "):
+        _match_fft_norm(fft_norm_1, fft_norm_2, division=True)

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -1,0 +1,93 @@
+import pytest
+from pyfar.classes.audio import match_fft_norm
+
+
+def test_input_fft_norm_type():
+    """Test assertion by passig non str type"""
+    with pytest.raises(TypeError,
+                       match='Parameter fft_norm_1 must be type str.'):
+        match_fft_norm(0, 'none')
+    with pytest.raises(TypeError,
+                       match='Parameter fft_norm_2 must be type str.'):
+        match_fft_norm('none', 0)
+
+
+def test_input_fft_norm_valid():
+    """Test assertion by passing invalid fft_norm"""
+    with pytest.raises(ValueError,
+                       match='Parameter fft_norm_1 is not a valid fft_norm.'):
+        match_fft_norm('invalid', 'none')
+    with pytest.raises(ValueError,
+                       match='Parameter fft_norm_2 is not a valid fft_norm.'):
+        match_fft_norm('none', 'invalid')
+
+
+def test_input_division_type():
+    """Test assertion by passing invalid division parameter"""
+    with pytest.raises(TypeError,
+                       match='Parameter division must be type bool.'):
+        match_fft_norm('none', 'none', 'invalid')
+
+
+def test_result_no_division():
+    """Test the returned fft_norm for arithmetic operation by passing
+    valid combinations of fft_norms"""
+    #           fft_norm_1, fft_norm_2, result
+    fft_norms = [['none', 'none', 'none'],
+                 ['none', 'unitary', 'unitary'],
+                 ['none', 'amplitude', 'amplitude'],
+                 ['none', 'power', 'power'],
+                 ['none', 'psd', 'psd'],
+                 ['unitary', 'none', 'unitary'],
+                 ['amplitude', 'none', 'amplitude'],
+                 ['rms', 'none', 'rms'],
+                 ['power', 'none', 'power'],
+                 ['psd', 'none', 'psd'],
+                 ['unitary', 'unitary', 'unitary'],
+                 ['amplitude', 'amplitude', 'amplitude'],
+                 ['rms', 'rms', 'rms'],
+                 ['power', 'power', 'power'],
+                 ['psd', 'psd', 'psd']]
+    for fft_norm in fft_norms:
+        assert match_fft_norm(fft_norm[0], fft_norm[1]) == fft_norm[2]
+
+
+def test_assertion_no_division():
+    """Test assertion by passing invalid combinations of fft_norms"""
+    #           fft_norm_1, fft_norm_2, result
+    fft_norms = [['unitary', 'amplitude'],
+                 ['unitary', 'rms'],
+                 ['unitary', 'power'],
+                 ['unitary', 'psd'],
+                 ['amplitude', 'unitary'],
+                 ['amplitude', 'rms'],
+                 ['amplitude', 'power'],
+                 ['amplitude', 'psd'],
+                 ['rms', 'unitary'],
+                 ['rms', 'amplitude'],
+                 ['rms', 'power'],
+                 ['rms', 'psd'],
+                 ['power', 'unitary'],
+                 ['power', 'amplitude'],
+                 ['power', 'rms'],
+                 ['power', 'psd'],
+                 ['psd', 'unitary'],
+                 ['psd', 'amplitude'],
+                 ['psd', 'rms'],
+                 ['psd', 'power']]
+    for fft_norm in fft_norms:
+        with pytest.raises(ValueError,
+                           match="Either one fft_norm has to be "):
+            match_fft_norm(fft_norm[0], fft_norm[1])
+
+
+def test_result_division():
+    """Test the returned fft_norm for arithmetic operation by passing
+    valid combinations of fft_norms, with division=True"""
+    pass
+
+
+def test_assertion_division():
+    """Test assertion by passing invalid combinations of fft_norms,
+    with division=True"""
+    pass

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -54,7 +54,7 @@ def test_result_no_division():
 
 def test_assertion_no_division():
     """Test assertion by passing invalid combinations of fft_norms"""
-    #           fft_norm_1, fft_norm_2, result
+    #           fft_norm_1, fft_norm_2
     fft_norms = [['unitary', 'amplitude'],
                  ['unitary', 'rms'],
                  ['unitary', 'power'],

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -2,16 +2,6 @@ import pytest
 from pyfar.classes.audio import match_fft_norm
 
 
-def test_input_fft_norm_type():
-    """Test assertion by passig non str type"""
-    with pytest.raises(TypeError,
-                       match='Parameter fft_norm_1 must be type str.'):
-        match_fft_norm(0, 'none')
-    with pytest.raises(TypeError,
-                       match='Parameter fft_norm_2 must be type str.'):
-        match_fft_norm('none', 0)
-
-
 def test_input_fft_norm_valid():
     """Test assertion by passing invalid fft_norm"""
     with pytest.raises(ValueError,

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -22,49 +22,49 @@ def test_input_division_type():
 def test_result_no_division():
     """Test the returned fft_norm for arithmetic operation by passing
     valid combinations of fft_norms"""
-    #           fft_norm_1, fft_norm_2, result
-    fft_norms = [['none', 'none', 'none'],
-                 ['none', 'unitary', 'unitary'],
-                 ['none', 'amplitude', 'amplitude'],
-                 ['none', 'power', 'power'],
-                 ['none', 'psd', 'psd'],
-                 ['unitary', 'none', 'unitary'],
-                 ['amplitude', 'none', 'amplitude'],
-                 ['rms', 'none', 'rms'],
-                 ['power', 'none', 'power'],
-                 ['psd', 'none', 'psd'],
-                 ['unitary', 'unitary', 'unitary'],
-                 ['amplitude', 'amplitude', 'amplitude'],
-                 ['rms', 'rms', 'rms'],
-                 ['power', 'power', 'power'],
-                 ['psd', 'psd', 'psd']]
+    #             fft_norm_1,   fft_norm_2,     result
+    fft_norms = [['none',       'none',         'none'],
+                 ['none',       'unitary',      'unitary'],
+                 ['none',       'amplitude',    'amplitude'],
+                 ['none',       'power',        'power'],
+                 ['none',       'psd',          'psd'],
+                 ['unitary',    'none',         'unitary'],
+                 ['amplitude',  'none',         'amplitude'],
+                 ['rms',        'none',         'rms'],
+                 ['power',      'none',         'power'],
+                 ['psd',        'none',         'psd'],
+                 ['unitary',    'unitary',      'unitary'],
+                 ['amplitude',  'amplitude',    'amplitude'],
+                 ['rms',        'rms',          'rms'],
+                 ['power',      'power',        'power'],
+                 ['psd',        'psd',          'psd']]
     for fft_norm in fft_norms:
         assert _match_fft_norm(fft_norm[0], fft_norm[1]) == fft_norm[2]
 
 
 def test_assertion_no_division():
     """Test assertion by passing invalid combinations of fft_norms"""
-    #           fft_norm_1, fft_norm_2
-    fft_norms = [['unitary', 'amplitude'],
-                 ['unitary', 'rms'],
-                 ['unitary', 'power'],
-                 ['unitary', 'psd'],
-                 ['amplitude', 'unitary'],
-                 ['amplitude', 'rms'],
-                 ['amplitude', 'power'],
-                 ['amplitude', 'psd'],
-                 ['rms', 'unitary'],
-                 ['rms', 'amplitude'],
-                 ['rms', 'power'],
-                 ['rms', 'psd'],
-                 ['power', 'unitary'],
-                 ['power', 'amplitude'],
-                 ['power', 'rms'],
-                 ['power', 'psd'],
-                 ['psd', 'unitary'],
-                 ['psd', 'amplitude'],
-                 ['psd', 'rms'],
-                 ['psd', 'power']]
+    #           fft_norm_1,     fft_norm_2
+    fft_norms = [['unitary',    'amplitude'],
+                 ['unitary',    'rms'],
+                 ['unitary',    'power'],
+                 ['unitary',    'psd'],
+                 ['amplitude',  'unitary'],
+                 ['amplitude',  'rms'],
+                 ['amplitude',  'power'],
+                 ['amplitude',  'psd'],
+                 ['rms',        'unitary'],
+                 ['rms',        'amplitude'],
+                 ['rms',        'power'],
+                 ['rms',        'psd'],
+                 ['power',      'unitary'],
+                 ['power',      'amplitude'],
+                 ['power',      'rms'],
+                 ['power',      'psd'],
+                 ['psd',        'unitary'],
+                 ['psd',        'amplitude'],
+                 ['psd',        'rms'],
+                 ['psd',        'power']]
     for fft_norm in fft_norms:
         with pytest.raises(ValueError,
                            match="Either one fft_norm has to be "):
@@ -74,18 +74,18 @@ def test_assertion_no_division():
 def test_result_division():
     """Test the returned fft_norm for arithmetic operation by passing
     valid combinations of fft_norms, with division=True"""
-    #           fft_norm_1, fft_norm_2, result
-    fft_norms = [['none', 'none', 'none'],
-                 ['unitary', 'none', 'unitary'],
-                 ['amplitude', 'none', 'amplitude'],
-                 ['rms', 'none', 'rms'],
-                 ['power', 'none', 'power'],
-                 ['psd', 'none', 'psd'],
-                 ['unitary', 'unitary', 'none'],
-                 ['amplitude', 'amplitude', 'none'],
-                 ['rms', 'rms', 'none'],
-                 ['power', 'power', 'none'],
-                 ['psd', 'psd', 'none']]
+    #             fft_norm_1,   fft_norm_2,     result
+    fft_norms = [['none',       'none',         'none'],
+                 ['unitary',    'none',         'unitary'],
+                 ['amplitude',  'none',         'amplitude'],
+                 ['rms',        'none',         'rms'],
+                 ['power',      'none',         'power'],
+                 ['psd',        'none',         'psd'],
+                 ['unitary',    'unitary',      'none'],
+                 ['amplitude',  'amplitude',    'none'],
+                 ['rms',        'rms',          'none'],
+                 ['power',      'power',        'none'],
+                 ['psd',        'psd',          'none']]
     for fft_norm in fft_norms:
         assert _match_fft_norm(fft_norm[0],
                                fft_norm[1],
@@ -95,31 +95,31 @@ def test_result_division():
 def test_assertion_division():
     """Test assertion by passing invalid combinations of fft_norms,
     with division=True"""
-    #           fft_norm_1, fft_norm_2
-    fft_norms = [['none', 'unitary'],
-                 ['none', 'amplitude'],
-                 ['none', 'power'],
-                 ['none', 'psd'],
-                 ['unitary', 'amplitude'],
-                 ['unitary', 'rms'],
-                 ['unitary', 'power'],
-                 ['unitary', 'psd'],
-                 ['amplitude', 'unitary'],
-                 ['amplitude', 'rms'],
-                 ['amplitude', 'power'],
-                 ['amplitude', 'psd'],
-                 ['rms', 'unitary'],
-                 ['rms', 'amplitude'],
-                 ['rms', 'power'],
-                 ['rms', 'psd'],
-                 ['power', 'unitary'],
-                 ['power', 'amplitude'],
-                 ['power', 'rms'],
-                 ['power', 'psd'],
-                 ['psd', 'unitary'],
-                 ['psd', 'amplitude'],
-                 ['psd', 'rms'],
-                 ['psd', 'power']]
+    #             fft_norm_1,   fft_norm_2
+    fft_norms = [['none',       'unitary'],
+                 ['none',       'amplitude'],
+                 ['none',       'power'],
+                 ['none',       'psd'],
+                 ['unitary',    'amplitude'],
+                 ['unitary',    'rms'],
+                 ['unitary',    'power'],
+                 ['unitary',    'psd'],
+                 ['amplitude',  'unitary'],
+                 ['amplitude',  'rms'],
+                 ['amplitude',  'power'],
+                 ['amplitude',  'psd'],
+                 ['rms',        'unitary'],
+                 ['rms',        'amplitude'],
+                 ['rms',        'power'],
+                 ['rms',        'psd'],
+                 ['power',      'unitary'],
+                 ['power',      'amplitude'],
+                 ['power',      'rms'],
+                 ['power',      'psd'],
+                 ['psd',        'unitary'],
+                 ['psd',        'amplitude'],
+                 ['psd',        'rms'],
+                 ['psd',        'power']]
     for fft_norm in fft_norms:
         with pytest.raises(ValueError,
                            match="Either fft_norm_2 "):

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -5,10 +5,10 @@ from pyfar.classes.audio import _match_fft_norm
 def test_input_fft_norm_valid():
     """Test assertion by passing invalid fft_norm"""
     with pytest.raises(ValueError,
-                       match='Parameter fft_norm_1 is not a valid fft_norm.'):
+                       match='fft_norm_1 is invalid but must be in '):
         _match_fft_norm('invalid', 'none')
     with pytest.raises(ValueError,
-                       match='Parameter fft_norm_2 is not a valid fft_norm.'):
+                       match='fft_norm_2 is invalid but must be in '):
         _match_fft_norm('none', 'invalid')
 
 

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -1,22 +1,22 @@
 import pytest
-from pyfar.classes.audio import match_fft_norm
+from pyfar.classes.audio import _match_fft_norm
 
 
 def test_input_fft_norm_valid():
     """Test assertion by passing invalid fft_norm"""
     with pytest.raises(ValueError,
                        match='Parameter fft_norm_1 is not a valid fft_norm.'):
-        match_fft_norm('invalid', 'none')
+        _match_fft_norm('invalid', 'none')
     with pytest.raises(ValueError,
                        match='Parameter fft_norm_2 is not a valid fft_norm.'):
-        match_fft_norm('none', 'invalid')
+        _match_fft_norm('none', 'invalid')
 
 
 def test_input_division_type():
     """Test assertion by passing invalid division parameter"""
     with pytest.raises(TypeError,
                        match='Parameter division must be type bool.'):
-        match_fft_norm('none', 'none', 'invalid')
+        _match_fft_norm('none', 'none', 'invalid')
 
 
 def test_result_no_division():
@@ -39,7 +39,7 @@ def test_result_no_division():
                  ['power', 'power', 'power'],
                  ['psd', 'psd', 'psd']]
     for fft_norm in fft_norms:
-        assert match_fft_norm(fft_norm[0], fft_norm[1]) == fft_norm[2]
+        assert _match_fft_norm(fft_norm[0], fft_norm[1]) == fft_norm[2]
 
 
 def test_assertion_no_division():
@@ -68,7 +68,7 @@ def test_assertion_no_division():
     for fft_norm in fft_norms:
         with pytest.raises(ValueError,
                            match="Either one fft_norm has to be "):
-            match_fft_norm(fft_norm[0], fft_norm[1])
+            _match_fft_norm(fft_norm[0], fft_norm[1])
 
 
 def test_result_division():

--- a/tests/test_match_fft_norm.py
+++ b/tests/test_match_fft_norm.py
@@ -74,10 +74,53 @@ def test_assertion_no_division():
 def test_result_division():
     """Test the returned fft_norm for arithmetic operation by passing
     valid combinations of fft_norms, with division=True"""
-    pass
+    #           fft_norm_1, fft_norm_2, result
+    fft_norms = [['none', 'none', 'none'],
+                 ['unitary', 'none', 'unitary'],
+                 ['amplitude', 'none', 'amplitude'],
+                 ['rms', 'none', 'rms'],
+                 ['power', 'none', 'power'],
+                 ['psd', 'none', 'psd'],
+                 ['unitary', 'unitary', 'none'],
+                 ['amplitude', 'amplitude', 'none'],
+                 ['rms', 'rms', 'none'],
+                 ['power', 'power', 'none'],
+                 ['psd', 'psd', 'none']]
+    for fft_norm in fft_norms:
+        assert _match_fft_norm(fft_norm[0],
+                               fft_norm[1],
+                               division=True) == fft_norm[2]
 
 
 def test_assertion_division():
     """Test assertion by passing invalid combinations of fft_norms,
     with division=True"""
-    pass
+    #           fft_norm_1, fft_norm_2
+    fft_norms = [['none', 'unitary'],
+                 ['none', 'amplitude'],
+                 ['none', 'power'],
+                 ['none', 'psd'],
+                 ['unitary', 'amplitude'],
+                 ['unitary', 'rms'],
+                 ['unitary', 'power'],
+                 ['unitary', 'psd'],
+                 ['amplitude', 'unitary'],
+                 ['amplitude', 'rms'],
+                 ['amplitude', 'power'],
+                 ['amplitude', 'psd'],
+                 ['rms', 'unitary'],
+                 ['rms', 'amplitude'],
+                 ['rms', 'power'],
+                 ['rms', 'psd'],
+                 ['power', 'unitary'],
+                 ['power', 'amplitude'],
+                 ['power', 'rms'],
+                 ['power', 'psd'],
+                 ['psd', 'unitary'],
+                 ['psd', 'amplitude'],
+                 ['psd', 'rms'],
+                 ['psd', 'power']]
+    for fft_norm in fft_norms:
+        with pytest.raises(ValueError,
+                           match="Either fft_norm_2 "):
+            _match_fft_norm(fft_norm[0], fft_norm[1], division=True)


### PR DESCRIPTION
### Changes proposed in this pull request:

- add the function `match_fft_norm` which takes two fft_norms and returns one fft_norm resulting from arithmetic operations
  - raises errors, when invalid fft_norm combinations are passed
- basic testing of the function `match_fft_norm`

This pull request followed the discussion in #224


`match_fft_norm(fft_norm_1, fft_norm_2, division=False)`

Parameters:
`fft_norm_1` : str, first fft_norm for matching.
`fft_norm_2` : str, second fft_norm for matching.
`division` : bool, `False` if arithmetic operation is addition, subtraction or multiplication; `True` if arithmetic operation is division.

Returns:
`fft_norm_result` : str, the fft_norm resulting from arithmetic operation.