### PR TITLE
add aliasing suppression to resample function

### DIFF
--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -447,7 +447,7 @@ def fractional_time_shift(signal, shift, unit="samples", order=30,
 
 
 def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
-             suppress_artifacts=False):
+             post_filter=False):
     """Resample signal to new sampling rate.
 
     The SciPy function ``scipy.signal.resample_poly`` is used for resampling.
@@ -496,7 +496,7 @@ def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
         realizing the target sampling rate.
 
         The default is ``None``, which uses ``frac_limit = 1e6``.
-    suppress_artifacts : bool, optional
+    post_filter : bool, optional
         In some cases the up-sampling causes artifacts above the Nyquist
         frequency of the input signal, i.e., ``signal.sampling_rate/2``. If
         ``True`` the artifacts are suppressed by applying a zero-phase Elliptic
@@ -605,7 +605,7 @@ def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
     data = pf.Signal(data * gain, sampling_rate, fft_norm=signal.fft_norm,
                      comment=signal.comment)
 
-    if suppress_artifacts and L > 1:
+    if post_filter and L > 1:
 
         # Design elliptic filter
         # (pass band is given by nyquist frequency of input signal, other

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -447,7 +447,7 @@ def fractional_time_shift(signal, shift, unit="samples", order=30,
 
 
 def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
-             suppress_aliasing=False):
+             suppress_artifacts=False):
     """Resample signal to new sampling rate.
 
     The SciPy function ``scipy.signal.resample_poly`` is used for resampling.
@@ -496,7 +496,7 @@ def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
         realizing the target sampling rate.
 
         The default is ``None``, which uses ``frac_limit = 1e6``.
-    suppress_aliasing : bool, optional
+    suppress_artifacts : bool, optional
         In some cases the up-sampling causes artifacts above the Nyquist
         frequency of the input signal, i.e., ``signal.sampling_rate/2``. If
         ``True`` the artifacts are suppressed by applying a zero-phase Elliptic
@@ -605,7 +605,7 @@ def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
     data = pf.Signal(data * gain, sampling_rate, fft_norm=signal.fft_norm,
                      comment=signal.comment)
 
-    if suppress_aliasing and L > 1:
+    if suppress_artifacts and L > 1:
 
         # Design elliptic filter
         # (pass band is given by nyquist frequency of input signal, other

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -500,10 +500,11 @@ def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
         Suppress aliased energy above the Nyquist frequency of the input
         signal, i.e., ``signal.sampling_rate/2``. This is recommended, and is
         realized by applying a zero-phase Elliptic filter with a pass band
