### PR TITLE
Introduce caxis to concepts and functions

### DIFF
--- a/pyfar/_concepts/audio_classes.py
+++ b/pyfar/_concepts/audio_classes.py
@@ -25,9 +25,9 @@ conveniently, pyfar defines the channel shape - or ``cshape`` in short - which
 ignores how many samples or frequency bins are stored in an audio object. In
 the above example the cshape would be ``(3, 4)`` and `not` (3, 4, 128).
 
-In analogy, the channel axis - or ``caxis`` in short - refers to an axis of the
-cshape. For example ``caxis = 0`` refers to the first channel axis of
-size 3, and ``caxis = -1`` refers to the last channel axis of size 4 and `not`
+In analogy, the channel axis - or ``caxis`` in short - refers to the dimension
+or axis of the cshape. For example ``caxis = 0`` refers to the first dimension
+of size 3, and ``caxis = -1`` refers to the last dimension of size 4 and `not`
 to the last axis of the data array of size 128. Note that ``caxis`` can also be
 provided as a tuple or list, e.g., ``caxis = (0, 1)`` refers to both channel
 axes of size 3 and 4.

--- a/pyfar/_concepts/audio_classes.py
+++ b/pyfar/_concepts/audio_classes.py
@@ -15,6 +15,23 @@ such as the sampling rate or number of channels, and almost all functions in
 pyfar take audio classes as their main input. See
 :py:class:`audio classes <pyfar.classes.audio>` for a complete documentation.
 
+**Data inside audio classes:** ``cshape`` **and** ``caxis``
+
+All audio classes can store multi-dimensional data. For example 3 by 4
+channel audio data with 128 samples of data per channel would be stored in an
+array of shape 3 by 4 by 128, also written as ``(3, 4, 128)``. In audio signal
+processing, operations are often performed on channels. To handle this
+conveniently, pyfar defines the channel shape - or ``cshape`` in short - which
+ignores how many samples or frequency bins are stored in an audio object. In
+the above example the cshape would be ``(3, 4)`` and `not` (3, 4, 128).
+
+In analogy, the channel axis - or ``caxis`` in short - refers to an axis of the
+cshape. For example ``caxis = 0`` refers to the first channel axis of
+size 3, and ``caxis = -1`` refers to the last channel axis of size 4 and `not`
+to the last axis of the data array of size 128. Note that ``caxis`` can also be
+provided as a tuple or list, e.g., ``caxis = (0, 1)`` refers to both channel
+axes of size 3 and 4.
+
 **Signal Types**
 
 The :py:func:`~pyfar.classes.audio.Signal` class distinguishes between two

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1114,14 +1114,14 @@ def matrix_multiplication(
         second tuple) and writes the result to the last two axes of the output
         data (third tuple).
 
-        In case of pyfar audio objects, the indices refer to the caxes and
-        ignore the last dimension of the underlying data that contains the
-        samples or frequency bins (see
+        In case of pyfar audio objects, the indices refer to the channel
+        dimensions and ignore the last dimension of the underlying data that
+        contains the samples or frequency bins (see
         :py:mod:`audio classes <pyfar._concepts.audio_classes>` for more
         information). For example, a signal with 4 times 2 channels and 120
         frequency bins has a cshape of ``(4, 2)``, while the shape of the
         underlying frequency data is  ``(4, 2, 120)``. The default tuple
-        ``(-2, -1)`` would result in a 120 matrices of shape ``(4, 2)`` used
+        ``(-2, -1)`` would result in 120 matrices of shape ``(4, 2)`` used
         for the multiplication and not 4 matrices of shape ``(2, 120)``.
 
         If `data` contains more than two operands, the scheme given by `axes`

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1114,14 +1114,15 @@ def matrix_multiplication(
         second tuple) and writes the result to the last two axes of the output
         data (third tuple).
 
-        In case of pyfar audio objects, the indices refer to the channels and
+        In case of pyfar audio objects, the indices refer to the caxes and
         ignore the last dimension of the underlying data that contains the
-        samples or frequency bins. For example, a signal with 4 times 2
-        channels and 120 frequency bins has a cshape of ``(4, 2)``, while the
-        shape of the underlying frequency data is  ``(4, 2, 120)``.
-        The default tuple ``(-2, -1)`` would result in a 120 matrices of shape
-        ``(4, 2)`` used for the multiplication and not 4 matrices of shape
-        ``(2, 120)``.
+        samples or frequency bins (see
+        :py:mod:`audio classes <pyfar._concepts.audio_classes>` for more
+        information). For example, a signal with 4 times 2 channels and 120
+        frequency bins has a cshape of ``(4, 2)``, while the shape of the
+        underlying frequency data is  ``(4, 2, 120)``. The default tuple
+        ``(-2, -1)`` would result in a 120 matrices of shape ``(4, 2)`` used
+        for the multiplication and not 4 matrices of shape ``(2, 120)``.
 
         If `data` contains more than two operands, the scheme given by `axes`
         refers to all of the sequential multiplications.

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1881,8 +1881,8 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False):
 
         The default is ``'linear'``
     caxis: None, int, or tuple of ints, optional
-        Channel axis or axes along which the averaging is done. The default
-        ``None``, average across all channel axes. See
+        Channel axes along which the averaging is done. The default ``None``
+        averages across all channels. See
         :py:mod:`audio classes <pyfar._concepts.audio_classes>` for more
         information.
     weights: array like
@@ -1922,7 +1922,7 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False):
 
     # check for caxis
     if caxis and np.max(caxis) > len(signal.cshape):
