### PR TITLE
Enhancement/log prefix defaults

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -251,8 +251,8 @@ def nextpow2(x):
     return np.ceil(np.log2(x))
 
 
-def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
-                window='hann', window_length=1024, window_overlap_fct=0.5):
+def spectrogram(signal, window='hann', window_length=1024,
+                window_overlap_fct=0.5):
     """Compute the magnitude spectrum versus time.
 
     This is a wrapper for scipy.signal.spectogram with two differences. First,
@@ -265,12 +265,6 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
     ----------
     signal : Signal
         pyfar Signal object.
-    db : Boolean
-        False to plot the logarithmic magnitude spectrum. The default is True.
-    log_prefix : integer, float
-        Prefix for calculating the logarithmic time data. The default is 20.
-    log_reference : integer
-        Reference for calculating the logarithmic time data. The default is 1.
     window : str
         Specifies the window (See scipy.signal.get_window). The default is
         'hann'.
@@ -311,12 +305,6 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
     spectrogram = fft.normalization(
         spectrogram, window_length, signal.sampling_rate,
         signal.fft_norm, window=window)
-
-    # get magnitude data in dB
-    if dB:
-        eps = np.finfo(float).eps
-        spectrogram = log_prefix*np.log10(
-            np.abs(spectrogram) / log_reference + eps)
 
     # scipy.signal takes the center of the DFT blocks as time stamp we take the
     # beginning (looks nicer in plots, both conventions are used)

--- a/pyfar/plot/_interaction.py
+++ b/pyfar/plot/_interaction.py
@@ -132,7 +132,8 @@ class PlotParameter(object):
     """
     def __init__(self, plot,
                  dB_time=False, dB_freq=True,              # dB properties
-                 log_prefix=20, log_reference=10,          # same for time/freq
+                 log_prefix_time=20, log_prefix_freq=20,
+                 log_reference=1,                          # same for time/freq
                  xscale='log', yscale='linear',            # axis scaling
                  deg=False, unwrap=False,                  # phase properties
                  unit=None,                                # time unit
@@ -144,7 +145,8 @@ class PlotParameter(object):
         # store input
         self.dB_time = dB_time
         self.dB_freq = dB_freq
-        self.log_prefix = log_prefix
+        self.log_prefix_time = log_prefix_time
+        self.log_prefix_freq = log_prefix_freq
         self.log_reference = log_reference
         self.xscale = xscale
         self.yscale = yscale
@@ -536,13 +538,13 @@ class Interaction(object):
             if event.key in plot['time']:
                 self.params.update_axis_type('time')
                 self.ax = _line._time(
-                    self.signal, prm.dB_time, prm.log_prefix,
+                    self.signal, prm.dB_time, prm.log_prefix_time,
                     prm.log_reference, self.ax, **self.kwargs)
 
             elif event.key in plot['freq']:
                 self.params.update_axis_type('freq')
                 self.ax = _line._freq(
-                    self.signal, prm.dB_freq, prm.log_prefix,
+                    self.signal, prm.dB_freq, prm.log_prefix_freq,
                     prm.log_reference, prm.xscale, self.ax, **self.kwargs)
 
             elif event.key in plot['phase']:
@@ -561,22 +563,24 @@ class Interaction(object):
                 self.params.update_axis_type('spectrogram')
                 ax, *_ = _two_d._spectrogram(
                     self.signal[self.cycler.index], prm.dB_freq,
-                    prm.log_prefix, prm.log_reference, prm.yscale, prm.unit,
-                    prm.window, prm.window_length, prm.window_overlap_fct,
-                    prm.cmap, prm.colorbar, self.ax, **self.kwargs)
+                    prm.log_prefix_freq, prm.log_reference, prm.yscale,
+                    prm.unit, prm.window, prm.window_length,
+                    prm.window_overlap_fct, prm.cmap, prm.colorbar, self.ax,
+                    **self.kwargs)
                 self.ax = ax
 
             elif event.key in plot['time_freq']:
                 self.params.update_axis_type('time')
                 ax = _line._time_freq(
-                    self.signal, prm.dB_time, prm.dB_freq, prm.log_prefix,
+                    self.signal, prm.dB_time, prm.dB_freq,
+                    prm.log_prefix_time, prm.log_prefix_freq,
                     prm.log_reference, prm.xscale, self.ax, **self.kwargs)
                 self.ax = ax[0]
 
             elif event.key in plot['freq_phase']:
                 self.params.update_axis_type('freq')
                 ax = _line._freq_phase(
-                    self.signal, prm.dB_freq, prm.log_prefix,
+                    self.signal, prm.dB_freq, prm.log_prefix_freq,
                     prm.log_reference, prm.xscale, prm.deg, prm.unwrap,
                     self.ax, **self.kwargs)
                 self.ax = ax[0]
