### PR TITLE
Deprecate len(Signal)

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -12,6 +12,7 @@ import deepdiff
 import numpy as np
 import pyfar.dsp.fft as fft
 from typing import Callable
+from .warnings import PyfarDeprecationWarning
 
 
 class _Audio():
@@ -823,6 +824,9 @@ class Signal(FrequencyData, TimeData):
     def __len__(self):
         """Length of the object which is the number of samples stored.
         """
+        warnings.warn(
+            ("len(Signal) wil be deprecated in pyfar 0.8.0 "
+             "Use Signal.n_samples instead"), PyfarDeprecationWarning)
         return self.n_samples
 
     def __iter__(self):

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -825,7 +825,7 @@ class Signal(FrequencyData, TimeData):
         """Length of the object which is the number of samples stored.
         """
         warnings.warn(
-            ("len(Signal) wil be deprecated in pyfar 0.8.0 "
+            ("len(Signal) will be deprecated in pyfar 0.8.0 "
              "Use Signal.n_samples instead"), PyfarDeprecationWarning)
         return self.n_samples
 

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -185,7 +185,7 @@ def test_pad_zero_modi():
 
 def test_signal_len():
     with pytest.warns(PyfarDeprecationWarning,
-                      match=re.escape("len(Signal) wil be deprecated")):
+                      match=re.escape("len(Signal) will be deprecated")):
         len(pf.Signal([1, 2, 3], 44100))
 
     if version.parse(pf.__version__) >= version.parse('0.8.0'):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -13,12 +13,14 @@ Test deprecations. For each deprecation two things must be tested:
 import numpy as np
 from packaging import version
 import pathlib
+import re
 
 import pytest
 from unittest.mock import patch
 
 import pyfar as pf
 import pyfar.dsp.filter as pfilt
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 # This defines the plot size and the backend
 from pyfar.testing.plot_utils import create_figure
@@ -169,6 +171,7 @@ def test__check_time_unit():
             pf.plot._utils._check_time_unit(None)
 
 
+# deprecate in 0.8.0 ----------------------------------------------------------
 def test_pad_zero_modi():
     with pytest.warns(DeprecationWarning,
                       match='Mode "before" and "after" will be renamed into'):
@@ -178,3 +181,14 @@ def test_pad_zero_modi():
         with pytest.raises(ValueError):
             # remove mode 'before' and 'after' from pyfar 0.8.0!
             pf.dsp.pad_zeros(pf.Signal([1], 44100), 5, mode='before')
+
+
+def test_signal_len():
+    with pytest.warns(PyfarDeprecationWarning,
+                      match=re.escape("len(Signal) wil be deprecated")):
+        len(pf.Signal([1, 2, 3], 44100))
+
+    if version.parse(pf.__version__) >= version.parse('0.8.0'):
+        with pytest.raises(TypeError, match=re.escape("had no len()")):
+            # remove Signal.__len__ from pyfar 0.8.0!
+            len(pf.Signal([1, 2, 3], 44100))


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #412 

### Changes proposed in this pull request:

- deprecate `len(Signal)`
- test deprecation