-        raise ValueError(('The maximum of caxis needs to be smaller then '
+        raise ValueError(('The maximum of caxis needs to be smaller than '
                           'len(signal.cshape).'))
     # set caxis default
     if caxis is None:

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1851,7 +1851,7 @@ def rms(signal):
     return np.sqrt(power(signal))
 
 
-def average(signal, mode='linear', axis=None, weights=None, keepdims=False):
+def average(signal, mode='linear', caxis=None, weights=None, keepdims=False):
     """
     Average multi-channel signals.
 
@@ -1880,12 +1880,11 @@ def average(signal, mode='linear', axis=None, weights=None, keepdims=False):
             is reversed before returning the averaged signal.
 
         The default is ``'linear'``
-    axis: None, int, or tuple of ints, optional
-        Axis or axes along which the averaging is done. Can be ``None``, which
-        will calculate the average across all channel axes. Negative values
-        refer to ``signal.cshape`` to avoid averaging across the time or
-        frequency axis. If axis is a tuple of ints, average will perform on the
-        channels specified in the tuple. The default is ``None``.
+    caxis: None, int, or tuple of ints, optional
+        Channel axis or axes along which the averaging is done. The default
+        ``None``, average across all channel axes. See
+        :py:mod:`audio classes <pyfar._concepts.audio_classes>` for more
+        information.
     weights: array like
         Array with channel weights for averaging the data. Must be
         broadcastable to ``signal.cshape``. The default is ``None``, which
@@ -1921,21 +1920,23 @@ def average(signal, mode='linear', axis=None, weights=None, keepdims=False):
             f"mode is '{mode}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'FrequencyData'."))
 
-    # check for axis
-    if axis and np.max(axis) > len(signal.cshape):
-        raise ValueError('The maximum of axis needs to be smaller then '
-                         'len(signal.cshape).')
-    # set axis default
-    if axis is None:
-        axis = tuple([i for i in range(len((signal.cshape)))])
+    # check for caxis
+    if caxis and np.max(caxis) > len(signal.cshape):
+        raise ValueError(('The maximum of caxis needs to be smaller then '
+                          'len(signal.cshape).'))
+    # set caxis default
+    if caxis is None:
+        caxis = tuple([i for i in range(len((signal.cshape)))])
 
-    # check if averaging over one dimensional axis
+    # check if averaging over one dimensional caxis
     if 1 in signal.cshape:
-        for ax in axis:
+        for ax in caxis:
             if signal.cshape[ax] == 1:
-                warnings.warn(f"Averaging one dimensional axis={axis}.")
-    if not isinstance(axis, int):
-        axis = tuple([ax-1 if ax < 0 else ax for ax in axis])
+                warnings.warn(f"Averaging one dimensional caxis={caxis}.")
+    if not isinstance(caxis, int):
+        axis = tuple([cax-1 if cax < 0 else cax for cax in caxis])
+    else:
+        axis = caxis-1 if caxis < 0 else caxis
 
     # convert data to desired domain
     if mode == 'linear':

--- a/tests/test_dsp_average.py
+++ b/tests/test_dsp_average.py
@@ -29,16 +29,16 @@ def test_averaging(signal, mode, answer):
         npt.assert_almost_equal(ave_sig.freq[0], answer, decimal=15)
 
 
-@pytest.mark.parametrize('axis, answer', (
+@pytest.mark.parametrize('caxis, answer', (
     [(0, 2), [[(1+2+5+6)/4, (3+4+7+8)/4]]],
     [1, [[(1+3)/2, (2+4)/2], [(5+7)/2, (6+8)/2]]]
     ))
-def test_axis_averaging(axis, answer):
+def test_caxis_averaging(caxis, answer):
     """
-    Parametrized test for averaging along axis
+    Parametrized test for averaging along caxis
     """
     signal = pf.Signal(np.arange(1, 9).reshape(2, 2, 2), 44100)
-    ave_sig = pf.dsp.average(signal, axis=axis)
+    ave_sig = pf.dsp.average(signal, caxis=caxis)
     npt.assert_equal(ave_sig.time, answer)
 
 
@@ -68,15 +68,15 @@ def test_error_raises():
     with pytest.raises(ValueError,
                        match="mode is 'magnitude_phase' and signal is type"):
         pf.dsp.average(signal, 'magnitude_phase')
-    # test wrong axis input
+    # test wrong caxis input
     signal = pf.Signal(np.ones((2, 3, 4)), 44100)
     with pytest.raises(ValueError,
-                       match="The maximum of axis needs to be smaller"):
-        pf.dsp.average(signal, axis=(0, 3))
+                       match="The maximum of caxis needs to be smaller"):
+        pf.dsp.average(signal, caxis=(0, 3))
     # test invalid mode input
     with pytest.raises(ValueError,
                        match="mode must be 'linear', 'magnitude_zerophase',"):
         pf.dsp.average(signal, mode='invalid_mode')
     with pytest.warns(UserWarning,
-                      match="Averaging one dimensional axis"):
-        pf.dsp.average(pf.Signal(np.zeros((5, 2, 1, 1)), 44100), axis=(1, 2))
+                      match="Averaging one dimensional caxis"):
+        pf.dsp.average(pf.Signal(np.zeros((5, 2, 1, 1)), 44100), caxis=(1, 2))


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

As discussed in the weekly

### Changes proposed in this pull request:

- add `cshape` and `caxis` to audio class concepts
- add caxis to `dsp.average` and `matrix_multiplication`
