### PR TITLE
Deprecate/python 3.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"
@@ -192,7 +191,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.7"
                 - "3.8"
                 - "3.9"
                 - "3.10"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -20,6 +20,6 @@ formats:
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.10
   install:
     - requirements: requirements_dev.txt

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ Use pip to install pyfar
 
     $ pip install pyfar
 
-(Requires Python 3.7, 3.8 or 3.9)
+(Requires Python 3.8 or higher)
 
 Audio file reading/writing is supported through `SoundFile`_, which is based on `libsndfile`_. On Windows and OS X, it will be installed automatically. On Linux, you need to install libsndfile using your distribution’s package manager, for example ``sudo apt-get install libsndfile1``.
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10'
@@ -63,5 +62,5 @@ setup(
     url='https://github.com/pyfar/pyfar',
     version='0.4.3',
     zip_safe=False,
-    python_requires='>=3.7'
+    python_requires='>=3.8'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = py37, py38, py39, flake8, examples, build, wheel
+envlist = py38, py39, py310, flake8, examples, build, wheel
 
 [travis]
 python =
-    3.9: build, wheel, examples
-    3.8: build, wheel, examples, flake8
-    3.7: build, wheel, examples
+    3.10: build, wheel, examples
+    3.9: build, wheel, examples, flake8
+    3.8: build, wheel, examples
 
 # Test examples notebook
 [testenv:examples]


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #347 

### Changes proposed in this pull request:

remove support and testing for Python 3.7