@@ -584,7 +588,7 @@ class Interaction(object):
             elif event.key in plot['freq_group_delay']:
                 self.params.update_axis_type('freq')
                 ax = _line._freq_group_delay(
-                    self.signal, prm.dB_freq, prm.log_prefix,
+                    self.signal, prm.dB_freq, prm.log_prefix_freq,
                     prm.log_reference, prm.unit, prm.xscale,
                     self.ax, **self.kwargs)
                 self.ax = ax[0]

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -214,8 +214,9 @@ def _group_delay(signal, unit=None, xscale='log', ax=None, **kwargs):
     return ax
 
 
-def _time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
-               log_reference=1, xscale='log', unit=None, ax=None, **kwargs):
+def _time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
+               log_prefix_freq=None, log_reference=1, xscale='log', unit=None,
+               ax=None, **kwargs):
     """
     Plot the time signal and magnitude spectrum in a 2 by 1 subplot layout.
     """
@@ -223,8 +224,10 @@ def _time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
     fig, ax = _utils._prepare_plot(ax, (2, 1))
     kwargs = _utils._return_default_colors_rgb(**kwargs)
 
-    _time(signal, dB_time, log_prefix, log_reference, unit, ax[0], **kwargs)
-    _freq(signal, dB_freq, log_prefix, log_reference, xscale, ax[1], **kwargs)
+    _time(signal, dB_time, log_prefix_time, log_reference, unit, ax[0],
+          **kwargs)
+    _freq(signal, dB_freq, log_prefix_freq, log_reference, xscale, ax[1],
+          **kwargs)
     fig.align_ylabels()
 
     return ax

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -230,8 +230,8 @@ def _time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
     return ax
 
 
-def _freq_phase(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
-                deg=False, unwrap=False, ax=None, **kwargs):
+def _freq_phase(signal, dB=True, log_prefix=None, log_reference=1,
+                xscale='log', deg=False, unwrap=False, ax=None, **kwargs):
     """Plot the magnitude and phase spectrum in a 2 by 1 subplot layout."""
 
     fig, ax = _utils._prepare_plot(ax, (2, 1))
@@ -245,7 +245,7 @@ def _freq_phase(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
     return ax
 
 
-def _freq_group_delay(signal, dB=True, log_prefix=20, log_reference=1,
+def _freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
                       unit=None, xscale='log', ax=None, **kwargs):
     """
     Plot the magnitude and group delay spectrum in a 2 by 1 subplot layout.

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -56,7 +56,7 @@ def _time(signal, dB=False, log_prefix=20, log_reference=1, unit=None,
     return ax
 
 
-def _freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
+def _freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
           ax=None, **kwargs):
     """
     Plot the logarithmic absolute spectrum on the positive frequency axis.
@@ -71,6 +71,8 @@ def _freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
     # prepare input
     kwargs = _utils._return_default_colors_rgb(**kwargs)
     if dB:
+        if log_prefix is None:
+            log_prefix = _utils._log_prefix(signal.fft_norm)
         eps = np.finfo(float).eps
         data = log_prefix*np.log10(np.abs(signal.freq)/log_reference + eps)
         ymax = np.nanmax(data)

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -72,10 +72,7 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
     kwargs = _utils._return_default_colors_rgb(**kwargs)
     if dB:
         if log_prefix is None:
-            if isinstance(signal, Signal):
-                log_prefix = _utils._log_prefix(signal.fft_norm)
-            else:
-                log_prefix = 20
+            log_prefix = _utils._log_prefix(signal)
         eps = np.finfo(float).eps
         data = log_prefix*np.log10(np.abs(signal.freq)/log_reference + eps)
         ymax = np.nanmax(data)

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -72,7 +72,10 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
     kwargs = _utils._return_default_colors_rgb(**kwargs)
     if dB:
         if log_prefix is None:
-            log_prefix = _utils._log_prefix(signal.fft_norm)
+            if isinstance(signal, Signal):
+                log_prefix = _utils._log_prefix(signal.fft_norm)
+            else:
+                log_prefix = 20
         eps = np.finfo(float).eps
         data = log_prefix*np.log10(np.abs(signal.freq)/log_reference + eps)
         ymax = np.nanmax(data)

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -9,7 +9,7 @@ from .ticker import (
     LogLocatorITAToolbox)
 
 
-def _spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
+def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
                  yscale='linear', unit=None,
                  window='hann', window_length=1024, window_overlap_fct=0.5,
                  cmap=mpl.cm.get_cmap(name='magma'), colorbar=True, ax=None):
