### PR TITLE
dB Parameters in dsp.spectrogram

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -251,8 +251,8 @@ def nextpow2(x):
     return np.ceil(np.log2(x))
 
 
-def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
-                window='hann', window_length=1024, window_overlap_fct=0.5):
+def spectrogram(signal, window='hann', window_length=1024,
+                window_overlap_fct=0.5):
     """Compute the magnitude spectrum versus time.
 
     This is a wrapper for scipy.signal.spectogram with two differences. First,
@@ -265,12 +265,6 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
     ----------
     signal : Signal
         pyfar Signal object.
-    db : Boolean
-        False to plot the logarithmic magnitude spectrum. The default is True.
-    log_prefix : integer, float
-        Prefix for calculating the logarithmic time data. The default is 20.
-    log_reference : integer
-        Reference for calculating the logarithmic time data. The default is 1.
     window : str
         Specifies the window (See scipy.signal.get_window). The default is
         'hann'.
@@ -311,12 +305,6 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
     spectrogram = fft.normalization(
         spectrogram, window_length, signal.sampling_rate,
         signal.fft_norm, window=window)
-
-    # get magnitude data in dB
-    if dB:
-        eps = np.finfo(float).eps
-        spectrogram = log_prefix*np.log10(
-            np.abs(spectrogram) / log_reference + eps)
 
     # scipy.signal takes the center of the DFT blocks as time stamp we take the
     # beginning (looks nicer in plots, both conventions are used)

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -44,8 +44,13 @@ def _spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
 
     # get spectrogram
     frequencies, times, spectrogram = dsp.spectrogram(
-        signal[first_channel], dB, log_prefix, log_reference,
-        window, window_length, window_overlap_fct)
+        signal[first_channel], window, window_length, window_overlap_fct)
+
+    # get magnitude data in dB
+    if dB:
+        eps = np.finfo(float).eps
+        spectrogram = log_prefix*np.log10(
+            np.abs(spectrogram) / log_reference + eps)
 
     # auto detect the time unit
     if unit is None:

--- a/tests/test_dsp_spectrogram.py
+++ b/tests/test_dsp_spectrogram.py
@@ -28,33 +28,20 @@ def test_return_values():
     npt.assert_allclose(times, [0, 512/1024, 1])
 
     # check middle slice
-    assert np.all(spectro[:256, 1] < -200)
-    npt.assert_allclose(spectro[256, 1], 0, atol=1e-13)
-    assert np.all(spectro[257:, 1] < -200)
-
-
-def test_dB_False():
-    """Test values of the spectrogram without dB calculation"""
-    # test signal and spectrogram
-    signal = pf.signals.sine(256, 2*1024, sampling_rate=1024)
-    signal.fft_norm = 'amplitude'
-    _, _, spectro = pf.dsp.spectrogram(signal,  window='rect', dB=False)
-
-    # check middle slice
     npt.assert_allclose(spectro[:256, 1], 0, atol=1e-13)
     npt.assert_allclose(spectro[256, 1], 1, atol=1e-13)
     npt.assert_allclose(spectro[257:, 1], 0, atol=1e-13)
 
 
 @pytest.mark.parametrize('window,value', [
-    ('rect', [0, 1, 0]),            # rect window does not spread energy
+    ('rect', [0, 1, 0]),         # rect window does not spread energy
     ('hann', [.5, 1, .5])])      # hann window spreads energy
 def test_window(window, value):
     """Test return values of the spectrogram with default parameters"""
     # test signal and spectrogram
     signal = pf.signals.sine(256, 2*1024, sampling_rate=1024)
     signal.fft_norm = 'amplitude'
-    _, _, spectro = pf.dsp.spectrogram(signal,  dB=False, window=window)
+    _, _, spectro = pf.dsp.spectrogram(signal, window=window)
 
     # check middle slice
     npt.assert_allclose(spectro[255:258, 1], value, atol=1e-13)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #257 

### Changes proposed in this pull request:

- Remove dB parameters from `dsp.spectrogram` and tests thereof
- Move dB parameters to `plot.spectrogram`
- No additional tests of `plot.spectrogram` needed. Parameter tested in `test_plot.py::test_line_dB_option`