### PR TITLE
Write audio with different sampling rates types

### DIFF
--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -378,6 +378,7 @@ def write_audio(signal, filename, subtype=None, overwrite=True, **kwargs):
     * This function is based on :py:func:`soundfile.write`.
     * Except for the subtypes ``'FLOAT'``, ``'DOUBLE'`` and ``'VORBIS'`` ´
       amplitudes larger than +/- 1 are clipped.
+    * Only integer values are allowed for ``signal.sampling_rate``.
 
     """
     if not soundfile_imported:
@@ -386,6 +387,16 @@ def write_audio(signal, filename, subtype=None, overwrite=True, **kwargs):
 
     sampling_rate = signal.sampling_rate
     data = signal.time
+
+    # check sampling rate (libsoundfile only support ints)
+    if not isinstance(sampling_rate, int):
+        if sampling_rate % 1:
+            raise ValueError((
+                f"The sampling rate is {sampling_rate} but must have an "
+                f"integer value, e.g., {int(sampling_rate)} or "
+                f"{int(sampling_rate + 1)} (See pyfar.dsp.resample for help)"))
+        else:
+            sampling_rate = int(sampling_rate)
 
     # Reshape to 2D
     data = data.reshape(-1, data.shape[-1])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -9,6 +9,7 @@ from pyfar.testing.stub_utils import stub_str_to_type, stub_is_pyfar_type
 import os.path
 import pathlib
 import soundfile
+import re
 
 from pyfar import io
 from pyfar import Signal
@@ -556,6 +557,26 @@ def test_write_audio_clip(sf_write_mock):
     with pytest.warns(Warning, match='clipped'):
         pyfar.io.write_audio(
             signal=signal, filename='test.wav', subtype='PCM_16')
+
+
+def test_write_audio_sampling_rate_type(tmpdir):
+    """Test sampling_rates of type float"""
+
+    # test with integer value as float
+    signal = pyfar.signals.impulse(1024)
+    signal.sampling_rate = 44100.0
+    pyfar.io.write_audio(
+        signal, os.path.join(tmpdir, 'test_sampling_rate_float_1.wav'))
+
+    # test with non-integer value
+    signal.sampling_rate = 44100.5
+    error_message = re.escape((
+        "The sampling rate is 44100.5 but must have an "
+        "integer value, e.g., 44100 "
+        "or 44101 (See pyfar.dsp.resample for help)"))
+    with pytest.raises(ValueError, match=error_message):
+        pyfar.io.write_audio(
+            signal, os.path.join(tmpdir, 'test_sampling_rate_float_2.wav'))
 
 
 @pytest.mark.parametrize("subtype", soundfile.available_subtypes().keys())


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #411 

### Changes proposed in this pull request:

- Convert integer-valued sampling rates to int if they are of type float
- Raise an informal error for foat-valued sampling rates
- Update docstring
- Update testing
