### PR TITLE
392 Unexpected Gain using high shelve filter with shelve type I and II

### DIFF
--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -125,8 +125,8 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
         ``'III'``
             Defines the characteristic frequency at gain/2 dB.
 
-        For types ``I`` and ``II`` the absolute value of the gain must be 
-        sufficiently large (>12 dB) to set the characteristic frequency 
+        For types ``I`` and ``II`` the absolute value of the gain must be
+        sufficiently large (>12 dB) to set the characteristic frequency
         according to the above rules.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -128,8 +128,8 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules. For smaller `gains` the characteristic
-        frequency gets less accurate.
+        according to the above rules. For smaller absolute values the
+        characteristic frequency becomes less accurate.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.
@@ -186,8 +186,8 @@ def low_shelve(signal, frequency, gain, order, shelve_type='I',
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules. For smaller `gains` the characteristic
-        frequency gets less accurate.
+        according to the above rules. For smaller absolute values the
+        characteristic frequency becomes less accurate.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -117,15 +117,16 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
         Defines the characteristic frequency. The default is ``'I'``.
 
         ``'I'``
-            Defines the characteristic frequency 3 dB below the gain value if
-            the gain is positive and 3 dB above the gain value otherwise
+            Defines the characteristic frequency 3 dB below the `gain` value if
+            the `gain` is positive and 3 dB above the `gain` value if the `gain`
+            is negative.
         ``'II'``
-            Defines the characteristic frequency at 3 dB if the gain is
-            positive and at -3 dB if the gain is negative.
+            Defines the characteristic frequency at 3 dB if the `gain` is
+            positive and at -3 dB if the `gain` is negative.
         ``'III'``
-            Defines the characteristic frequency at gain/2 dB.
+            Defines the characteristic frequency at `gain`/2 dB.
 
-        For types ``I`` and ``II`` the absolute value of the gain must be
+        For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
         according to the above rules.
     sampling_rate : None, number

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -128,7 +128,7 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules. For smaller absolute values the
+        according to the above rules. For smaller absolute `gain` values the
         characteristic frequency becomes less accurate.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
@@ -186,7 +186,7 @@ def low_shelve(signal, frequency, gain, order, shelve_type='I',
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules. For smaller absolute values the
+        according to the above rules. For smaller absolute `gain` values the
         characteristic frequency becomes less accurate.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -127,9 +127,11 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
             Defines the characteristic frequency at `gain`/2 dB.
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
-        sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules. For smaller absolute `gain` values the
-        characteristic frequency becomes less accurate.
+        sufficiently large (> 9 dB) to set the characteristic
+        frequency according to the above rules with an error below 0.5 dB.
+        For smaller absolute `gain` values the gain at the characteristic
+        frequency becomes less accurate.
+        For type ``III`` the characteristic frequency is always set correctly.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.
@@ -185,9 +187,11 @@ def low_shelve(signal, frequency, gain, order, shelve_type='I',
             Defines the characteristic frequency at `gain`/2 dB.
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
-        sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules. For smaller absolute `gain` values the
-        characteristic frequency becomes less accurate.
+        sufficiently large (> 9 dB) to set the characteristic
+        frequency according to the above rules with an error below 0.5 dB.
+        For smaller absolute `gain` values the gain at the characteristic
+        frequency becomes less accurate.
+        For type ``III`` the characteristic frequency is always set correctly.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -117,13 +117,16 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
         Defines the characteristic frequency. The default is ``'I'``
 
         ``'I'``
-            defines the characteristic frequency 3 dB below the gain value if
+            Defines the characteristic frequency 3 dB below the gain value if
             the gain is positive and 3 dB above the gain value otherwise
         ``'II'``
-            defines the characteristic frequency at 3 dB if the gain is
+            Defines the characteristic frequency at 3 dB if the gain is
             positive and at -3 dB if the gain is negative.
         ``'III'``
-            defines the characteristic frequency at gain/2 dB.
+            Defines the characteristic frequency at gain/2 dB.
+        
+        For types ``I`` and ``II`` the absolute value of the gain must be 
+        sufficiently large (>12 dB) to set the characteristic frequency according to the above rules.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -114,7 +114,7 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
     order : number
         The shelve order. Must be ``1`` or ``2``.
     shelve_type : str
-        Defines the characteristic frequency. The default is ``'I'``
+        Defines the characteristic frequency. The default is ``'I'``.
 
         ``'I'``
             Defines the characteristic frequency 3 dB below the gain value if

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -118,8 +118,8 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
 
         ``'I'``
             Defines the characteristic frequency 3 dB below the `gain` value if
-            the `gain` is positive and 3 dB above the `gain` value if the `gain`
-            is negative.
+            the `gain` is positive and 3 dB above the `gain` value if the
+            `gain` is negative.
         ``'II'``
             Defines the characteristic frequency at 3 dB if the `gain` is
             positive and at -3 dB if the `gain` is negative.
@@ -175,8 +175,8 @@ def low_shelve(signal, frequency, gain, order, shelve_type='I',
 
         ``'I'``
             Defines the characteristic frequency 3 dB below the `gain` value if
-            the `gain` is positive and 3 dB above the `gain` value if the `gain`
-            is negative.
+            the `gain` is positive and 3 dB above the `gain` value if the
+            `gain` is negative.
         ``'II'``
             Defines the characteristic frequency at 3 dB if the `gain` is
             positive and at -3 dB if the `gain` is negative.

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -171,16 +171,21 @@ def low_shelve(signal, frequency, gain, order, shelve_type='I',
     order : number
         The shelve order. Must be ``1`` or ``2``.
     shelve_type : str
-        Defines the characteristic frequency. The default is ``'I'``
+        Defines the characteristic frequency. The default is ``'I'``.
 
         ``'I'``
-            defines the characteristic frequency 3 dB below the gain value if
-            the gain is positive and 3 dB above the gain value otherwise.
+            Defines the characteristic frequency 3 dB below the `gain` value if
+            the `gain` is positive and 3 dB above the `gain` value if the `gain`
+            is negative.
         ``'II'``
-            defines the characteristic frequency at 3 dB if the gain is
-            positive and at -3 dB if the gain is negative.
+            Defines the characteristic frequency at 3 dB if the `gain` is
+            positive and at -3 dB if the `gain` is negative.
         ``'III'``
-            defines the characteristic frequency at gain/2 dB.
+            Defines the characteristic frequency at `gain`/2 dB.
+
+        For types ``I`` and ``II`` the absolute value of the `gain` must be
+        sufficiently large (>12 dB) to set the characteristic frequency
+        according to the above rules.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -124,9 +124,10 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
             positive and at -3 dB if the gain is negative.
         ``'III'``
             Defines the characteristic frequency at gain/2 dB.
-        
+
         For types ``I`` and ``II`` the absolute value of the gain must be 
-        sufficiently large (>12 dB) to set the characteristic frequency according to the above rules.
+        sufficiently large (>12 dB) to set the characteristic frequency 
+        according to the above rules.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -128,7 +128,8 @@ def high_shelve(signal, frequency, gain, order, shelve_type='I',
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules.
+        according to the above rules. For smaller `gains` the characteristic
+        frequency gets less accurate.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.
@@ -185,7 +186,8 @@ def low_shelve(signal, frequency, gain, order, shelve_type='I',
 
         For types ``I`` and ``II`` the absolute value of the `gain` must be
         sufficiently large (>12 dB) to set the characteristic frequency
-        according to the above rules.
+        according to the above rules. For smaller `gains` the characteristic
+        frequency gets less accurate.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #392

### Changes proposed in this pull request:

Revised docstring to clarify that the characteristic frequency of the shelve filter in modes ``I`` and ``II`` can only be set if the absolute value of the gain is sufficiently large. Documentation build locally with sphinx looks ok to me.
### Labels

**documentation**, **dsp**
