### PR TITLE
add `freq_range` kwarg to `deconvolve`

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1472,7 +1472,13 @@ def deconvolve(system_output, system_input, freq_range=None, fft_length=None, **
         The system input signal (e.g., used to perform a measurement).
         The system input signal is zero padded, if it is shorter than the
         system output signal.
-    fft_length: int or None
+    freq_range : tuple, array_like, double
+        The upper and lower frequency limits outside of which the
+        regularization factor is to be applied. The default ``None``
+        bypasses the regularization, which might cause numerical
+        instabilities in case of band-limited `system_input`. Also see
+        :py:func:`~pyfar.dsp.regularized_spectrum_inversion`.
+    fft_length : int or None
         The length the signals system_output and system_input are zero padded
         to before deconvolving. The default is None. In this case only the
         shorter signal is padded to the length of the longer signal, no padding

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1506,9 +1506,7 @@ def deconvolve(system_output, system_input, freq_range=None, fft_length=None, **
     if not system_output.sampling_rate == system_input.sampling_rate:
         raise ValueError("The two signals have different sampling rates!")
 
-    if freq_range is not None:
-        assert hasattr(freq_range, '__iter__') and len(freq_range) == 2
-    else:
+    if freq_range is None:
         freq_range = (0, system_input.sampling_rate)
 
     # Set fft_length to the max n_samples of both signals,

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1438,7 +1438,7 @@ def time_shift(signal, shift, unit='samples'):
     return shifted.reshape(signal.cshape)
 
 
-def deconvolve(system_output, system_input, fft_length=None, **kwargs):
+def deconvolve(system_output, system_input, freq_range=None, fft_length=None, **kwargs):
     r"""Calculate transfer functions by spectral deconvolution of two signals.
 
     The transfer function :math:`H(\omega)` is calculated by spectral
@@ -1506,6 +1506,11 @@ def deconvolve(system_output, system_input, fft_length=None, **kwargs):
     if not system_output.sampling_rate == system_input.sampling_rate:
         raise ValueError("The two signals have different sampling rates!")
 
+    if freq_range is not None:
+        assert hasattr(freq_range, '__iter__') and len(freq_range) == 2
+    else:
+        freq_range = (0, system_input.sampling_rate)
+
     # Set fft_length to the max n_samples of both signals,
     # if it is not explicitly set to a value
     if fft_length is None:
@@ -1528,7 +1533,7 @@ def deconvolve(system_output, system_input, fft_length=None, **kwargs):
     # multiply system_output signal with regularized inversed system_input
     # signal to get the system response
     system_response = (system_output *
-                       regularized_spectrum_inversion(system_input, **kwargs))
+                       regularized_spectrum_inversion(system_input, freq_range, **kwargs))
 
     # Check if the signals have any comments,
     # if yes: concatenate the comments for the system_response

--- a/tests/test_dsp_deconvolution.py
+++ b/tests/test_dsp_deconvolution.py
@@ -63,7 +63,7 @@ def test_output_type():
 
 
 def test_output_length():
-    """Test im output length is correct"""
+    """Test if output length is correct"""
     res = deconvolve(impulse(3), impulse(3), freq_range=(1, 22050))
     assert res.n_samples == 3
     res = deconvolve(impulse(5), impulse(3), freq_range=(1, 22050))
@@ -95,3 +95,10 @@ def test_fft_norm():
     sig3 = pf.Signal([1, 0, 0, 0], 44100, fft_norm='amplitude')
     with pytest.raises(ValueError, match="Either fft_norm_2 "):
         deconvolve(sig2, sig3, freq_range=(1, 44100))
+
+
+def test_freq_range():
+    """Test if freq_range default is correct"""
+    res1 = deconvolve(impulse(3), impulse(3), freq_range=None)
+    res2 = deconvolve(impulse(3), impulse(3), freq_range=(0, 22050))
+    npt.assert_allclose(res1.time, res2.time, rtol=1e-9)


### PR DESCRIPTION
Calling `deconvolve` without a `freq_range` argument leads to an error in `regularized_spectrum_inversion`, because `freq_range` is mandatory. I've added a mechanism for setting a default value.