-        ripple of 0.1 dB, a stop band attenuation of 60 dB, and pass/stop
-        band frequencies of ``signal.sampling_rate/2`` and
-        ``min(1, 1.05 * signal.sampling_rate/2)`` Hz. Note that this is only
-        applied in case of up-sampling.
+        ripple of 0.1 dB, a stop band attenuation of 60 dB. The pass band edge
+        frequency is ``signal.sampling_rate/2``. The stop band edge frequency
+        is the minimum of 1.05 times the pass band frequency and the new
+        Nyquist frequency (``sampling_rate/2``). The default is ``True``. Note
+        that this is only applied in case of up-sampling.
 
     Returns
     -------

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -447,7 +447,7 @@ def fractional_time_shift(signal, shift, unit="samples", order=30,
 
 
 def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
-             suppress_aliasing=True):
+             suppress_aliasing=False):
     """Resample signal to new sampling rate.
 
     The SciPy function ``scipy.signal.resample_poly`` is used for resampling.
@@ -497,14 +497,15 @@ def resample(signal, sampling_rate, match_amplitude="auto", frac_limit=None,
 
         The default is ``None``, which uses ``frac_limit = 1e6``.
     suppress_aliasing : bool, optional
-        Suppress aliased energy above the Nyquist frequency of the input
-        signal, i.e., ``signal.sampling_rate/2``. This is recommended, and is
-        realized by applying a zero-phase Elliptic filter with a pass band
-        ripple of 0.1 dB, a stop band attenuation of 60 dB. The pass band edge
-        frequency is ``signal.sampling_rate/2``. The stop band edge frequency
-        is the minimum of 1.05 times the pass band frequency and the new
-        Nyquist frequency (``sampling_rate/2``). The default is ``True``. Note
-        that this is only applied in case of up-sampling.
+        In some cases the up-sampling causes artifacts above the Nyquist
+        frequency of the input signal, i.e., ``signal.sampling_rate/2``. If
+        ``True`` the artifacts are suppressed by applying a zero-phase Elliptic
+        filter with a pass band ripple of 0.1 dB, a stop band attenuation of 60
+        dB. The pass band edge frequency is ``signal.sampling_rate/2``. The
+        stop band edge frequency is the minimum of 1.05 times the pass band
+        frequency and the new Nyquist frequency (``sampling_rate/2``). The
+        default is ``False``. Note that this is only applied in case of
+        up-sampling.
 
     Returns
     -------

--- a/tests/test_dsp_resample.py
+++ b/tests/test_dsp_resample.py
@@ -12,7 +12,7 @@ def test_resampling(L):
     fs_1 = 48000
     fs_2 = L*fs_1
     signal = pf.signals.noise(1024, sampling_rate=fs_1)
-    resampled_sig = pf.dsp.resample(signal, fs_2, suppress_aliasing=False)
+    resampled_sig = pf.dsp.resample(signal, fs_2, suppress_artifacts=False)
     # asserts the sample length
     assert L*signal.n_samples == resampled_sig.n_samples
     # asserts the length of time of the signals
@@ -30,7 +30,7 @@ def test_upsampling_delayed_impulse():
     signal = pf.signals.impulse(N, 64, sampling_rate=fs_1)
     # Get resampled Signal with function
     resampled = pf.dsp.resample(signal, fs_2, match_amplitude="time",
-                                suppress_aliasing=False)
+                                suppress_artifacts=False)
     # Calculated the analytic signal with sinc function
     L = fs_2 / fs_1
     n = np.arange(-N/2, N/2, 1/L)
@@ -102,7 +102,7 @@ def test_frequency_matching():
     N = 128
     signal = pf.signals.impulse(N, 64, sampling_rate=fs_1)
     resampled = pf.dsp.resample(signal, fs_2, match_amplitude="freq",
-                                suppress_aliasing=False)
+                                suppress_artifacts=False)
     np.testing.assert_almost_equal(resampled.freq[0][:int(N/2)-10],
                                    signal.freq[0][:int(N/2)-10], decimal=2)
 
@@ -118,7 +118,7 @@ def test_resample_multidimensional_impulse():
     signal = pf.signals.impulse(N, 64, amplitude=[[1, 2, 3], [4, 5, 6]],
                                 sampling_rate=fs_1)
     # Get resampled Signal with function
-    resampled = pf.dsp.resample(signal, fs_2, 'time', suppress_aliasing=False)
+    resampled = pf.dsp.resample(signal, fs_2, 'time', suppress_artifacts=False)
     # Test the cshape
     assert signal.cshape == resampled.cshape
     # Calculated the analytic signal with sinc function
@@ -138,8 +138,8 @@ def test_resample_suppress_aliasing():
     # test signal
     signal = pf.signals.impulse(1024, 512)
     # measure impulse response of anti-aliasing filter
-    true = pf.dsp.resample(signal, 48000, suppress_aliasing=True)
-    false = pf.dsp.resample(signal, 48000, suppress_aliasing=False)
+    true = pf.dsp.resample(signal, 48000, suppress_artifacts=True)
+    false = pf.dsp.resample(signal, 48000, suppress_artifacts=False)
     diff = true / false
 
     phase = pf.dsp.phase(diff)

--- a/tests/test_dsp_resample.py
+++ b/tests/test_dsp_resample.py
@@ -1,7 +1,6 @@
 import pyfar as pf
 import pytest
 import numpy as np
-import numpy.testing as npt
 
 
 @pytest.mark.parametrize('L', [2, 0.5])
@@ -134,6 +133,7 @@ def test_resample_multidimensional_impulse():
 
 
 def test_resample_suppress_aliasing():
+    """Test the aliasing suppression filter"""
 
     # test signal
     signal = pf.signals.impulse(1024, 512)
@@ -157,4 +157,3 @@ def test_resample_suppress_aliasing():
     # below -50 dB possibly due to the finite length of the signal)
     idx_stop = diff.find_nearest_frequency(22050 * 1.05)
     assert np.all(mag[..., idx_stop + 1:] < -50)
-

--- a/tests/test_dsp_resample.py
+++ b/tests/test_dsp_resample.py
@@ -12,7 +12,7 @@ def test_resampling(L):
     fs_1 = 48000
     fs_2 = L*fs_1
     signal = pf.signals.noise(1024, sampling_rate=fs_1)
-    resampled_sig = pf.dsp.resample(signal, fs_2, suppress_artifacts=False)
+    resampled_sig = pf.dsp.resample(signal, fs_2, post_filter=False)
     # asserts the sample length
     assert L*signal.n_samples == resampled_sig.n_samples
     # asserts the length of time of the signals
@@ -30,7 +30,7 @@ def test_upsampling_delayed_impulse():
     signal = pf.signals.impulse(N, 64, sampling_rate=fs_1)
     # Get resampled Signal with function
     resampled = pf.dsp.resample(signal, fs_2, match_amplitude="time",
-                                suppress_artifacts=False)
+                                post_filter=False)
     # Calculated the analytic signal with sinc function
     L = fs_2 / fs_1
     n = np.arange(-N/2, N/2, 1/L)
@@ -102,7 +102,7 @@ def test_frequency_matching():
     N = 128
     signal = pf.signals.impulse(N, 64, sampling_rate=fs_1)
     resampled = pf.dsp.resample(signal, fs_2, match_amplitude="freq",
-                                suppress_artifacts=False)
+                                post_filter=False)
     np.testing.assert_almost_equal(resampled.freq[0][:int(N/2)-10],
                                    signal.freq[0][:int(N/2)-10], decimal=2)
 
@@ -118,7 +118,7 @@ def test_resample_multidimensional_impulse():
     signal = pf.signals.impulse(N, 64, amplitude=[[1, 2, 3], [4, 5, 6]],
                                 sampling_rate=fs_1)
     # Get resampled Signal with function
-    resampled = pf.dsp.resample(signal, fs_2, 'time', suppress_artifacts=False)
+    resampled = pf.dsp.resample(signal, fs_2, 'time', post_filter=False)
     # Test the cshape
     assert signal.cshape == resampled.cshape
     # Calculated the analytic signal with sinc function
@@ -138,8 +138,8 @@ def test_resample_suppress_aliasing():
     # test signal
     signal = pf.signals.impulse(1024, 512)
     # measure impulse response of anti-aliasing filter
-    true = pf.dsp.resample(signal, 48000, suppress_artifacts=True)
-    false = pf.dsp.resample(signal, 48000, suppress_artifacts=False)
+    true = pf.dsp.resample(signal, 48000, post_filter=True)
+    false = pf.dsp.resample(signal, 48000, post_filter=False)
     diff = true / false
 
     phase = pf.dsp.phase(diff)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #328 

### Changes proposed in this pull request:

add aliasing suppression to resample function. To see this in action, e.g., use

```python
import pyfar as pf

signal = pf.signals.noise(512, seed=7)

true = pf.dsp.resample(signal, 48000, suppress_aliasing=True)
false = pf.dsp.resample(signal, 48000, suppress_aliasing=False)

pf.plot.time_freq(false, label="false")
ax = pf.plot.time_freq(true, label="true")

ax[1].legend()
```
![supression](https://user-images.githubusercontent.com/58219902/181783371-e81ed23a-886e-42a5-a2c5-3085dd202e32.png)

