### PR TITLE
Enhancement: signals parameters

### DIFF
--- a/pyfar/signals/deterministic.py
+++ b/pyfar/signals/deterministic.py
@@ -35,7 +35,10 @@ def sine(frequency, n_samples, amplitude=1, phase=0, sampling_rate=44100,
     -----
     The parameters `frequency`, `amplitude`, and `phase` are
     `broadcasted <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
-    to the parameter that contains the most elements.
+    to the parameter that contains the most elements. For example `frequency`
+    could be of shape ``(2, 4)``, `amplitude` of shape ``(2, 1)``, and `phase`
+    could be a scalar. In this case all parameters would be broadcasted to a
+    shape of ``(2, 4)``.
     """
 
     # check and match the cshape
@@ -113,7 +116,9 @@ def impulse(n_samples, delay=0, amplitude=1, sampling_rate=44100):
     -----
     The parameters `delay` and `amplitude` are
     `broadcasted <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
-    to the parameter that contains the most elements.
+    to the parameter that contains the most elements. For example `delay`
+    could be of shape ``(2, 4)``, `amplitude` of shape ``(2, 1)`` or a scalar.
+    In this case all parameters would be broadcasted to a shape of ``(2, 4)``.
     """
     # check and match the cshape
     try:

--- a/pyfar/signals/deterministic.py
+++ b/pyfar/signals/deterministic.py
@@ -33,14 +33,18 @@ def sine(frequency, n_samples, amplitude=1, phase=0, sampling_rate=44100,
 
     Notes
     -----
-    The parameters `frequency`, `amplitude`, and `phase` must must be scalars
-    and/or array likes of the same shape.
+    The parameters `frequency`, `amplitude`, and `phase` are
+    `broadcasted <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
+    to the parameter that contains the most elements.
     """
 
     # check and match the cshape
-    cshape = _get_common_shape(frequency, amplitude, phase)
-    frequency, amplitude, phase = _match_shape(
-        cshape, frequency, amplitude, phase)
+    try:
+        cshape, (frequency, amplitude, phase) = _match_shape(
+            frequency, amplitude, phase)
+    except ValueError:
+        raise ValueError(("The parameters frequency, amplitude, and phase can "
+                          "not be broadcasted to the same shape"))
 
     if np.any(frequency < 0) or np.any(frequency > sampling_rate/2):
         raise ValueError(
@@ -107,12 +111,16 @@ def impulse(n_samples, delay=0, amplitude=1, sampling_rate=44100):
 
     Notes
     -----
-    The parameters `delay` and `amplitude` must be scalars and/or array likes
-    of the same shape.
+    The parameters `delay` and `amplitude` are
+    `broadcasted <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
+    to the parameter that contains the most elements.
     """
     # check and match the cshape
-    cshape = _get_common_shape(delay, amplitude)
-    delay, amplitude = _match_shape(cshape, delay, amplitude)
+    try:
+        cshape, (delay, amplitude) = _match_shape(delay, amplitude)
+    except ValueError:
+        raise ValueError(("The parameters delay and amplitude can not be "
+                          "broadcasted to the same shape"))
 
     # generate the impulse
     n_samples = int(n_samples)
@@ -354,59 +362,39 @@ def _exponential_sweep(n_samples, frequency_range, amplitude, sweep_rate,
     return sweep
 
 
-def _get_common_shape(*data):
-    """Check if all entries in data have the same shape or shape (1, )
+def _match_shape(*args):
+    """
+    Match the shape of *args to the shape of the arg with the largest size
+    using np.broadcast_to()
 
     Parameters
     ----------
-    data : *args
-       Numbers and array likes for which the shape is checked.
+    *args :
+        data for matching shape
 
     Returns
     -------
-    cshape : tuple
-        Common shape of data, e.g., (1, ) if al entries in data are numbers or
-        (2, 3) if data has entries with shape (2, 3) (and (1, )).
-    """
-
-    cshape = None
-    for d in data:
-        d = np.atleast_1d(d)
-        if cshape is None or cshape == (1, ):
-            cshape = d.shape
-        elif d.shape != (1, ):
-            if d.shape != cshape:
-                raise ValueError(
-                    "Input data must be of the same shape or of shape (1, ).")
-
-    return cshape
-
-
-def _match_shape(shape, *args):
-    """
-    Match the shape of *args by using np.tile(shape) if the shape is not (1, 0)
-
-    Note that calling _get_common_shape before might be a good idea.
-
-    Parameters
-    ----------
     shape : tuple
-        The desired shape
-    *args : number array likes
-        All *args must be of shape (1, ) or shape
-
-    Returns
-    -------
-    args : tuple
-        (*arg_1, *arg_2, ..., arg_N)
+        new common shape of the args
+    args : list
+        args with new common shape
+        (*arg_1, *arg_2, ..., *arg_N)
     """
 
+    # find the shape of the largest array
+    size = 0
+    shape = (1, )
+    for arg in args:
+        arg = np.asarray(arg)
+        if arg.size > size:
+            size = arg.size
+            shape = arg.shape
+
+    # try to match the shape
     result = []
     for arg in args:
-        arg = np.atleast_1d(arg)
-        if arg.shape == (1, ):
-            arg = np.tile(arg, shape)
+        arg = np.broadcast_to(arg, shape)
+        arg.setflags(write=1)
+        result.append(np.atleast_1d(arg))
 
-        result.append(arg)
-
-    return tuple(result)
+    return shape, result

--- a/tests/test_signals.py
+++ b/tests/test_signals.py
@@ -5,7 +5,7 @@ import os
 from pyfar import Signal
 import pyfar.dsp.filter as pff
 import pyfar.signals as pfs
-from pyfar.signals.deterministic import _get_common_shape, _match_shape
+from pyfar.signals.deterministic import _match_shape
 
 
 def test_sine_with_defaults():
@@ -63,6 +63,8 @@ def test_sine_assertions():
     """Test assertions for sine."""
     with pytest.raises(ValueError, match="The frequency must be"):
         pfs.sine(40000, 100)
+    with pytest.raises(ValueError, match="The parameters frequency"):
+        pfs.sine(100, 100, [1, 2], [1, 2, 3])
 
 
 def test_impulse_with_defaults():
@@ -99,6 +101,12 @@ def test_impulse_float():
     """Test impulse signal with float number of samples."""
     signal = pfs.impulse(441.8)
     assert signal.n_samples == 441
+
+
+def test_impulse_assertions():
+    """Test assertions for impulse functions"""
+    with pytest.raises(ValueError, match="The parameters delay"):
+        pfs.impulse(10, [1, 2], [1, 2, 3])
 
 
 def test_noise_with_defaults():
@@ -335,34 +343,12 @@ def test_exponential_sweep_time_assertion():
         pfs.exponential_sweep_time(2**10, [0, 20e3])
 
 
-def test_get_common_shape():
-    """Test get_common_shape with all possible inputs."""
-    a = 1
-    b = [1, 2]
-    c = [[1, 2, 3], [1, 2, 3]]
-
-    # test with two numbers
-    assert _get_common_shape(a, a) == (1, )
-    # test with three numbers
-    assert _get_common_shape(a, a, a) == (1, )
-    # test with number and 1d data
-    assert _get_common_shape(a, b) == (2, )
-    # test with two 1d data entries
-    assert _get_common_shape(b, b) == (2, )
-    # test with number and 2d data
-    assert _get_common_shape(a, c) == (2, 3)
-    # test with two 2d data entries
-    assert _get_common_shape(c, c) == (2, 3)
-    # test not matching data
-    with pytest.raises(ValueError, match="Input data must be of the same"):
-        _get_common_shape(b, c)
-
-
 def test_match_shape():
     """Test _match_shape with all possible inputs."""
     a = 1
     b = [[1, 2, 3], [1, 2, 3]]
 
-    a_match, b_match = _match_shape((3, 2), a, b)
-    npt.assert_allclose(np.ones((3, 2)), a_match)
+    cshape, (a_match, b_match) = _match_shape(a, b)
+    assert cshape == (2, 3)
+    npt.assert_allclose(np.ones(cshape), a_match)
     npt.assert_allclose(b, b_match)


### PR DESCRIPTION
### Changes proposed in this pull request:

The parameters for the functions `pyfar.signals.impulse` and `pyfar.signals.sine` had to be scalars or of the same shape. Now any parameters that can be broadcasted to the same shape can be passed. This is more flexible, maintains backwards compatibility, and made the code shorter and easier to read.

- added new parameter handling
- added new tests