### PR TITLE
Bugfix: Add missing sofar and soundfike dependencies to requirements and rtd config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+build:
+  image: latest
+  apt_packages:
+    - libsndfile1
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -19,3 +19,4 @@ insipid-sphinx-theme
 tox-wheel
 autodocsumm
 soundfile
+sofar>=0.1.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,4 +20,3 @@ tox-wheel
 autodocsumm
 soundfile
 sofar>=0.1.2
-soundfile

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -20,3 +20,4 @@ tox-wheel
 autodocsumm
 soundfile
 sofar>=0.1.2
+soundfile


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #246 

### Changes proposed in this pull request:

Add sofar and soundfile + dependencies to the requirements_dev file for readthedocs and ci as well to work properly in cases where the pyfar  package itself is not installed or the libsndfile dependency is missing.

Working docs are found here:
https://pyfar.readthedocs.io/en/bugfix-missing_sofar/modules/pyfar.dsp.html