### PR TITLE
Fix warnings in tests

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1366,7 +1366,7 @@ def find_impulse_response_start(
     """
     ir_squared = np.abs(impulse_response.time)**2
 
-    mask_start = np.int(0.9*impulse_response.n_samples)
+    mask_start = int(0.9*impulse_response.n_samples)
 
     mask = np.arange(mask_start, ir_squared.shape[-1])
     noise = np.mean(np.take(ir_squared, mask, axis=-1), axis=-1)

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -351,6 +351,7 @@ def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         times = times * factor
 
     # plot the data
+    ax[0].grid(False)
     qm = ax[0].pcolormesh(times, frequencies, spectrogram, **kwargs)
 
     # Adjust axes:
@@ -394,5 +395,6 @@ def _plot_2d(x, y, data, method, ax, **kwargs):
                     kwargs["vmin"], kwargs["vmax"], kwargs["levels"])
         qm = ax.contourf(x, y, data, **kwargs)
     else:
+        ax.grid(False)
         qm = ax.pcolormesh(x, y, data, **kwargs)
     return qm

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -131,7 +131,8 @@ def test_domain_setter_time_when_time():
 
 
 def test_domain_setter_time_when_freq():
-    signal = Signal([1, 2, 3, 4], 44100, domain='freq', fft_norm='rms')
+    with pytest.warns(UserWarning, match="Number of time samples"):
+        signal = Signal([1, 2, 3, 4], 44100, domain='freq', fft_norm='rms')
     domain = 'time'
     signal.domain = domain
     assert signal.domain == domain
@@ -200,20 +201,15 @@ def test_getter_freq():
 
 
 def test_setter_freq():
-    """Test if attribute freq is set correctly."""
+    """Test if attribute freq is set correctly and for the warning for
+    estimating the number of samples from n_bins."""
     signal = Signal([1, 2, 3], 44100, fft_norm='amplitude')
-    signal.freq = np.array([[1., 2., 3.]])
+    with pytest.warns(UserWarning, match="Number of frequency bins"):
+        signal.freq = np.array([[1., 2., 3.]])
     assert signal.domain == 'freq'
     desired = signal.n_samples * np.array([[1., 2./2, 3.]])
     npt.assert_allclose(signal._data, desired)
     npt.assert_allclose(signal.freq, np.array([[1., 2., 3.]]))
-
-
-def test_re_setter_freq():
-    """Test the warning for estimating the number of samples from n_bins."""
-    signal = Signal([1, 2, 3], 44100, domain='freq', n_samples=4)
-    with pytest.warns(UserWarning):
-        signal.freq = [1, 2, 3, 4]
 
 
 def test_getter_sampling_rate():
@@ -471,17 +467,11 @@ def test_freq_raw():
 
 def test_setter_freq_raw():
     """Test if attribute freq_raw is set correctly."""
-    signal = Signal([1, 2, 3], 44100, fft_norm='amplitude')
-    signal.freq_raw = np.array([[1., 2., 3.]])
+    signal = Signal([1, 2, 3], 44100, fft_norm='amplitude', n_samples=4)
+    with pytest.warns(UserWarning, match="Number of frequency bins"):
+        signal.freq_raw = np.array([[1., 2., 3.]])
     assert signal.domain == 'freq'
     npt.assert_allclose(signal._data, np.array([[1., 2., 3.]]))
-
-
-def test_setter_freq_raw_warning():
-    """Test the warning for estimating the number of samples from n_bins."""
-    signal = Signal([1, 2, 3], 44100, domain='freq', n_samples=4)
-    with pytest.warns(UserWarning, match="Number of frequency bins changed"):
-        signal.freq_raw = [1, 2, 3, 4]
 
 
 def test_setter_freq_raw_dtype():

--- a/tests/test_dsp_interpolation.py
+++ b/tests/test_dsp_interpolation.py
@@ -348,7 +348,8 @@ def test_interpolate_spectrum_fscale():
     # generate interpolator with logarithmic frequency
     interpolator_log = InterpolateSpectrum(
         data, "magnitude", ("linear", "linear", "linear"), fscale="log")
-    _ = interpolator_log(n_samples, sampling_rate)
+    with pytest.warns(RuntimeWarning):
+        _ = interpolator_log(n_samples, sampling_rate)
 
     # test frequency vectors
     npt.assert_allclose(interpolator_lin._f_in, f_in_lin)

--- a/tests/test_fractional_octaves.py
+++ b/tests/test_fractional_octaves.py
@@ -65,8 +65,10 @@ def test_fractional_coeff_oct_filter_iec():
     sr = 16e3
     order = 6
 
-    actual = filter.fractional_octaves._coefficients_fractional_octave_bands(
-        sr, 1, freq_range=(5e3, 20e3), order=order)
+    with pytest.warns(UserWarning, match="Skipping bands"):
+        actual = filter.fractional_octaves. \
+                    _coefficients_fractional_octave_bands(
+                        sr, 1, freq_range=(5e3, 20e3), order=order)
 
     assert actual.shape == (1, order, 6)
 

--- a/tests/test_orientations.py
+++ b/tests/test_orientations.py
@@ -1,4 +1,4 @@
-from pytest import raises
+from pytest import raises, warns
 
 import numpy as np
 import numpy.testing as npt
@@ -53,7 +53,8 @@ def test_orientations_from_view_up_invalid():
     views = [[1, 0, 0], [0, 0]]
     ups = [[0, 1, 0], [0, 0, 0]]
     with raises(ValueError):
-        Orientations.from_view_up(views, ups)
+        with warns(np.VisibleDeprecationWarning):
+            Orientations.from_view_up(views, ups)
     # any of views and ups has zero-length
     views = [[1, 0, 0], [0, 0, 1]]
     ups = [[0, 1, 0], [0, 0, 0]]

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -300,12 +300,20 @@ def test_2d_colorbar_options(function, colorbar, handsome_signal_2d):
     fig = create_figure()
     if colorbar == "off":
         # test not plotting a colorbar
-        function(signal, colorbar=False)
+        if function == plot.spectrogram:
+            with pytest.warns(UserWarning, match="Using only the first"):
+                function(signal, colorbar=False)
+        else:
+            function(signal, colorbar=False)
     elif colorbar == "axes":
         # test plotting colorbar to specified axis
         fig.clear()
         _, ax = plt.subplots(1, 2, num=fig.number)
-        function(signal, ax=ax)
+        if function == plot.spectrogram:
+            with pytest.warns(UserWarning, match="Using only the first"):
+                function(signal, colorbar=False)
+        else:
+            function(signal, colorbar=False)
     save_and_compare(create_baseline, baseline_path, output_path,
                      filename, file_type, compare_output)
 

--- a/tests/test_plot_interaction.py
+++ b/tests/test_plot_interaction.py
@@ -153,8 +153,11 @@ def test_interaction_attached():
         # exclude functions that do not support interaction
         if function[0] in ["context", "custom_subplots"]:
             continue
-
-        ax = function[1](signal)
+        if function[1] == pf.plot.spectrogram:
+            with pytest.warns(UserWarning, match="Using only the first"):
+                ax = function[1](signal)
+        else:
+            ax = function[1](signal)
         # axis is first return parameter if function returns multiple
         ax = ax[0] if isinstance(ax, (tuple)) else ax
         # interaction axis is first axis if functions returns multiple
@@ -546,7 +549,8 @@ def test_cycle_and_toggle_signals():
 
     # init and check start conditions
     signal = pf.signals.impulse(1024, amplitude=[1, 2])
-    ax, *_ = pf.plot.spectrogram(signal)
+    with pytest.warns(UserWarning, match="Using only the first"):
+        ax, *_ = pf.plot.spectrogram(signal)
 
     assert ax[0].interaction.txt is None
     # use the clim because the image data is identical


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #362 

### Changes proposed in this pull request:
The following warnings were raised while running the tests

- [ ] Matplotlib deprecation for ``tight_layout()``, to be solved separately, see #363
- [ ] ``UserWarning: Number of time samples not given ...`` in tests/test_audio_signal.py
- [ ] Scipy warning ``RuntimeWarning: h does not appear to by symmetric ...`` in test_dsp.py
- [ ] ``DeprecationWarning: `np.int` ...`` in dsp.py
- [ ] Scipy warning ``RuntimeWarning: invalid value encountered in divide ...`` in test_dsp_interpolation.py
- [ ] ``UserWarning: Skipping bands above the Nyquist frequency`` in test_fractional_octaves.py
- [ ] ``UserWarning: The upper frequency limit ...`` in test_fractional_octaves.py
- [ ] ``VisibleDeprecationWarning`` in test_orientations.py
- [ ] ``MatplotlibDeprecationWarning: Auto-removal of grids by pcolor() and pcolormesh()`` solved by added ``grid(False)`` in plot._two_d.py
- [ ] ``UserWarning: Using only the first channel ...`` caused by calling plot.sprectrogram in tests, solved by catching warnings
- [ ] ``UserWarning: Attempting to set identical low and high ...`` in test_plot_interaction.py
- [ ] ``InsecureRequestWarning`` caused by samplings.sph_extremal and samplings.sph_t_design
- [ ] `` UserWarning: The upper frequency limit ...`` caused by calling fractional_octave_bands in test_noise_rms_pink_spectrum
