### PR TITLE
Array broadcasting in arithmetic operations

### DIFF
--- a/pyfar/_concepts/arithmetic_operations.py
+++ b/pyfar/_concepts/arithmetic_operations.py
@@ -19,24 +19,25 @@ and in the frequency domain by
 **Note** that frequency domain operations are performed on the raw spectrum
 ``signal.freq_raw``.
 
-Arithmetic operations also work with more than two instances and supports array
-likes and scalar values, e.g.,
+Arithmetic operations also work with more than two instances and support
+array likes and scalar values, e.g.,
 
 >>> result = pf.add((signal_1, 1), 'time')
 
 In this case the scalar `1` is broadcasted, i.e., it is is added to every
 sample of `signal` (or every bin in case of a frequency domain operation).
-Arrays are either need to match ``cshape``,
+The shape of arrays need to match the ``cshape`` of the resulting audio object,
+e.g.,
 
 >>> x = np.arange(2 * 3 * 4).reshape((2, 3, 4))
 >>> y = pf.Signal(np.ones((2, 3, 4, 10)), 44100)
 >>> z = pf.add((x, y))
 
-or the shape of the underlying time or frequency data,
+or are broadcasted, e.g.,
 
->>> x = np.arange(2 * 3 * 4 * 10).reshape((2, 3, 4, 10))
+>>> x = np.arange(3 * 4).reshape((3, 4))
 >>> y = pf.Signal(np.ones((2, 3, 4, 10)), 44100)
->>> z = pf.add((x, y), domain='time')
+>>> z = pf.add((x, y))
 
 The operators ``+``, ``-``, ``*``, ``/``, and ``**`` are overloaded for
 convenience. Note, however, that their behavior depends on the Audio object.

--- a/pyfar/_concepts/arithmetic_operations.py
+++ b/pyfar/_concepts/arithmetic_operations.py
@@ -39,6 +39,9 @@ or are broadcasted, e.g.,
 >>> y = pf.Signal(np.ones((2, 3, 4, 10)), 44100)
 >>> z = pf.add((x, y))
 
+where ``y`` is a signal with ``y.cshape = (2, 3, 4)`` and a length of 10
+samples.
+
 The operators ``+``, ``-``, ``*``, ``/``, and ``**`` are overloaded for
 convenience. Note, however, that their behavior depends on the Audio object.
 Frequency domain operations are applied for

--- a/pyfar/_concepts/arithmetic_operations.py
+++ b/pyfar/_concepts/arithmetic_operations.py
@@ -10,11 +10,11 @@ are implemented in the methods :py:func:`~pyfar.classes.audio.add`,
 :py:func:`~pyfar.classes.audio.FrequencyData` instances can be added in the
 time domain by
 
->>> result = pyfar.classes.audio.add((signal_1, signal_2), 'time')
+>>> result = pf.add((signal_1, signal_2), 'time')
 
 and in the frequency domain by
 
->>> result = pyfar.classes.audio.add((signal_1, signal_2), 'freq')
+>>> result = pf.add((signal_1, signal_2), 'freq')
 
 **Note** that frequency domain operations are performed on the raw spectrum
 ``signal.freq_raw``.
@@ -22,10 +22,21 @@ and in the frequency domain by
 Arithmetic operations also work with more than two instances and supports array
 likes and scalar values, e.g.,
 
->>> result = pyfar.classes.audio.add((signal_1, 1), 'time')
+>>> result = pf.add((signal_1, 1), 'time')
 
 In this case the scalar `1` is broadcasted, i.e., it is is added to every
 sample of `signal` (or every bin in case of a frequency domain operation).
+Arrays are either need to match ``cshape``,
+
+>>> x = np.arange(2 * 3 * 4).reshape((2, 3, 4))
+>>> y = pf.Signal(np.ones((2, 3, 4, 10)), 44100)
+>>> z = pf.add((x, y))
+
+or the shape of the underlying time or frequency data,
+
+>>> x = np.arange(2 * 3 * 4 * 10).reshape((2, 3, 4, 10))
+>>> y = pf.Signal(np.ones((2, 3, 4, 10)), 44100)
+>>> z = pf.add((x, y), domain='time')
 
 The operators ``+``, ``-``, ``*``, ``/``, and ``**`` are overloaded for
 convenience. Note, however, that their behavior depends on the Audio object.
@@ -37,7 +48,7 @@ Frequency domain operations are applied for
 
 is equivalent to
 
