### PR TITLE
Test if sphinx build is succesful

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-base
       - python/install-packages:
           pkg-manager: pip
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-recommended
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-extra
       - python/install-packages:
           pkg-manager: pip
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,7 @@ jobs:
           command: |
             pip install -e .
             cd docs/
-            make html
+            make html SPHINXOPTS="-W"
 
   test_pypi_publish:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,32 @@ jobs:
             pip install -e .
             pytest --nbmake examples/*.ipynb
 
+  test_documentation_build:
+    parameters:
+      version:
+        description: "version tag"
+        default: "latest"
+        type: string
+    executor:
+      name: python-docker
+      version: <<parameters.version>>
+
+    steps:
+      - checkout
+      - run:
+          name: Install System Dependencies
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1
+      - python/install-packages:
+          pkg-manager: pip
+          # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.
+          pip-dependency-file: requirements_dev.txt
+      - run:
+          name: Sphinx
+          command: |
+            pip install -e .
+            cd docs/
+            make html
+
   test_pypi_publish:
     parameters:
       version:
@@ -147,6 +173,15 @@ workflows:
                 - "3.9"
           requires:
             - build_and_test
+
+      - test_documentation_build:
+          matrix:
+            parameters:
+              version:
+                - "3.9"
+          requires:
+            - build_and_test
+
 
   test_and_publish:
     # Test and publish on new git version tags

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-base
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-recommended
       - python/install-packages:
           pkg-manager: pip
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-extra
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-extra dvipng
       - python/install-packages:
           pkg-manager: pip
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,6 +230,20 @@ workflows:
             tags:
               only: /^v[0-9]+(\.[0-9]+)*$/
 
+      - test_documentation_build:
+          matrix:
+            parameters:
+              version:
+                - "3.9"
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)*$/
+
       - test_pypi_publish:
           matrix:
             parameters:
@@ -239,6 +253,7 @@ workflows:
             - build_and_test
             - flake
             - test_examples
+            - test_documentation_build
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
       - checkout
       - run:
           name: Install System Dependencies
-          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-recommended
+          command: sudo apt-get update && sudo apt-get install -y libsndfile1 texlive-latex-recommended
       - python/install-packages:
           pkg-manager: pip
           # app-dir: ~/project/package-directory/  # If you're requirements.txt isn't in the root directory.


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #314 

### Changes proposed in this pull request:

Test building the Sphinx documentation

This will not check if the generated HTML documents are valid nor will it validate against a reference.
It will merely fail on:
- broken example code
- Sphinx build errors

Building the docs on CircleCI required adding about 400 megabytes of latex packages.
It's probably better to add them to the Docker container in the future. This probably requires a custom one though.
