### PR TITLE
Specify the plot backend in deprecation tests

### DIFF
--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -20,6 +20,9 @@ from unittest.mock import patch
 import pyfar as pf
 import pyfar.dsp.filter as pfilt
 
+# This defines the plot size and the backend
+from pyfar.testing.plot_utils import create_figure
+
 
 # deprecate in 0.5.0 ----------------------------------------------------------
 def test_get_nearest_deprecations():
@@ -126,11 +129,13 @@ def test_xscale_deprecation(function, handsome_signal):
 
     with pytest.warns(PendingDeprecationWarning,
                       match="The xscale parameter will be removed"):
+        create_figure()
         function(handsome_signal, xscale='linear')
 
     if version.parse(pf.__version__) >= version.parse('0.6.0'):
         with pytest.raises(AttributeError):
             # remove xscale from pyfar 0.6.0!
+            create_figure()
             function(handsome_signal)
 
 
@@ -139,11 +144,13 @@ def test_spectrogram_yscale_deprecation(sine):
 
     with pytest.warns(PendingDeprecationWarning,
                       match="The yscale parameter will be removed"):
+        create_figure()
         pf.plot.spectrogram(sine, yscale='linear')
 
     if version.parse(pf.__version__) >= version.parse('0.6.0'):
         with pytest.raises(AttributeError):
             # remove xscale from pyfar 0.6.0!
+            create_figure()
             pf.plot.spectrogram(sine)
 
 
@@ -152,9 +159,11 @@ def test__check_time_unit():
 
     with pytest.warns(PendingDeprecationWarning,
                       match="unit=None will be deprecated"):
+        create_figure()
         pf.plot._utils._check_time_unit(None)
 
     if version.parse(pf.__version__) >= version.parse('0.6.0'):
         with pytest.raises(ValueError):
             # remove xscale from pyfar 0.6.0!
+            create_figure()
             pf.plot._utils._check_time_unit(None)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -90,6 +90,7 @@ def test_line_phase_options(param, handsome_signal):
 
 def test_line_phase_unwrap_assertion(sine):
     """Test assertion for unwrap parameter."""
+    create_figure()
     with raises(ValueError):
         plot.phase(sine, unwrap='infinity')
 
@@ -140,6 +141,7 @@ def test_line_freq_scale_assertion(function, sine):
     Test if all line plots raise an assertion for a wrong scale parameter.
     """
 
+    create_figure()
     with raises(ValueError):
         function(sine, freq_scale="warped")
 
@@ -164,6 +166,7 @@ def test_time_unit(function, unit, handsome_signal):
 def test_time_unit_assertion(sine):
     """Test if all line plots raise an assertion for a wrong unit parameter."""
 
+    create_figure()
     with raises(ValueError):
         plot.time(sine, unit="pascal")
 
@@ -314,6 +317,7 @@ def test_2d_colorbar_assertion(function, handsome_signal_2d):
     """
     Test assertion when passing an array of axes but not having a colorbar.
     """
+    create_figure()
     with raises(ValueError, match="A list of axes"):
         function(handsome_signal_2d, colorbar=False,
                  ax=[plt.gca(), plt.gca()])
@@ -328,6 +332,7 @@ def test_2d_cshape_assertion(function):
     Test assertion when passing a signal with wrong cshape.
     """
     error_str = r"signal.cshape must be \(m, \) with m\>=2 but is \(2, 2\)"
+    create_figure()
     with raises(ValueError, match=error_str):
         function(pf.signals.impulse(10, [[0, 0], [0, 0]]))
 
@@ -349,6 +354,7 @@ def test_2d_phase_options(param, handsome_signal_2d):
 
 def test_phase_2d_unwrap_assertion(handsome_signal_2d):
     """Test assertion for unwrap parameter."""
+    create_figure()
     with raises(ValueError):
         plot.phase_2d(handsome_signal_2d, unwrap='infinity')
 