->>> result = pyfar.classes.audio.add((signal1, signal2), 'freq')
+>>> result = pf.add((signal1, signal2), 'freq')
 
 and time domain operations are applied for
 :py:func:`~pyfar.classes.audio.TimeData` objects, i.e.,
@@ -46,7 +57,7 @@ and time domain operations are applied for
 
 is equivalent to
 
->>> result = pyfar.classes.audio.add((time_data_1, time_data_2), 'time')
+>>> result = pf.add((time_data_1, time_data_2), 'time')
 
 In addition to the arithmetic operations, the equality operator is overloaded
 to allow comparisons

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -886,6 +886,11 @@ def add(data: tuple, domain='freq'):
         ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
         used.
 
+    Notes
+    -----
+    Arrays included in the data either need to match the ``cshape`` of the
+    resulting audio object or need to be broadcastable to the shape of the
+    underlying time/frequency data.
     """
     return _arithmetic(data, domain, _add)
 
@@ -920,6 +925,12 @@ def subtract(data: tuple, domain='freq'):
         audio object. The `fft_norm` is ``'none'`` if all FFT norms are
         ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
         used.
+
+    Notes
+    -----
+    Arrays included in the data either need to match the ``cshape`` of the
+    resulting audio object or need to be broadcastable to the shape of the
+    underlying time/frequency data.
     """
     return _arithmetic(data, domain, _subtract)
 
@@ -954,6 +965,12 @@ def multiply(data: tuple, domain='freq'):
         audio object. The `fft_norm` is ``'none'`` if all FFT norms are
         ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
         used.
+
+    Notes
+    -----
+    Arrays included in the data either need to match the ``cshape`` of the
+    resulting audio object or need to be broadcastable to the shape of the
+    underlying time/frequency data.
     """
     return _arithmetic(data, domain, _multiply)
 
@@ -987,6 +1004,12 @@ def divide(data: tuple, domain='freq'):
         audio object. The `fft_norm` is ``'none'`` if all FFT norms are
         ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
         used.
+
+    Notes
+    -----
+    Arrays included in the data either need to match the ``cshape`` of the
+    resulting audio object or need to be broadcastable to the shape of the
+    underlying time/frequency data.
    """
     return _arithmetic(data, domain, _divide)
 
@@ -1020,6 +1043,11 @@ def power(data: tuple, domain='freq'):
         audio object. The `fft_norm` is ``'none'`` if all FFT norms are
         ``'none'``. Otherwise the first `fft_norm` that is not ``'none'`` is
         used.
+
+    Notes
+    -----
+    Arrays included in the data either need to match the ``cshape`` of the
+    resulting audio object or the shape of the underlying time/frequency data.
     """
     return _arithmetic(data, domain, _power)
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -21,6 +21,9 @@ class _Audio():
     three sub-classes :py:func:`TimeData`, :py:func:`FrequencyData`, and
     :py:func:`Signal`.
     """
+    # indicate use of _Audio arithmetic operations for overloaded operators
+    # (e.g. __rmul__)
+    __array_priority__ = 1.0
 
     def __init__(self, domain, comment=None, dtype=np.double):
 
@@ -1026,15 +1029,16 @@ def _arithmetic(data: tuple, domain: str, operation: Callable):
 
     # check input and obtain meta data of new signal
     division = True if operation == _divide else False
-    sampling_rate, n_samples, fft_norm, times, frequencies, audio_type = \
+    sampling_rate, n_samples, fft_norm, times, frequencies, audio_type, \
+        cshape = \
         _assert_match_for_arithmetic(data, domain, division)
 
     # apply arithmetic operation
-    result = _get_arithmetic_data(data[0], n_samples, domain)
+    result = _get_arithmetic_data(data[0], n_samples, domain, cshape)
 
     for d in range(1, len(data)):
         result = operation(
-            result, _get_arithmetic_data(data[d], n_samples, domain))
+            result, _get_arithmetic_data(data[d], n_samples, domain, cshape))
 
     # check if to return an audio object
     if audio_type == Signal:
@@ -1056,7 +1060,7 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool):
 
     Check if sampling rate and number of samples agree if multiple signals are
     provided. Check if arrays are numeric. Check if a power signal is contained
-    in the input.
+    in the input. Extract cshape of result.
 
     Input:
     data : tuple
@@ -1083,6 +1087,9 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool):
         The frequencies if a FrequencyData object was passed. None otherwise.
     audio_type : type, None
         Type of the audio class if contained in data. Otherwise None.
