### PR TITLE
Fix/binder

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -215,6 +215,6 @@ $ git push --follow-tags
 Travis will then deploy to PyPI if tests pass.
 
 - merge main back into develop
-- check binder `examples notebook`_
+- check `binder`_
 
-.. _examples notebook: https://mybinder.org/v2/gh/pyfar/pyfar/main?filepath=examples%2Fpyfar_demo.ipynb
+.. _binder: https://mybinder.org/v2/gh/pyfar/pyfar/main?filepath=examples%2Fpyfar_demo.ipynb

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -215,3 +215,6 @@ $ git push --follow-tags
 Travis will then deploy to PyPI if tests pass.
 
 - merge main back into develop
+- check binder `examples notebook`_
+
+.. _examples notebook: https://mybinder.org/v2/gh/pyfar/pyfar/main?filepath=examples%2Fpyfar_demo.ipynb

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - python>=3.8
   - pip
   - numpy>=1.23.0
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python=3.8
+  - python=3.10
   - pip
   - numpy>=1.23.0
   - matplotlib

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
-  - python>=3.8
+  - python=3.8
   - pip
   - numpy>=1.23.0
   - matplotlib


### PR DESCRIPTION
### Changes proposed in this pull request:

- mybinder standard python is 3.7, so it was not working since pyfar 0.5.0
- add check binder to todos for release
- added python=3.8 in env, hope that does not break anything else???, mybinder is working again:
https://mybinder.org/v2/gh/pyfar/pyfar.git/fix/binder?labpath=examples%2Fpyfar_demo.ipynb