@@ -48,6 +48,8 @@ def _spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
 
     # get magnitude data in dB
     if dB:
+        if log_prefix is None:
+            log_prefix = _utils._log_prefix(signal)
         eps = np.finfo(float).eps
         spectrogram = log_prefix*np.log10(
             np.abs(spectrogram) / log_reference + eps)

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -44,8 +44,13 @@ def _spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
 
     # get spectrogram
     frequencies, times, spectrogram = dsp.spectrogram(
-        signal[first_channel], dB, log_prefix, log_reference,
-        window, window_length, window_overlap_fct)
+        signal[first_channel], window, window_length, window_overlap_fct)
+
+    # get magnitude data in dB
+    if dB:
+        eps = np.finfo(float).eps
+        spectrogram = log_prefix*np.log10(
+            np.abs(spectrogram) / log_reference + eps)
 
     # auto detect the time unit
     if unit is None:

--- a/pyfar/plot/_utils.py
+++ b/pyfar/plot/_utils.py
@@ -279,7 +279,7 @@ def _deal_time_units(unit='s'):
     return factor, string
 
 
-def _log_prefix(fft_norm):
+def _log_prefix(signal):
     """Return prefix for dB calculation in frequency domain depending on
     fft_norm.
 
@@ -291,7 +291,7 @@ def _log_prefix(fft_norm):
     fft_norm : str
         FFT normalization
     """
-    if fft_norm in ('power', 'psd'):
+    if isinstance(signal, Signal) and signal.fft_norm in ('power', 'psd'):
         log_prefix = 10
     else:
         log_prefix = 20

--- a/pyfar/plot/_utils.py
+++ b/pyfar/plot/_utils.py
@@ -277,3 +277,22 @@ def _deal_time_units(unit='s'):
         factor = 1
         string = ''
     return factor, string
+
+
+def _log_prefix(fft_norm):
+    """Return prefix for dB calculation in frequency domain depending on
+    fft_norm.
+
+    For the FFT normalizations ``'psd'`` and ``'power'`` the prefix is 10,
+    for the other normalizations it is 20.
+
+    Parameters
+    ----------
+    fft_norm : str
+        FFT normalization
+    """
+    if fft_norm in ('power', 'psd'):
+        log_prefix = 10
+    else:
+        log_prefix = 20
+    return log_prefix

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -252,8 +252,8 @@ def group_delay(signal, unit=None, xscale='log', ax=None, style='light',
     return ax
 
 
-def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
-              log_reference=1, xscale='log', unit=None,
+def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
+              log_prefix_freq=None, log_reference=1, xscale='log', unit=None,
               ax=None, style='light', **kwargs):
     """
     Plot the time signal and magnitude spectrum in a 2 by 1 subplot layout.
@@ -273,9 +273,13 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
         Indicate if the data should be plotted in dB in which case
         ``log_prefix * np.log10(abs(signal.freq) / log_reference)`` is used.
         The default is ``True``.
-    log_prefix : integer, float
-        Prefix for calculating the logarithmic time/frequency data.
+    log_prefix_time : integer, float
+        Prefix for calculating the logarithmic time data.
         The default is ``20``.
+    log_prefix_freq : integer, float
+        Prefix for calculating the logarithmic frequency data. The default is
+        ``None``, so either ``20`` or ``10`` is chosen depending on
+        ``signal.fft_norm``.
     log_reference : integer
         Reference for calculating the logarithmic time/frequency data.
         The default is ``1``.
@@ -311,13 +315,14 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
     """
 
     with context(style):