+    cshape : tuple, None
+        Largest channel shape of the audio classes if contained in data.
+        Otherwise empty tuple.
 
     """
 
@@ -1101,6 +1108,7 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool):
     times = None
     frequencies = None
     audio_type = type(None)
+    cshape = ()
 
     # check input types and meta data
     found_audio_data = False
@@ -1124,7 +1132,7 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool):
                     if domain != "freq":
                         raise ValueError("The domain must be 'freq'.")
                     frequencies = d.frequencies
-
+                cshape = d.cshape
                 found_audio_data = True
                 audio_type = type(d)
 
@@ -1148,6 +1156,11 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool):
                             frequencies, d.frequencies, atol=1e-15):
                         raise ValueError(
                             "The frequencies do not match.")
+                try:
+                    cshape = np.broadcast_shapes(cshape, d.cshape)
+                except ValueError:
+                    raise ValueError(
+                        "The cshapes do not match.")
 
         # check type of non signal input
         else:
@@ -1162,10 +1175,11 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool):
                 raise ValueError(
                     "Complex input can not be applied in the time domain.")
 
-    return sampling_rate, n_samples, fft_norm, times, frequencies, audio_type
+    return (sampling_rate, n_samples, fft_norm, times, frequencies, audio_type,
+            cshape)
 
 
-def _get_arithmetic_data(data, n_samples, domain):
+def _get_arithmetic_data(data, n_samples, domain, cshape):
     """
     Return data in desired domain without any fft normalization.
 
@@ -1178,6 +1192,9 @@ def _get_arithmetic_data(data, n_samples, domain):
         normalization).
     domain : 'time', 'freq'
         Domain in which the data is returned
+    cshape : tuple
+        Desired channel shape of output (required for operations including
+        array likes and Audio objects).
 
     Returns
     -------
@@ -1197,9 +1214,12 @@ def _get_arithmetic_data(data, n_samples, domain):
         else:
             raise ValueError(
                 f"domain must be 'time' or 'freq' but found {domain}")
-
     else:
         data_out = np.asarray(data)
+
+    if data_out.ndim <= len(cshape):
+        # extend by time/frequency axis, scalars are extended to shape (1,)
+        data_out = data_out[..., None]
 
     return data_out
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -888,9 +888,8 @@ def add(data: tuple, domain='freq'):
 
     Notes
     -----
-    Arrays included in the data either need to match the ``cshape`` of the
-    resulting audio object or need to be broadcastable to the shape of the
-    underlying time/frequency data.
+    The shape of arrays included in data need to match or be broadcastable
+    into the ``cshape`` of the resulting audio object.
     """
     return _arithmetic(data, domain, _add)
 
@@ -928,9 +927,8 @@ def subtract(data: tuple, domain='freq'):
 
     Notes
     -----
-    Arrays included in the data either need to match the ``cshape`` of the
-    resulting audio object or need to be broadcastable to the shape of the
-    underlying time/frequency data.
+    The shape of arrays included in data need to match or be broadcastable
+    into the ``cshape`` of the resulting audio object.
     """
     return _arithmetic(data, domain, _subtract)
 
@@ -968,9 +966,8 @@ def multiply(data: tuple, domain='freq'):
 
     Notes
     -----
-    Arrays included in the data either need to match the ``cshape`` of the
-    resulting audio object or need to be broadcastable to the shape of the
-    underlying time/frequency data.
+    The shape of arrays included in data need to match or be broadcastable
+    into the ``cshape`` of the resulting audio object.
     """
     return _arithmetic(data, domain, _multiply)
 
@@ -1007,9 +1004,8 @@ def divide(data: tuple, domain='freq'):
 
     Notes
     -----
-    Arrays included in the data either need to match the ``cshape`` of the
-    resulting audio object or need to be broadcastable to the shape of the
-    underlying time/frequency data.
+    The shape of arrays included in data need to match or be broadcastable
+    into the ``cshape`` of the resulting audio object.
    """
     return _arithmetic(data, domain, _divide)
 
@@ -1046,8 +1042,8 @@ def power(data: tuple, domain='freq'):
 
     Notes
     -----
