### PR TITLE
Use MathJax instead of imgmath in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,8 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'matplotlib.sphinxext.plot_directive',
-    'sphinx.ext.imgmath',
+    # 'sphinx.ext.imgmath',
+    'sphinx.ext.mathjax',
     'autodocsumm']
 
 # show tocs for classes and functions of modules using the autodocsumm
@@ -49,7 +50,8 @@ autodoc_default_options = {'autosummary': True}
 # package matplotlib.sphinxext.plot_directive
 plot_include_source = True
 
-imgmath_latex_preamble = r'\usepackage{array}'
+# imgmath_latex_preamble = r'\usepackage{array}'
+# imgmath_image_format = 'svg'
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,6 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autosummary',
     'matplotlib.sphinxext.plot_directive',
-    # 'sphinx.ext.imgmath',
     'sphinx.ext.mathjax',
     'autodocsumm']
 
@@ -49,9 +48,6 @@ autodoc_default_options = {'autosummary': True}
 # show the code of plots that follows the command .. plot:: based on the
 # package matplotlib.sphinxext.plot_directive
 plot_include_source = True
-
-# imgmath_latex_preamble = r'\usepackage{array}'
-# imgmath_image_format = 'svg'
 
 # Add any paths that contain templates here, relative to this directory.
 # templates_path = ['_templates']

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ watchdog
 flake8
 tox
 coverage
-Sphinx<5.3
+Sphinx
 twine
 pytest
 pytest-runner

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ watchdog
 flake8
 tox
 coverage
-Sphinx
+Sphinx<5.3
 twine
 pytest
 pytest-runner


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Use MathJax instead of the imgmath Sphinx extension. Works with recent Sphinx versions, so no need to limit to versions prior to v5.3.
This also generates nice vector font equations instead of rasterized images with quite low resolution.

See https://pyfar.readthedocs.io/en/bugfix-sphinx_math/ for the generated docs.

Closes #408, requires #409

