### PR TITLE
Bugfix/micro seconds label in plots

### DIFF
--- a/pyfar/plot/_utils.py
+++ b/pyfar/plot/_utils.py
@@ -269,7 +269,7 @@ def _deal_time_units(unit='s'):
         string = 'ms'
     elif unit == 'mus':
         factor = 1 / 1e-6
-        string = 'µs'
+        string = r'$\mathrm{\mu}$s'
     elif unit == 'samples':
         factor = 1
         string = 'samples'

--- a/pyfar/plot/_utils.py
+++ b/pyfar/plot/_utils.py
@@ -269,7 +269,7 @@ def _deal_time_units(unit='s'):
         string = 'ms'
     elif unit == 'mus':
         factor = 1 / 1e-6
-        string = r'$\mathrm{\mu s}$'
+        string = 'µs'
     elif unit == 'samples':
         factor = 1
         string = 'samples'

--- a/tests/test_plot__utils.py
+++ b/tests/test_plot__utils.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import pytest
 from pytest import raises
 import pyfar.plot as plot
+import pyfar as pf
 
 
 def test_prepare_plot():
@@ -105,3 +106,9 @@ def test__log_prefix_norms(sine, fft_norm, expected):
 
 def test__log_prefix_frequency_data(frequency_data):
     assert plot._utils._log_prefix(frequency_data) == 20
+
+
+def test__deal_time_units_mus():
+    """Test previous bugfix for unit micro seconds in labels."""
+    s = pf.signals.impulse(10, sampling_rate=44100)
+    pf.plot.time(s)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Plotting with time unit µs as axis label (e.g., in time, group_delay) raises an "Unknown symbol" error:

```
s = pf.signals.impulse(10, sampling_rate=44100)
pf.plot.time(s)
```

### Changes proposed in this pull request:

- exchanged  ``r'$\mathrm{\mu s}$'`` with unicode ``'µs'`` in private function ``_deal_time_units``
- added test