-        ax = _line._time_freq(signal.flatten(), dB_time, dB_freq, log_prefix,
+        ax = _line._time_freq(signal.flatten(), dB_time, dB_freq,
+                              log_prefix_time, log_prefix_freq,
                               log_reference, xscale, unit, ax, **kwargs)
     _utils._tight_layout()
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'time', dB_time=dB_time, log_prefix=log_prefix,
+        'time', dB_time=dB_time, log_prefix=log_prefix_time,
         log_reference=log_reference)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -70,7 +70,7 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit=None, ax=None,
     return ax
 
 
-def freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
+def freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
          ax=None, style='light', **kwargs):
     """
     Plot the magnitude spectrum.
@@ -90,7 +90,7 @@ def freq(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
         The default is ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``20``.
+        ``None``, which chooses the prefix depending on ``signal.fft_norm``.
     log_reference : integer, float
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -62,7 +62,7 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit=None, ax=None,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'time', dB_time=dB, log_prefix=log_prefix,
+        'time', dB_time=dB, log_prefix_time=log_prefix,
         log_reference=log_reference)
     interaction = ia.Interaction(signal, ax, style, plot_parameter, **kwargs)
     ax.interaction = interaction
@@ -129,7 +129,7 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'freq', dB_freq=dB, log_prefix=log_prefix,
+        'freq', dB_freq=dB, log_prefix_freq=log_prefix,
         log_reference=log_reference, xscale=xscale)
     interaction = ia.Interaction(signal, ax, style, plot_parameter, **kwargs)
     ax.interaction = interaction
@@ -322,8 +322,8 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'time', dB_time=dB_time, log_prefix=log_prefix_time,
-        log_reference=log_reference)
+        'time', dB_time=dB_time, log_prefix_time=log_prefix_time,
+        log_prefix_freq=log_prefix_freq, log_reference=log_reference)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)
     ax[0].interaction = interaction
@@ -386,7 +386,7 @@ def freq_phase(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'freq', dB_freq=dB, log_prefix=log_prefix,
+        'freq', dB_freq=dB, log_prefix_freq=log_prefix,
         log_reference=log_reference, xscale=xscale)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)
@@ -457,7 +457,7 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'freq', dB_freq=dB, log_prefix=log_prefix,
+        'freq', dB_freq=dB, log_prefix_freq=log_prefix,
         log_reference=log_reference, xscale=xscale)
     interaction = ia.Interaction(
         signal, ax[0], style, plot_parameter, **kwargs)

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -90,8 +90,8 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
         The default is ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``None``, so either ``20`` or ``10`` is chosen depending on
-        ``signal.fft_norm``.
+        ``None``, so ``10`` is chosen if ``signal.fft_norm`` is ``'power'`` or
+        ``'psd'`` and ``20`` otherwise.
     log_reference : integer, float
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.
@@ -278,8 +278,8 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         The default is ``20``.
     log_prefix_freq : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``None``, so either ``20`` or ``10`` is chosen depending on
-        ``signal.fft_norm``.
+        ``None``, so ``10`` is chosen if ``signal.fft_norm`` is ``'power'`` or
+        ``'psd'`` and ``20`` otherwise.
     log_reference : integer
         Reference for calculating the logarithmic time/frequency data.
         The default is ``1``.
@@ -347,8 +347,8 @@ def freq_phase(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
         The default is ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``None``, so either ``20`` or ``10`` is chosen depending on
-        ``signal.fft_norm``.
+        ``None``, so ``10`` is chosen if ``signal.fft_norm`` is ``'power'`` or
+        ``'psd'`` and ``20`` otherwise..
     log_reference : integer
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.
@@ -413,8 +413,8 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
         ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``None``, so either ``20`` or ``10`` is chosen depending on
-        ``signal.fft_norm``.
+        ``None``, so ``10`` is chosen if ``signal.fft_norm`` is ``'power'`` or
+        ``'psd'`` and ``20`` otherwise.
     log_reference : integer
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -90,7 +90,8 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
         The default is ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``None``, which chooses the prefix depending on ``signal.fft_norm``.
+        ``None``, so either ``20`` or ``10`` is chosen depending on
+        ``signal.fft_norm``.
     log_reference : integer, float
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.
@@ -325,7 +326,7 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix=20,
     return ax
 
 
-def freq_phase(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
+def freq_phase(signal, dB=True, log_prefix=None, log_reference=1, xscale='log',
                deg=False, unwrap=False, ax=None, style='light', **kwargs):
     """Plot the magnitude and phase spectrum in a 2 by 1 subplot layout.
 
