### PR TITLE
Add environment.yml for mybinder.org.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+name: pyfar
+channels:
+  - defaults
+  - conda-forge
+dependencies:
+  - numpy>=1.14.0
+  - matplotlib
+  - libsndfile
+  - pip:
+    - urllib3
+    - deepdiff
+    - soundfile
+    - sofar>=0.1.2
+    - pyfar

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,10 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - pip
   - numpy>=1.14.0
   - matplotlib
+  - scipy>=1.5.0
   - libsndfile
   - pip:
     - urllib3


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #337 

### Changes proposed in this pull request:

- Add a specific and complete enviroment.yml for mybinder to install non python packages via conda.
- This PR does not require a new version of pyfar, as it only affects running the example notebook on mybinder.org

The mybinder.org link for this branch is found here:
https://mybinder.org/v2/gh/pyfar/pyfar/bugfix/libsndfile_mybinder?filepath=examples%2Fpyfar_demo.ipynb

Setting up can take a bit longer due to the custom conda environment. There's also options to use apt, but I'm expecting that this will result in similar setup times. Using the conda environment is more accessible to non-unix users.