-    Arrays included in the data either need to match the ``cshape`` of the
-    resulting audio object or the shape of the underlying time/frequency data.
+    The shape of arrays included in data need to match or be broadcastable
+    into the ``cshape`` of the resulting audio object.
     """
     return _arithmetic(data, domain, _power)
 
@@ -1245,9 +1241,13 @@ def _get_arithmetic_data(data, n_samples, domain, cshape):
     else:
         data_out = np.asarray(data)
 
-    if data_out.ndim <= len(cshape):
-        # extend by time/frequency axis, scalars are extended to shape (1,)
-        data_out = data_out[..., None]
+        if data_out.ndim <= len(cshape):
+            # extend by time/frequency axis, scalars are extended to shape (1,)
+            data_out = data_out[..., None]
+        elif cshape != ():
+            # operation includes arrays and audio objects
+            raise ValueError(
+                "array dimension is larger than the channel dimensions")
 
     return data_out
 

--- a/tests/test_signal_arithmetic.py
+++ b/tests/test_signal_arithmetic.py
@@ -174,6 +174,36 @@ def test_add_frequency_data_and_number_wrong_frequencies():
         pf.add((x, y), 'freq')
 
 
+def test_add_array_and_signal():
+    # With broadcasting
+    x = np.arange(2 * 3 * 4).reshape((2, 3, 4))
+    y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
+    z = pf.add((x, y))
+    npt.assert_allclose(
+        z.freq, np.ones_like(z.freq)*x[..., None] + 1, atol=1e-15)
+    # without broadcasting, in frequency domain
+    x = np.arange(2 * 3 * 4 * 6).reshape((2, 3, 4, 6))
+    y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
+    z = pf.add((x, y))
+    npt.assert_allclose(
+        z.freq, np.ones_like(z.freq)*x + 1, atol=1e-15)
+
+
+def test_add_signal_and_array():
+    # With broadcasting
+    x = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
+    y = np.arange(2 * 3 * 4).reshape((2, 3, 4))
+    z = pf.add((x, y))
+    npt.assert_allclose(
+        z.freq, np.ones_like(z.freq)*y[..., None] + 1, atol=1e-15)
+    # without broadcasting, in frequency domain
+    x = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
+    y = np.arange(2 * 3 * 4 * 6).reshape((2, 3, 4, 6))
+    z = pf.add((x, y))
+    npt.assert_allclose(
+        z.freq, np.ones_like(z.freq)*y + 1, atol=1e-15)
+
+
 def test_signal_inversion():
     """Test signal inversion with different FFT norms"""
 
@@ -328,6 +358,47 @@ def test_overloaded_operators_frequency_data():
         npt.assert_allclose(z.freq, np.array([8, 4, 2], ndmin=2), atol=1e-15)
 
 
+def test_overloaded_operators_array_and_signal():
+    x = np.arange(2 * 3 * 4).reshape(2, 3, 4) + 1
+    y = Signal(np.ones((2, 3, 4, 5)), 44100, n_samples=8, domain='freq')
+
+    # addition
+    z = x + y
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None] + 1, atol=1e-15)
+    z = y + x
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None] + 1, atol=1e-15)
+    # subtraction
+    z = x - y
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None] - 1, atol=1e-15)
+    z = y - x
+    npt.assert_allclose(
+        z.freq, -1 * (np.ones((2, 3, 4, 5)) * x[..., None] - 1), atol=1e-15)
+    # multiplication
+    z = x * y
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None], atol=1e-15)
+    z = y * x
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None], atol=1e-15)
+    # division
+    z = x / y
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None], atol=1e-15)
+    z = y / x
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) / x[..., None], atol=1e-15)
+    # power
+    z = x**y
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)) * x[..., None], atol=1e-15)
+    z = y**x
+    npt.assert_allclose(
+        z.freq, np.ones((2, 3, 4, 5)), atol=1e-15)
+
+
 def test_assert_match_for_arithmetic():
     s = Signal([1, 2, 3, 4], 44100)
     s1 = Signal([1, 2, 3, 4], 48000)
@@ -346,6 +417,7 @@ def test_assert_match_for_arithmetic():
     assert out[0] == 44100
     assert out[1] == 4
     assert out[2] == 'none'
+    assert out[-1] == (1,)
     out = signal._assert_match_for_arithmetic((s, s4), 'time', division=False)
     assert out[2] == 'rms'
 
@@ -371,7 +443,7 @@ def test_assert_match_for_arithmetic():
 def test_get_arithmetic_data_with_array():
 
     data_in = np.asarray(1)
-    data_out = signal._get_arithmetic_data(data_in, None, None)
+    data_out = signal._get_arithmetic_data(data_in, None, None, (1,))
     npt.assert_allclose(data_in, data_out)
 
 
@@ -403,7 +475,7 @@ def test_get_arithmetic_data_with_signal():
 
             # get output data
             data_out = signal._get_arithmetic_data(
-                s_in, n_samples=3, domain=domain)
+                s_in, n_samples=3, domain=domain, cshape=(1,))
             if domain == 'time':
                 npt.assert_allclose(s_ref.time, data_out, atol=1e-15)
             elif domain == 'freq':
@@ -421,6 +493,20 @@ def test_assert_match_for_arithmetic_data_wrong_domain():
         signal._assert_match_for_arithmetic((1, 1), 'space', division=False)
 
 
+def test_assert_match_for_arithmetic_data_wrong_cshape():
+    x = Signal(np.ones((2, 3, 4)), 44100)
+    y = Signal(np.ones((5, 4)), 44100)
+    with raises(ValueError, match="The cshapes"):
+        signal._assert_match_for_arithmetic((x, y), 'freq', division=False)
+
+
 def test_get_arithmetic_data_wrong_domain():
     with raises(ValueError):
-        signal._get_arithmetic_data(Signal(1, 44100), 1, 'space')
+        signal._get_arithmetic_data(Signal(1, 44100), 1, 'space', (1,))
+
+
+def test_array_broadcasting_error():
+    x = np.arange(2 * 3 * 4 * 11).reshape((2, 3, 4, 11))
+    y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
+    with raises(ValueError):
+        pf.add((x, y), domain='time')

--- a/tests/test_signal_arithmetic.py
+++ b/tests/test_signal_arithmetic.py
@@ -175,33 +175,42 @@ def test_add_frequency_data_and_number_wrong_frequencies():
 
 
 def test_add_array_and_signal():
-    # With broadcasting
+    # shapes match
     x = np.arange(2 * 3 * 4).reshape((2, 3, 4))
     y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
     z = pf.add((x, y))
     npt.assert_allclose(
         z.freq, np.ones_like(z.freq)*x[..., None] + 1, atol=1e-15)
-    # without broadcasting, in frequency domain
-    x = np.arange(2 * 3 * 4 * 6).reshape((2, 3, 4, 6))
+    # broadcasting
+    x = np.arange(3 * 4).reshape((3, 4))
     y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
     z = pf.add((x, y))
     npt.assert_allclose(
-        z.freq, np.ones_like(z.freq)*x + 1, atol=1e-15)
+        z.freq, np.ones_like(z.freq)*x[..., None] + 1, atol=1e-15)
 
 
 def test_add_signal_and_array():
-    # With broadcasting
+    # shapes match
     x = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
     y = np.arange(2 * 3 * 4).reshape((2, 3, 4))
     z = pf.add((x, y))
     npt.assert_allclose(
         z.freq, np.ones_like(z.freq)*y[..., None] + 1, atol=1e-15)
-    # without broadcasting, in frequency domain
+    # broadcasting
     x = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
-    y = np.arange(2 * 3 * 4 * 6).reshape((2, 3, 4, 6))
+    y = np.arange(3 * 4).reshape((3, 4))
     z = pf.add((x, y))
     npt.assert_allclose(
-        z.freq, np.ones_like(z.freq)*y + 1, atol=1e-15)
+        z.freq, np.ones_like(z.freq)*y[..., None] + 1, atol=1e-15)
+
+
+def test_add_arrays():
+    # With broadcasting
+    x = np.arange(2 * 3 * 4).reshape((2, 3, 4))
+    y = np.arange(2 * 3 * 4).reshape((2, 3, 4))
+    z = pf.add((x, y))
+    npt.assert_allclose(
+        z, x + y, atol=1e-15)
 
 
 def test_signal_inversion():
@@ -505,8 +514,13 @@ def test_get_arithmetic_data_wrong_domain():
         signal._get_arithmetic_data(Signal(1, 44100), 1, 'space', (1,))
 
 
-def test_array_broadcasting_error():
-    x = np.arange(2 * 3 * 4 * 11).reshape((2, 3, 4, 11))
+def test_array_broadcasting_errors():
+    x = np.arange(2 * 3 * 4 * 10).reshape((2, 3, 4, 10))
     y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 4)))
-    with raises(ValueError):
+    with raises(ValueError, match="array dimension"):
         pf.add((x, y), domain='time')
+
+    x = np.arange(2 * 3 * 4).reshape((2, 3, 4))
+    y = pf.signals.impulse(10, amplitude=np.ones((2, 3, 5)))
+    with raises(ValueError):
+        pf.add((x, y))


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #317

### Changes proposed in this pull request:

- clarifies arithmetic operations including arrays and audio objects by implementing broadcasting rules
- fixed error for overloaded operators in operations, where the array is first
- add tests for both
- updated docs and concepts