### PR TITLE
Fix bugs and failing test caused by numpy update

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1366,7 +1366,7 @@ def find_impulse_response_start(
     """
     ir_squared = np.abs(impulse_response.time)**2
 
-    mask_start = np.int(0.9*impulse_response.n_samples)
+    mask_start = int(0.9*impulse_response.n_samples)
 
     mask = np.arange(mask_start, ir_squared.shape[-1])
     noise = np.mean(np.take(ir_squared, mask, axis=-1), axis=-1)

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -44,11 +44,11 @@ def test_domains_normalization():
     time = pf.dsp.normalize(signal, domain="time")
     freq = pf.dsp.normalize(signal, domain="freq")
 
-    assert np.max(np.abs(time.time)) == 1
+    assert np.abs(1 - np.max(np.abs(time.time))) < 1e-15
     assert np.max(np.abs(time.freq)) != 1
 
     assert np.max(np.abs(freq.time)) != 1
-    assert np.max(np.abs(freq.freq)) == 1
+    assert np.abs(1 - np.max(np.abs(freq.freq))) < 1e-15
 
 
 @pytest.mark.parametrize('unit, limit1, limit2', (

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -44,11 +44,11 @@ def test_domains_normalization():
     time = pf.dsp.normalize(signal, domain="time")
     freq = pf.dsp.normalize(signal, domain="freq")
 
-    assert np.abs(1 - np.max(np.abs(time.time))) < 1e-15
+    npt.assert_allclose(np.max(np.abs(time.time)), 1)
     assert np.max(np.abs(time.freq)) != 1
 
     assert np.max(np.abs(freq.time)) != 1
-    assert np.abs(1 - np.max(np.abs(freq.freq))) < 1e-15
+    npt.assert_allclose(np.max(np.abs(freq.freq)), 1)
 
 
 @pytest.mark.parametrize('unit, limit1, limit2', (


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

- `dsp.find_impulse_response_start` still used `numpy.int`, which has been removed from numpy
- the test for `dsp.normalize` failed because the test tolerance was to low

### Changes proposed in this pull request:

- used `int` instead of `numpy.int` in `dsp.find_impulse_response_start`
- add test tolerance in `tests/test_dsp_normalize.py`
