### PR TITLE
Fix wrong default value for resample function

### DIFF
--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -446,7 +446,7 @@ def fractional_time_shift(signal, shift, unit="samples", order=30,
     return signal
 
 
-def resample(signal, sampling_rate, match_amplitude="time", frac_limit=None):
+def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None):
     """Resample signal to new sampling rate.
 
     The SciPy function ``scipy.signal.resample_poly`` is used for resampling.

--- a/tests/test_dsp_resample.py
+++ b/tests/test_dsp_resample.py
@@ -116,7 +116,7 @@ def test_resample_multidimensional_impulse():
     signal = pf.signals.impulse(N, 64, amplitude=[[1, 2, 3], [4, 5, 6]],
                                 sampling_rate=fs_1)
     # Get resampled Signal with function
-    resampled = pf.dsp.resample(signal, fs_2)
+    resampled = pf.dsp.resample(signal, fs_2, 'time')
     # Test the cshape
     assert signal.cshape == resampled.cshape
     # Calculated the analytic signal with sinc function


### PR DESCRIPTION
### Changes proposed in this pull request:

The default for `match_amplitude` should be `'auto'` but was `'time'`.