### PR TITLE
Refactor pyfar.io.read_sofa

### DIFF
--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -111,14 +111,14 @@ def read_sofa(filename, verify=True):
 
         - :py:class:`~pyfar.classes.audio.Signal`
             A Signal object is returned is the DataType is ``'FIR'``,
-            ``'FIR-E'``, or ``'FIRE'``
+            ``'FIR-E'``, or ``'FIRE'``.
         - :py:class:`~pyfar.classes.audio.FrequencyData`
             A FrequencyData object is returned is the DataType is ``'TF'``,
-            ``'TF-E'``, or ``'TFE'``
+            ``'TF-E'``, or ``'TFE'``.
 
-        :py:class:`~pyfar.classes.audio.Signal` object containing the data
-        stored in `SOFA_Object.Data.IR`.
-        `cshape` is equal to ``(number of measurements, number of receivers)``.
+        The `cshape` of the object is is ``(M, R)`` with `M` being the number
+        of measurements and `R` being the number of receivers from the SOFA
+        file.
     source_coordinates : Coordinates
         Coordinates object containing the data stored in
         `SOFA_object.SourcePosition`. The domain, convention and unit are
@@ -130,15 +130,14 @@ def read_sofa(filename, verify=True):
 
     Notes
     -----
-    * This function is based on the python-sofa [#]_.
-    * Currently, only SOFA files of `DataType` ``FIR`` are supported.
+    * This function uses the sofar package to read SOFA files [#]_.
 
     References
     ----------
     .. [#] https://www.sofaconventions.org
     .. [#] “AES69-2020: AES Standard for File Exchange-Spatial Acoustic Data
         File Format.”, 2020.
-    .. [#] https://github.com/spatialaudio/python-sofa
+    .. [#] https://pyfar.org
 
     """
     sofafile = sf.read_sofa(filename, verify)

--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -16,10 +16,7 @@ import sofar as sf
 import zipfile
 import io
 
-
-from pyfar import Signal
-from pyfar import Coordinates
-
+from pyfar import Signal, FrequencyData, Coordinates
 from . import _codec as codec
 import pyfar.classes.filter as fo
 
@@ -148,8 +145,12 @@ def read_sofa(filename, verify=True):
     # Check for DataType
     if sofafile.GLOBAL_DataType in ['FIR', 'FIR-E', 'FIRE']:
         # make a Signal
-        signal = Signal(sofafile.Data_IR, sofafile.Data_SamplingRate,
-                        domain='time')
+        signal = Signal(sofafile.Data_IR, sofafile.Data_SamplingRate)
+
+    elif sofafile.GLOBAL_DataType in ['TF', 'TF-E', 'TFE']:
+        # make FrequencyData
+        signal = FrequencyData(
+            sofafile.Data_Real + 1j * sofafile.Data_Imag, sofafile.N)
     else:
         raise ValueError(
             "DataType {sofafile.GLOBAL_DataType} is not supported.")

--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -12,8 +12,6 @@ import scipy.io.wavfile as wavfile
 import os.path
 import pathlib
 import warnings
-import numpy as np
-import sofa
 import sofar as sf
 import zipfile
 import io

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -13,7 +13,6 @@ pytest-cov
 numpy>=1.14.0
 scipy>=1.5.0
 matplotlib
-python-sofa>=0.2.0
 urllib3
 deepdiff
 insipid-sphinx-theme

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     'matplotlib',
     'sofar>=0.1.2',
     'urllib3',
-    'deepdiff'
+    'deepdiff',
+    'requests'
 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     'numpy>=1.14.0',
     'scipy>=1.5.0',
     'matplotlib',
-    'python-sofa>=0.2.0',
+    'sofar>=0.1.2',
     'urllib3',
     'deepdiff'
 ]

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ requirements = [
     'matplotlib',
     'sofar>=0.1.2',
     'urllib3',
-    'deepdiff',
-    'requests'
+    'deepdiff'
 ]
 
 setup_requirements = ['pytest-runner', ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -509,38 +509,6 @@ def generate_sofa_postype_spherical(
 
 
 @pytest.fixture
-def generate_sofa_unit_error(
-        tmpdir, noise_two_by_three_channel, sofa_reference_coordinates):
-    """ Generate the reference sofa files of type GeneralFIR
-    with incorrect sampling rate unit.
-    """
-    sofatype = 'GeneralFIR'
-    n_measurements = noise_two_by_three_channel.cshape[0]
-    n_receivers = noise_two_by_three_channel.cshape[1]
-    n_samples = noise_two_by_three_channel.n_samples
-    dimensions = {"M": n_measurements, "R": n_receivers, "N": n_samples}
-
-    filename = os.path.join(tmpdir, (sofatype + '.sofa'))
-    sofafile = sofa.Database.create(filename, sofatype, dimensions=dimensions)
-
-    sofafile.Listener.initialize(fixed=["Position", "View", "Up"])
-    sofafile.Source.initialize(variances=["Position"], fixed=["View", "Up"])
-    sofafile.Source.Position.set_values(sofa_reference_coordinates[0])
-    sofafile.Receiver.initialize(variances=["Position"], fixed=["View", "Up"])
-    r_coords = np.transpose(sofa_reference_coordinates[1], (0, 2, 1))
-    sofafile.Receiver.Position.set_values(r_coords)
-    sofafile.Emitter.initialize(fixed=["Position", "View", "Up"], count=1)
-    sofafile.Data.Type = 'FIR'
-    sofafile.Data.initialize()
-    sofafile.Data.IR = noise_two_by_three_channel.time
-    sofafile.Data.SamplingRate = noise_two_by_three_channel.sampling_rate
-    sofafile.Data.SamplingRate.Units = 'not_hertz'
-
-    sofafile.close()
-    return filename
-
-
-@pytest.fixture
 def generate_sofa_postype_error(
         tmpdir, noise_two_by_three_channel, sofa_reference_coordinates):
     """ Generate the reference sofa files of type GeneralFIR

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 import os.path
-import sofa
+import sofar as sf
 import scipy.io.wavfile as wavfile
 
 from pyfar.samplings import SphericalVoronoi
@@ -409,67 +409,45 @@ def sofa_reference_coordinates(noise_two_by_three_channel):
     n_measurements = noise_two_by_three_channel.cshape[0]
     n_receivers = noise_two_by_three_channel.cshape[1]
     source_coordinates = np.random.rand(n_measurements, 3)
-    receiver_coordinates = np.random.rand(n_receivers, n_measurements, 3)
+    receiver_coordinates = np.random.rand(n_receivers, 3)
     return source_coordinates, receiver_coordinates
 
 
 @pytest.fixture
 def generate_sofa_GeneralFIR(
         tmpdir, noise_two_by_three_channel, sofa_reference_coordinates):
-    """ Generate the reference sofa files of type GeneralFIR.
-    """
-    sofatype = 'GeneralFIR'
-    n_measurements = noise_two_by_three_channel.cshape[0]
-    n_receivers = noise_two_by_three_channel.cshape[1]
-    n_samples = noise_two_by_three_channel.n_samples
-    dimensions = {"M": n_measurements, "R": n_receivers, "N": n_samples}
+    """ Generate the reference sofa files of type GeneralFIR."""
+    filename = os.path.join(tmpdir, ('GeneralFIR' + '.sofa'))
 
-    filename = os.path.join(tmpdir, (sofatype + '.sofa'))
-    sofafile = sofa.Database.create(filename, sofatype, dimensions=dimensions)
+    sofafile = sf.Sofa('GeneralFIR', True)
+    sofafile.Data_IR = noise_two_by_three_channel.time
+    sofafile.Data_Delay = np.zeros((1, noise_two_by_three_channel.cshape[1]))
+    sofafile.Data_SamplingRate = noise_two_by_three_channel.sampling_rate
+    sofafile.SourcePosition = sofa_reference_coordinates[0]
+    sofafile.SourcePosition_Type = "cartesian"
+    sofafile.SourcePosition_Units = "meter"
+    sofafile.ReceiverPosition = sofa_reference_coordinates[1]
 
-    sofafile.Listener.initialize(fixed=["Position", "View", "Up"])
-    sofafile.Source.initialize(variances=["Position"], fixed=["View", "Up"])
-    sofafile.Source.Position.set_values(sofa_reference_coordinates[0])
-    sofafile.Receiver.initialize(variances=["Position"], fixed=["View", "Up"])
-    r_coords = np.transpose(sofa_reference_coordinates[1], (0, 2, 1))
-    sofafile.Receiver.Position.set_values(r_coords)
-    sofafile.Emitter.initialize(fixed=["Position", "View", "Up"], count=1)
-    sofafile.Data.Type = 'FIR'
-    sofafile.Data.initialize()
-    sofafile.Data.IR = noise_two_by_three_channel.time
-    sofafile.Data.SamplingRate = noise_two_by_three_channel.sampling_rate
+    sf.write_sofa(filename, sofafile)
 
-    sofafile.close()
     return filename
 
 
 @pytest.fixture
 def generate_sofa_GeneralTF(
         tmpdir, noise_two_by_three_channel, sofa_reference_coordinates):
-    """ Generate the reference sofa files of type GeneralTF.
-    """
-    sofatype = 'GeneralTF'
-    n_measurements = noise_two_by_three_channel.cshape[0]
-    n_receivers = noise_two_by_three_channel.cshape[1]
-    n_bins = noise_two_by_three_channel.n_bins
-    dimensions = {"M": n_measurements, "R": n_receivers, "N": n_bins}
+    """ Generate the reference sofa files of type GeneralTF."""
+    filename = os.path.join(tmpdir, ('GeneralTF' + '.sofa'))
 
-    filename = os.path.join(tmpdir, (sofatype + '.sofa'))
-    sofafile = sofa.Database.create(filename, sofatype, dimensions=dimensions)
+    sofafile = sf.Sofa('GeneralTF', True)
+    sofafile.Data_Real = np.real(noise_two_by_three_channel.freq)
+    sofafile.Data_Imag = np.imag(noise_two_by_three_channel.freq)
+    sofafile.N = noise_two_by_three_channel.frequencies
+    sofafile.SourcePosition = sofa_reference_coordinates[0]
+    sofafile.ReceiverPosition = sofa_reference_coordinates[1]
 
-    sofafile.Listener.initialize(fixed=["Position", "View", "Up"])
-    sofafile.Source.initialize(variances=["Position"], fixed=["View", "Up"])
-    sofafile.Source.Position.set_values(sofa_reference_coordinates[0])
-    sofafile.Receiver.initialize(variances=["Position"], fixed=["View", "Up"])
-    r_coords = np.transpose(sofa_reference_coordinates[1], (0, 2, 1))
-    sofafile.Receiver.Position.set_values(r_coords)
-    sofafile.Emitter.initialize(fixed=["Position", "View", "Up"], count=1)
-    sofafile.Data.Type = 'TF'
-    sofafile.Data.initialize()
-    sofafile.Data.Real.set_values(np.real(noise_two_by_three_channel.freq))
-    sofafile.Data.Imag.set_values(np.imag(noise_two_by_three_channel.freq))
+    sf.write_sofa(filename, sofafile)
 
-    sofafile.close()
     return filename
 
 
@@ -479,64 +457,20 @@ def generate_sofa_postype_spherical(
     """ Generate the reference sofa files of type GeneralFIR,
     spherical position type.
     """
-    sofatype = 'GeneralFIR'
-    n_measurements = noise_two_by_three_channel.cshape[0]
-    n_receivers = noise_two_by_three_channel.cshape[1]
-    n_samples = noise_two_by_three_channel.n_samples
-    dimensions = {"M": n_measurements, "R": n_receivers, "N": n_samples}
 
-    filename = os.path.join(tmpdir, (sofatype + '.sofa'))
-    sofafile = sofa.Database.create(filename, sofatype, dimensions=dimensions)
+    filename = os.path.join(tmpdir, ('GeneralFIR' + '.sofa'))
 
-    sofafile.Listener.initialize(fixed=["Position", "View", "Up"])
-    sofafile.Source.initialize(
-        variances=["Position"], fixed=["View", "Up"])
-    sofafile.Source.Position.set_system('spherical')
-    sofafile.Source.Position.set_values(sofa_reference_coordinates[0])
-    sofafile.Receiver.initialize(
-        variances=["Position"], fixed=["View", "Up"])
-    sofafile.Receiver.Position.set_system('spherical')
-    r_coords = np.transpose(sofa_reference_coordinates[1], (0, 2, 1))
-    sofafile.Receiver.Position.set_values(r_coords)
-    sofafile.Emitter.initialize(fixed=["Position", "View", "Up"], count=1)
-    sofafile.Data.Type = 'FIR'
-    sofafile.Data.initialize()
-    sofafile.Data.IR = noise_two_by_three_channel.time
-    sofafile.Data.SamplingRate = noise_two_by_three_channel.sampling_rate
+    sofafile = sf.Sofa('GeneralFIR', True)
+    sofafile.Data_IR = noise_two_by_three_channel.time
+    sofafile.Data_Delay = np.zeros((1, noise_two_by_three_channel.cshape[1]))
+    sofafile.Data_SamplingRate = noise_two_by_three_channel.sampling_rate
+    sofafile.SourcePosition = sofa_reference_coordinates[0]
+    sofafile.ReceiverPosition = sofa_reference_coordinates[1]
+    sofafile.ReceiverPosition_Type = "spherical"
+    sofafile.ReceiverPosition_Units = "degree, degree, meter"
 
-    sofafile.close()
-    return filename
+    sf.write_sofa(filename, sofafile)
 
-
-@pytest.fixture
-def generate_sofa_postype_error(
-        tmpdir, noise_two_by_three_channel, sofa_reference_coordinates):
-    """ Generate the reference sofa files of type GeneralFIR
-    with incorrect position type.
-    """
-    sofatype = 'GeneralFIR'
-    n_measurements = noise_two_by_three_channel.cshape[0]
-    n_receivers = noise_two_by_three_channel.cshape[1]
-    n_samples = noise_two_by_three_channel.n_samples
-    dimensions = {"M": n_measurements, "R": n_receivers, "N": n_samples}
-
-    filename = os.path.join(tmpdir, (sofatype + '.sofa'))
-    sofafile = sofa.Database.create(filename, sofatype, dimensions=dimensions)
-
-    sofafile.Listener.initialize(fixed=["Position", "View", "Up"])
-    sofafile.Source.initialize(variances=["Position"], fixed=["View", "Up"])
-    sofafile.Source.Position.set_values(sofa_reference_coordinates[0])
-    sofafile.Receiver.initialize(variances=["Position"], fixed=["View", "Up"])
-    r_coords = np.transpose(sofa_reference_coordinates[1], (0, 2, 1))
-    sofafile.Receiver.Position.set_values(r_coords)
-    sofafile.Emitter.initialize(fixed=["Position", "View", "Up"], count=1)
-    sofafile.Data.Type = 'FIR'
-    sofafile.Data.initialize()
-    sofafile.Data.IR = noise_two_by_three_channel.time
-    sofafile.Data.SamplingRate = noise_two_by_three_channel.sampling_rate
-    sofafile.Source.Position.Type = 'wrong_type'
-
-    sofafile.close()
     return filename
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -108,12 +108,6 @@ def test_read_sofa_coordinates(
         r_coords.get_cart(), sofa_reference_coordinates[1])
 
 
-def test_read_sofa_sampling_rate_unit(generate_sofa_unit_error):
-    """Test to verify correct sampling rate unit of sofa file"""
-    with pytest.raises(ValueError):
-        io.read_sofa(generate_sofa_unit_error)
-
-
 def test_read_sofa_position_type_spherical(
         generate_sofa_postype_spherical, sofa_reference_coordinates):
     """Test to verify correct position type of sofa file"""

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -92,10 +92,11 @@ def test_read_sofa_GeneralFIR(
     npt.assert_allclose(signal.time, noise_two_by_three_channel.time)
 
 
-def test_read_sofa_GeneralTF(generate_sofa_GeneralTF):
+def test_read_sofa_GeneralTF(
+        generate_sofa_GeneralTF, noise_two_by_three_channel):
     """Test for sofa datatype GeneralTF"""
-    with pytest.raises(ValueError):
-        io.read_sofa(generate_sofa_GeneralTF)
+    signal = io.read_sofa(generate_sofa_GeneralTF)[0]
+    npt.assert_allclose(signal.freq, noise_two_by_three_channel.freq)
 
 
 def test_read_sofa_coordinates(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -120,12 +120,6 @@ def test_read_sofa_position_type_spherical(
         sofa_reference_coordinates[1])
 
 
-def test_read_sofa_position_type_unit(generate_sofa_postype_error):
-    """Test to verify correct position type of sofa file"""
-    with pytest.raises(ValueError):
-        io.read_sofa(generate_sofa_postype_error)
-
-
 @patch('pyfar.io._codec._str_to_type', new=stub_str_to_type())
 @patch('pyfar.io._codec._is_pyfar_type', new=stub_is_pyfar_type())
 def test_write_read_flat_data(tmpdir, flat_data):


### PR DESCRIPTION
### Which issue(s) are closed by this pull request? / Changes proposed in this pull request:

- Use sofar for reading SOFA files
- Extend DataTypes that can be read for Transfer Functions
- Remove tests for checking the validity of SOFA files in pyfar. This is taken care of by sofar