### PR TITLE
Insert prefix_return in dB function

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1384,7 +1384,7 @@ def convolve(signal1, signal2, mode='full', method='overlap_add'):
 
 
 def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
-            prefix_return=False):
+            return_prefix=False):
     r"""Convert data of the selected signal domain into decibels (dB).
 
     The converted data is calculated by the base 10 logarithmic scale:
@@ -1445,8 +1445,8 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
         +---------------------------------+--------------+
 
         The default is 1.
-    prefix_return : bool, optional
-        If prefix_return is ``True``, the function will also return the
+    return_prefix : bool, optional
+        If return_prefix is ``True``, the function will also return the
         `log_prefix` value. This can be used to delogrithmize the data. The
         default is ``False``.
     Returns
@@ -1454,7 +1454,7 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
     decibel : numpy.ndarray
         The given signal in decibel in chosen domain.
     log_prefix : int or float
-        Will be returned if `prefix_return` is set to ``True``.
+        Will be returned if `return_prefix` is set to ``True``.
 
     Examples
     --------
@@ -1494,7 +1494,7 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
             f"Domain is '{domain}', but has to be 'time', 'freq',"
             " or 'freq_raw'.")
     data[data == 0] = np.finfo(float).eps
-    if prefix_return is True:
+    if return_prefix is True:
         return log_prefix * np.log10(np.abs(data) / log_reference), log_prefix
     else:
         return log_prefix * np.log10(np.abs(data) / log_reference)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1454,7 +1454,7 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
     decibel : numpy.ndarray
         The given signal in decibel in chosen domain.
     log_prefix : int or float
-        Will be returned if prefix_return is set to ``True``.
+        Will be returned if `prefix_return` is set to ``True``.
 
     Examples
     --------

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1447,7 +1447,7 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
         The default is 1.
     prefix_return : bool, optional
         If prefix_return is ``True``, the function will also return the
-        log_prefix value. This can be used to delogrithmize the data. The
+        `log_prefix` value. This can be used to delogrithmize the data. The
         default is ``False``.
     Returns
     -------

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1383,7 +1383,8 @@ def convolve(signal1, signal2, mode='full', method='overlap_add'):
         res, signal1.sampling_rate, domain='time', fft_norm=fft_norm)
 
 
-def decibel(signal, domain='freq', log_prefix=None, log_reference=1):
+def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
+            prefix_return=False):
     r"""Convert data of the selected signal domain into decibels (dB).
 
     The converted data is calculated by the base 10 logarithmic scale:
@@ -1444,10 +1445,16 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1):
         +---------------------------------+--------------+
 
         The default is 1.
+    prefix_return : bool, optional
+        If prefix_return is ``True``, the function will also return the 
+        log_prefix value. This can be used to delogrithmize the data. The 
+        default is ``False``.
     Returns
     -------
     decibel : numpy.ndarray
         The given signal in decibel in chosen domain.
+    log_prefix : int or float
+        Will be returned if prefix_return is set to ``True``.
 
     Examples
     --------
@@ -1487,4 +1494,7 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1):
             f"Domain is '{domain}', but has to be 'time', 'freq',"
             " or 'freq_raw'.")
     data[data == 0] = np.finfo(float).eps
-    return log_prefix * np.log10(np.abs(data) / log_reference)
+    if prefix_return is True:
+        return log_prefix * np.log10(np.abs(data) / log_reference), log_prefix
+    else:
+        return log_prefix * np.log10(np.abs(data) / log_reference)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1446,8 +1446,8 @@ def decibel(signal, domain='freq', log_prefix=None, log_reference=1,
 
         The default is 1.
     prefix_return : bool, optional
-        If prefix_return is ``True``, the function will also return the 
-        log_prefix value. This can be used to delogrithmize the data. The 
+        If prefix_return is ``True``, the function will also return the
+        log_prefix value. This can be used to delogrithmize the data. The
         default is ``False``.
     Returns
     -------

--- a/tests/test_dsp_decibel.py
+++ b/tests/test_dsp_decibel.py
@@ -54,7 +54,7 @@ def test_decibel_FrequencyData():
         pf.dsp.decibel(test_FreqData, domain='time')
 
 
-def test_prefix_return():
+def test_return_prefix():
     test_signal = pf.Signal([0, 1, 0], sampling_rate=44100, fft_norm='power')
-    dB_sig, prefix = pf.dsp.decibel(test_signal, prefix_return=True)
+    dB_sig, prefix = pf.dsp.decibel(test_signal, return_prefix=True)
     assert prefix == 10

--- a/tests/test_dsp_decibel.py
+++ b/tests/test_dsp_decibel.py
@@ -52,3 +52,9 @@ def test_decibel_FrequencyData():
     # Test wrong domain input
     with raises(ValueError, match="Domain is 'time' and signal is type"):
         pf.dsp.decibel(test_FreqData, domain='time')
+
+
+def test_prefix_return():
+    test_signal = pf.Signal([0, 1, 0], sampling_rate=44100, fft_norm='power')
+    dB_sig, prefix = pf.dsp.decibel(test_signal, prefix_return=True)
+    assert prefix == 10


### PR DESCRIPTION
New Parameter 'prefix_return' in dB function.
Default False will do nothing.
Set True and the function will also return 'log_prefix'.

Added, because it is used in two functions currently being developed in branches (normalization and soft limiting)