@@ -397,6 +403,7 @@ def test_2d_freq_scale_assertion(handsome_signal_2d):
     Test if all 2d plots raise an assertion for a wrong scale parameter.
     """
 
+    create_figure()
     with raises(ValueError):
         plot.freq_2d(handsome_signal_2d, freq_scale="warped")
 
@@ -427,6 +434,7 @@ def test_2d_time_unit(function, unit, handsome_signal_2d):
 def test_2d_time_unit_assertion(handsome_signal_2d):
     """Test if all 2d plots raise an assertion for a wrong unit parameter."""
 
+    create_figure()
     with raises(ValueError):
         plot.time_2d(handsome_signal_2d, unit="pascal")
 
@@ -482,6 +490,7 @@ def test_2d_contourf(function, handsome_signal_2d):
     (plot.time_freq_2d), (plot.freq_phase_2d), (plot.freq_group_delay_2d)])
 def test_2d_method_assertion(function, handsome_signal_2d):
     """Test 2d plots method assertion ."""
+    create_figure()
     with raises(ValueError, match="method must be"):
         function(handsome_signal_2d, method='pcontourmesh')
 

--- a/tests/test_plot_interaction.py
+++ b/tests/test_plot_interaction.py
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 import pyfar as pf
 import pyfar.plot._interaction as ia
 from pyfar.plot._utils import _get_quad_mesh_from_axis
+from pyfar.testing.plot_utils import create_figure
 
 # use non showing backend for speed
 mpl.use("Agg")
@@ -143,6 +144,9 @@ def test_interaction_attached():
     # with at least two channels)
     signal = pf.signals.impulse(1024, [0, 0])
 
+    # Use create figure to specify the plot backend
+    create_figure()
+
     # loop functions
     for function in getmembers(pf.plot.line, isfunction) + \
             getmembers(pf.plot.two_d, isfunction):
@@ -170,6 +174,9 @@ def test_toggle_plots(plot_type, initial_function, function_list):
     # dummy signal (needs to as longe as the default spectrogram block size
     # with at least two channels)
     signal = pf.signals.impulse(1024, [0, 1000])
+
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # initital plot
     ax = initial_function(signal)
@@ -229,6 +236,8 @@ def test_interaction_not_allowed(plot, signal, shortcut):
     Test interactions that are not allowed are caught.
     Can be extended if required in the future.
     """
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # plot signal
     ax = plot(signal)
@@ -255,6 +264,8 @@ def test_interaction_not_allowed(plot, signal, shortcut):
 def test_get_new_axis_limits(ax_type, operation, direction,
                              limits, new_limits):
     """Test calculation of new axis limits for all parameter combinations."""
+    # Use create figure to specify the plot backend
+    create_figure()
 
     test_limits = ia.get_new_axis_limits(
         limits, ax_type, operation, direction)
@@ -272,6 +283,8 @@ def test_move_and_zoom_linear():
     if the pyfar.plot._interaction.PlotParameter are set correctly in
     pyfar.plot.function.
     """
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # initialize the plot
     signal = pf.signals.impulse(1024)
@@ -335,6 +348,8 @@ def test_toggle_x_axis():
     if the pyfar.plot._interaction.PlotParameter are set correctly in
     pyfar.plot.function.
     """
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # init the plot
     ax = pf.plot.freq(pf.Signal([1, 2, 3, 4, 5], 44100))
@@ -356,6 +371,8 @@ def test_toggle_y_axis():
     if the pyfar.plot._interaction.PlotParameter are set correctly in
     pyfar.plot.function.
     """
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # init the plot
     ax = pf.plot.freq(pf.Signal([1, 2, 3, 4, 5], 44100))
@@ -377,6 +394,8 @@ def test_toggle_colormap():
     if the pyfar.plot._interaction.PlotParameter are set correctly in
     pyfar.plot.function.
     """
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # init the plot
     ax, *_ = pf.plot.spectrogram(pf.signals.impulse(1024))
@@ -396,6 +415,9 @@ def test_toggle_orientation_2d_plots():
     Test if the orientation is toggled by comparing the axis labels before
     and after toggling.
     """
+    # Use create figure to specify the plot backend
+    create_figure()
+
 
     signal = pf.signals.impulse(1024, [0, 1000])
     key = sc_ctr["toggle_orientation"]["key"][0]
@@ -446,6 +468,8 @@ def test_toggle_orientation_2d_plots():
 
 def test_cycle_and_toggle_lines_1d_signal():
     """Test toggling and cycling channels of a one-dimensional Signal."""
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # init and check start conditions
     signal = pf.Signal([[1, 0], [2, 0]], 44100)
@@ -479,6 +503,8 @@ def test_cycle_and_toggle_lines_1d_signal():
 
 def test_cycle_and_toggle_lines_2d_signal():
     """Test toggling and cycling channels of a two-dimensional Signal."""
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # init and check start conditions
     signal = pf.signals.impulse(10, [[1, 2], [3, 4]])
@@ -515,6 +541,8 @@ def test_cycle_and_toggle_lines_2d_signal():
 
 def test_cycle_and_toggle_signals():
     """Test toggling and cycling Signal slices."""
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # init and check start conditions
     signal = pf.signals.impulse(1024, amplitude=[1, 2])
@@ -543,6 +571,8 @@ def test_cycle_and_toggle_signals():
 
 def test_cycle_plot_styles():
     """Test cycle the plot styles between line and 2d plots."""
+    # Use create figure to specify the plot backend
+    create_figure()
 
     # dummy signal (needs to as longe as the default spectrogram block size
     # with at least two channels)


### PR DESCRIPTION
### Changes proposed in this pull request:

Use `create_figure()` from the testing module to specify the plot backend and limit figure size
