### PR TITLE
zero padding descriptors

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -978,7 +978,7 @@ def pad_zeros(signal, pad_width, mode='end'):
         ``'end'``
             Append zeros to the end of the signal
         ``'beginning'``
-            Pre-pend zeros before the starting time of the signal
+            Prepend zeros to the beginning of the signal
         ``'center'``
             Insert the number of zeros in the middle of the signal.
             This mode can be used to pad signals with a symmetry with respect

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1003,10 +1003,9 @@ def pad_zeros(signal, pad_width, mode='end'):
         raise TypeError('Input data has to be of type: Signal.')
 
     if mode in ['before', 'after']:
-        warnings.simplefilter('always')
         warnings.warn(('Mode "before" and "after" will be renamed into '
                        '"beginning" and "end" and can no longer be used in '
-                       'Pyfar 0.5.8.'), PendingDeprecationWarning)
+                       'Pyfar 0.8.0.'), DeprecationWarning)
 
         mode = 'beginning' if mode == 'before' else 'end'
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -963,7 +963,7 @@ def minimum_phase(signal, n_fft=None, truncate=True):
     return pyfar.Signal(data, signal.sampling_rate)
 
 
-def pad_zeros(signal, pad_width, mode='after'):
+def pad_zeros(signal, pad_width, mode='end'):
     """Pad a signal with zeros in the time domain.
 
     Parameters
@@ -975,16 +975,16 @@ def pad_zeros(signal, pad_width, mode='after'):
     mode : str, optional
         The padding mode:
 
-        ``'after'``
+        ``'end'``
             Append zeros to the end of the signal
-        ``'before'``
+        ``'beginning'``
             Pre-pend zeros before the starting time of the signal
         ``'center'``
             Insert the number of zeros in the middle of the signal.
             This mode can be used to pad signals with a symmetry with respect
             to the time ``t=0``.
 
-        The default is ``'after'``.
+        The default is ``'end'``.
 
     Returns
     -------
@@ -995,18 +995,26 @@ def pad_zeros(signal, pad_width, mode='after'):
     --------
     >>> import pyfar as pf
     >>> impulse = pf.signals.impulse(512, amplitude=1)
-    >>> impulse_padded = pf.dsp.pad_zeros(impulse, 128, mode='after')
+    >>> impulse_padded = pf.dsp.pad_zeros(impulse, 128, mode='end')
 
     """
 
     if not isinstance(signal, pyfar.Signal):
         raise TypeError('Input data has to be of type: Signal.')
 
+    if mode in ['before', 'after']:
+        warnings.simplefilter('always')
+        warnings.warn(('Mode "before" and "after" will be renamed into '
+                       '"beginning" and "end" and can no longer be used in '
+                       'Pyfar 0.5.8.'), PendingDeprecationWarning)
+
+        mode = 'beginning' if mode == 'before' else 'end'
+
     padded_signal = signal.flatten()
 
-    if mode in ['after', 'center']:
+    if mode in ['end', 'center']:
         pad_array = ((0, 0), (0, pad_width))
-    elif mode == 'before':
+    elif mode == 'beginning':
         pad_array = ((0, 0), (pad_width, 0))
     else:
         raise ValueError("Unknown padding mode.")

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -167,3 +167,9 @@ def test__check_time_unit():
             # remove xscale from pyfar 0.6.0!
             create_figure()
             pf.plot._utils._check_time_unit(None)
+
+
+def test_pad_zero_modi():
+    with pytest.warns(PendingDeprecationWarning,
+                      match='Mode "before" and "after" will be renamed into'):
+        pf.dsp.pad_zeros(pf.Signal([1], 44100), 5, 'before')

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -170,6 +170,11 @@ def test__check_time_unit():
 
 
 def test_pad_zero_modi():
-    with pytest.warns(PendingDeprecationWarning,
+    with pytest.warns(DeprecationWarning,
                       match='Mode "before" and "after" will be renamed into'):
         pf.dsp.pad_zeros(pf.Signal([1], 44100), 5, 'before')
+
+    if version.parse(pf.__version__) >= version.parse('0.8.0'):
+        with pytest.raises(ValueError):
+            # remove mode 'before' and 'after' from pyfar 0.8.0!
+            pf.dsp.pad_zeros(pf.Signal([1], 44100), 5, mode='before')

--- a/tests/test_dsp_pad_zeros.py
+++ b/tests/test_dsp_pad_zeros.py
@@ -14,8 +14,8 @@ def test_pad_zeros():
     with pytest.raises(ValueError, match="Unknown padding mode"):
         pyfar.dsp.pad_zeros(test_signal, 1, mode='invalid')
 
-    # test padding before start of the signal
-    padded = pyfar.dsp.pad_zeros(test_signal, num_zeros, mode='before')
+    # test padding at the beginning of the signal
+    padded = pyfar.dsp.pad_zeros(test_signal, num_zeros, mode='beginning')
     # check of dimensions are maintained
     assert test_signal.cshape == padded.cshape
     # check if final number of samples after padding is correct
@@ -27,8 +27,8 @@ def test_pad_zeros():
 
     np.testing.assert_allclose(padded.time, desired.time)
 
-    # test padding after end of the signal
-    padded = pyfar.dsp.pad_zeros(test_signal, num_zeros, mode='after')
+    # test padding at the end of the signal
+    padded = pyfar.dsp.pad_zeros(test_signal, num_zeros, mode='end')
     # check of dimensions are maintained
     assert test_signal.cshape == padded.cshape
     # check if final number of samples after padding is correct


### PR DESCRIPTION
- Modi "before" and "after" are called "beginning" and "end" now. 
- Wrote PendingDeprecationWarning, that modi "before" and "after" can no longer be used in Pyfar Version 0.6.0. 
- PendingDeprecationWarning was ignored by default, so I used 'warnings.simplefilter('always')' to show the warning when modi "before" and "after" will be used. Is there a way to activate PendingDeprecationWarning permanent without using this line everytime?
- Insert 'test_pad_zero_modi' into test_deprecations.py 