@@ -341,7 +342,8 @@ def freq_phase(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
         The default is ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``20``.
+        ``None``, so either ``20`` or ``10`` is chosen depending on
+        ``signal.fft_norm``.
     log_reference : integer
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.
@@ -388,7 +390,7 @@ def freq_phase(signal, dB=True, log_prefix=20, log_reference=1, xscale='log',
     return ax
 
 
-def freq_group_delay(signal, dB=True, log_prefix=20, log_reference=1,
+def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
                      unit=None, xscale='log', ax=None, style='light',
                      **kwargs):
     """Plot the magnitude and group delay spectrum in a 2 by 1 subplot layout.
@@ -406,7 +408,8 @@ def freq_group_delay(signal, dB=True, log_prefix=20, log_reference=1,
         ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``20``.
+        ``None``, so either ``20`` or ``10`` is chosen depending on
+        ``signal.fft_norm``.
     log_reference : integer
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -23,7 +23,8 @@ def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``True``.
     log_prefix : integer, float
         Prefix for calculating the logarithmic frequency data. The default is
-        ``20``.
+        ``None``, so ``10`` is chosen if ``signal.fft_norm`` is ``'power'`` or
+        ``'psd'`` and ``20`` otherwise.
     log_reference : integer
         Reference for calculating the logarithmic frequency data. The default
         is ``1``.

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -107,7 +107,7 @@ def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
 
     # manage interaction
     plot_parameter = ia.PlotParameter(
-        'spectrogram', dB_freq=dB, log_prefix=log_prefix,
+        'spectrogram', dB_freq=dB, log_prefix_freq=log_prefix,
         log_reference=log_reference, yscale=yscale, unit=unit, window=window,
         window_length=window_length, window_overlap_fct=window_overlap_fct,
         cmap=cmap)

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -5,7 +5,7 @@ from . import (_two_d, _utils)
 from . import _interaction as ia
 
 
-def spectrogram(signal, dB=True, log_prefix=20, log_reference=1,
+def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
                 yscale='linear', unit=None, window='hann', window_length=1024,
                 window_overlap_fct=0.5, cmap=mpl.cm.get_cmap(name='magma'),
                 colorbar=True, ax=None, style='light'):

--- a/tests/test_dsp_spectrogram.py
+++ b/tests/test_dsp_spectrogram.py
@@ -28,33 +28,20 @@ def test_return_values():
     npt.assert_allclose(times, [0, 512/1024, 1])
 
     # check middle slice
-    assert np.all(spectro[:256, 1] < -200)
-    npt.assert_allclose(spectro[256, 1], 0, atol=1e-13)
-    assert np.all(spectro[257:, 1] < -200)
-
-
-def test_dB_False():
-    """Test values of the spectrogram without dB calculation"""
-    # test signal and spectrogram
-    signal = pf.signals.sine(256, 2*1024, sampling_rate=1024)
-    signal.fft_norm = 'amplitude'
-    _, _, spectro = pf.dsp.spectrogram(signal,  window='rect', dB=False)
-
-    # check middle slice
     npt.assert_allclose(spectro[:256, 1], 0, atol=1e-13)
     npt.assert_allclose(spectro[256, 1], 1, atol=1e-13)
     npt.assert_allclose(spectro[257:, 1], 0, atol=1e-13)
 
 
 @pytest.mark.parametrize('window,value', [
-    ('rect', [0, 1, 0]),            # rect window does not spread energy
+    ('rect', [0, 1, 0]),         # rect window does not spread energy
     ('hann', [.5, 1, .5])])      # hann window spreads energy
 def test_window(window, value):
     """Test return values of the spectrogram with default parameters"""
     # test signal and spectrogram
     signal = pf.signals.sine(256, 2*1024, sampling_rate=1024)
     signal.fft_norm = 'amplitude'
-    _, _, spectro = pf.dsp.spectrogram(signal,  dB=False, window=window)
+    _, _, spectro = pf.dsp.spectrogram(signal, window=window)
 
     # check middle slice
     npt.assert_allclose(spectro[255:258, 1], value, atol=1e-13)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -3,6 +3,8 @@ from pytest import raises
 import matplotlib.pyplot as plt
 import pyfar.plot as plot
 from pyfar.testing.plot_utils import create_figure, save_and_compare
+import numpy as np
+import numpy.testing as npt
 
 # global parameters -----------------------------------------------------------
 # flag for creating new baseline plots
@@ -311,3 +313,37 @@ def test_use():
         plt.plot([1, 2, 3], [1, 2, 3])
         save_and_compare(create_baseline, baseline_path, output_path, filename,
                          file_type, compare_output)
+
+
+def test_freq_fft_norm_dB(noise):
+    """Test correct log_prefix in plot.freq depending on fft_norm."""
+    create_figure()
+    noise.fft_norm = 'power'
+    ax = plot.freq(noise)
+    y_actual = ax.lines[0].get_ydata().flatten()
+    y_desired = 10*np.log10(np.abs(noise.freq)).flatten()
+    npt.assert_allclose(y_actual, y_desired, atol=1e-6)
+
+    create_figure()
+    noise.fft_norm = 'psd'
+    ax = plot.freq(noise)
+    y_actual = ax.lines[0].get_ydata().flatten()
+    y_desired = 10*np.log10(np.abs(noise.freq)).flatten()
+    npt.assert_allclose(y_actual, y_desired, atol=1e-6)
+
+
+def test_time_freq_fft_norm_dB(noise):
+    """Test correct log_prefix in plot.time_freq depending on fft_norm."""
+    create_figure()
+    noise.fft_norm = 'power'
+    ax = plot.time_freq(noise)
+    y_actual = ax[1].lines[0].get_ydata().flatten()
+    y_desired = 10*np.log10(np.abs(noise.freq)).flatten()
+    npt.assert_allclose(y_actual, y_desired, atol=1e-6)
+
+    create_figure()
+    noise.fft_norm = 'psd'
+    ax = plot.time_freq(noise)
+    y_actual = ax[1].lines[0].get_ydata().flatten()
+    y_desired = 10*np.log10(np.abs(noise.freq)).flatten()
+    npt.assert_allclose(y_actual, y_desired, atol=1e-6)

--- a/tests/test_plot__utils.py
+++ b/tests/test_plot__utils.py
@@ -1,4 +1,5 @@
 import matplotlib.pyplot as plt
+import pytest
 from pytest import raises
 import pyfar.plot as plot
 
@@ -91,3 +92,16 @@ def test_default_colors():
             prop_cycle = plt.rcParams['axes.prop_cycle']
             colors_style = prop_cycle.by_key()['color']
             assert colors == colors_style
+
+
+@pytest.mark.parametrize(
+    "fft_norm, expected",
+    [('none', 20), ('unitary', 20), ('amplitude', 20),
+     ('rms', 20), ('power', 10), ('psd', 10)])
+def test__log_prefix_norms(sine, fft_norm, expected):
+    sine.fft_norm = fft_norm
+    assert plot._utils._log_prefix(sine) == expected
+
+
+def test__log_prefix_frequency_data(frequency_data):
+    assert plot._utils._log_prefix(frequency_data) == 20


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #259 

### Changes proposed in this pull request:

- changed default behavior of spectrum plots for signals with `fft_norm`  ``'power'`` and ``'psd'`` to ``10 * log10(signal.freq)`` instead of ``20 * log10(signal.freq)``
- added `log_prefix_time` and `log_prefix_freq` parameters to `plot.time_freq` instead of a single `log_prefix`