### PR TITLE
Fix return arguments in Coordinates.find_slice

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1028,7 +1028,7 @@ class Coordinates():
         if show:
             self.show(mask)
 
-        index = np.asarray(mask).nonzero()
+        index = np.asarray(mask).nonzero()[0]
 
         return index, mask
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -960,7 +960,7 @@ class Coordinates():
 
         Returns
         -------
-        index : numpy array of ints
+        index : tuple of numpy arrays
             The indices of the selected points as a tuple of arrays. The length
             of the tuple matches :py:func:`~cdim`. The length of each array
             matches the number of selected points.
@@ -1028,7 +1028,7 @@ class Coordinates():
         if show:
             self.show(mask)
 
-        index = np.asarray(mask).nonzero()[0]
+        index = np.where(mask)
 
         return index, mask
 

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -565,33 +565,39 @@ def test_find_slice():
 
     c = Coordinates(d, 0, 0)
     index, mask = c.find_slice('x', 'met', 0, 1)
-    npt.assert_allclose(index, np.array([1, 2, 3]))
+    npt.assert_allclose(index, (np.array([1, 2, 3]), ))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
 
     c = Coordinates(0, d, 0)
     index, mask = c.find_slice('y', 'met', 0, 1)
-    npt.assert_allclose(index, np.array([1, 2, 3]))
+    npt.assert_allclose(index, (np.array([1, 2, 3]), ))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
 
     c = Coordinates(0, 0, d)
     index, mask = c.find_slice('z', 'met', 0, 1)
-    npt.assert_allclose(index, np.array([1, 2, 3]))
+    npt.assert_allclose(index, (np.array([1, 2, 3]), ))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
+
+    # cartesian grid, multi-dimensional coordinates
+    c = Coordinates([[0, 1], [1, 0]], 2, 3)
+    index, mask = c.find_slice('x', 'met', 0)
+    npt.assert_allclose(index, ([0, 1], [0, 1]))
+    npt.assert_allclose(mask, np.array([[1, 0], [0, 1]]))
 
     # spherical grid
     d = [358, 359, 0, 1, 2]
     c = Coordinates(d, 0, 1, 'sph', 'top_elev', 'deg')
     # cyclic query for lower bound
     index, mask = c.find_slice('azimuth', 'deg', 0, 1)
-    npt.assert_allclose(index, np.array([1, 2, 3]))
+    npt.assert_allclose(index, (np.array([1, 2, 3]), ))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
     # cyclic query for upper bound
     index, mask = c.find_slice('azimuth', 'deg', 359, 2)
-    npt.assert_allclose(index, np.array([0, 1, 2, 3]))
+    npt.assert_allclose(index, (np.array([0, 1, 2, 3]), ))
     npt.assert_allclose(mask, np.array([1, 1, 1, 1, 0]))
     # non-cyclic query
     index, mask = c.find_slice('azimuth', 'deg', 1, 1)
-    npt.assert_allclose(index, np.array([2, 3, 4]))
+    npt.assert_allclose(index, (np.array([2, 3, 4]), ))
     npt.assert_allclose(mask, np.array([0, 0, 1, 1, 1]))
     # out of range query
     with raises(AssertionError):
@@ -606,6 +612,17 @@ def test_find_slice():
     # not tested here.
 
     plt.close("all")
+
+
+@pytest.mark.parametrize("coordinates,desired", [
+    (Coordinates([0, 1], 2, 3), [0, 2, 3]),
+    (Coordinates([[0, 1], [1, 0]], 2, 3), [[0, 2, 3], [0, 2, 3]])])
+def test_find_slice_slicing(coordinates, desired):
+    """Test if return values can be used for slicing"""
+
+    index, mask = coordinates.find_slice('x', 'met', 0)
+    assert coordinates[index] == coordinates[mask]
+    npt.assert_equal(coordinates[index].get_cart(), np.atleast_2d(desired))
 
 
 @pytest.mark.parametrize("rot_type,rot", [

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -565,17 +565,17 @@ def test_find_slice():
 
     c = Coordinates(d, 0, 0)
     index, mask = c.find_slice('x', 'met', 0, 1)
-    npt.assert_allclose(index[0], np.array([1, 2, 3]))
+    npt.assert_allclose(index, np.array([1, 2, 3]))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
 
     c = Coordinates(0, d, 0)
     index, mask = c.find_slice('y', 'met', 0, 1)
-    npt.assert_allclose(index[0], np.array([1, 2, 3]))
+    npt.assert_allclose(index, np.array([1, 2, 3]))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
 
     c = Coordinates(0, 0, d)
     index, mask = c.find_slice('z', 'met', 0, 1)
-    npt.assert_allclose(index[0], np.array([1, 2, 3]))
+    npt.assert_allclose(index, np.array([1, 2, 3]))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
 
     # spherical grid
@@ -583,15 +583,15 @@ def test_find_slice():
     c = Coordinates(d, 0, 1, 'sph', 'top_elev', 'deg')
     # cyclic query for lower bound
     index, mask = c.find_slice('azimuth', 'deg', 0, 1)
-    npt.assert_allclose(index[0], np.array([1, 2, 3]))
+    npt.assert_allclose(index, np.array([1, 2, 3]))
     npt.assert_allclose(mask, np.array([0, 1, 1, 1, 0]))
     # cyclic query for upper bound
     index, mask = c.find_slice('azimuth', 'deg', 359, 2)
-    npt.assert_allclose(index[0], np.array([0, 1, 2, 3]))
+    npt.assert_allclose(index, np.array([0, 1, 2, 3]))
     npt.assert_allclose(mask, np.array([1, 1, 1, 1, 0]))
     # non-cyclic query
     index, mask = c.find_slice('azimuth', 'deg', 1, 1)
-    npt.assert_allclose(index[0], np.array([2, 3, 4]))
+    npt.assert_allclose(index, np.array([2, 3, 4]))
     npt.assert_allclose(mask, np.array([0, 0, 1, 1, 1]))
     # out of range query
     with raises(AssertionError):


### PR DESCRIPTION
The tuple returned by `Coordinates.find_slice` can not be used to index multi-dimensional coordinates objects.

Sorry for the confusion. The return argument has to be a tuple, not an array. Otherwise it can not be used to assess multi-dimensional coordinates.

- fixed return argument
- added tests