### PR TITLE
Return axes handle in custom_subplots

### DIFF
--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -391,3 +391,5 @@ def _custom_subplots(signal, plots, ax, **kwargs):
                 ca = ax[row * cols + col]
             # plot
             plots[row][col](signal, ax=ca, **kwargs)
+
+    return ax


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

`pyfar.plot.custom_subplot` does not return axes handle

### Changes proposed in this pull request:

Return axes handle