### PR TITLE
Ignore axis in broadcasting

### DIFF
--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -62,7 +62,7 @@ def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
         if not isinstance(signal, (pf.Signal, pf.TimeData, pf.FrequencyData)):
             raise TypeError("All input data must be pyfar audio objects")
     if cshape is not None and ignore_caxis is not None:
-        raise ValueError(f"Use ignore_axis = 'None' to broadcast to cshape ="
+        raise ValueError(f"Use ignore_caxis = 'None' to broadcast to cshape ="
                          f" {cshape}.")
     if cshape is None:
         if ignore_caxis is not None:

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -67,7 +67,12 @@ def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
                          f" {cshape}.")
     if cshape is None:
         if ignore_caxis is not None:
+            # Adjust cshapes to largest dimention
             data_shapes = [s.cshape for s in signals]
+            max_dim = np.max([len(sh) for sh in data_shapes], axis=0)
+            for i, sh in enumerate(data_shapes):
+                for _ in range(max_dim-len(sh)):
+                    data_shapes[i] = (1,) + data_shapes[i]
             # Finds broadcast cshape without the axis to ignore
             cshape = np.broadcast_shapes(*np.delete(data_shapes, ignore_caxis,
                                          axis=-1))

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -50,8 +50,10 @@ def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
         ``numpy.broadcast_shapes``. The default is ``None``.
     ignore_caxis : int, optional
         Channel axis (:py:mod:`caxis <pyfar._concepts.audio_classes>`) which
-        will be ignore during broadcasting. Must be ``None``, if `cshape` is
-        not ``None``. The default is ``None``, which broadcasts all caxis.
+        will be ignored during broadcasting. Must be ``None``, if `cshape` is
+        not ``None``. Note that caxis refers to the channel axis after
+        :py:func:~broadcast.cdims is applied. The default is ``None``, which
+        broadcasts all caxis.
 
     Returns
     -------
@@ -67,25 +69,25 @@ def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
                          f" {cshape}.")
     if cshape is None:
         if ignore_caxis is not None:
-            # Adjust cshapes to largest dimention
-            data_shapes = [s.cshape for s in signals]
-            max_dim = np.max([len(sh) for sh in data_shapes], axis=0)
-            for i, sh in enumerate(data_shapes):
-                for _ in range(max_dim-len(sh)):
-                    data_shapes[i] = (1,) + data_shapes[i]
+            # Adjust cshapes to largest dimension
+            cshapes = [s.cshape for s in signals]
+            max_cdim = np.max([len(sh) for sh in cshapes])
+            for i, sh in enumerate(cshapes):
+                for _ in range(max_cdim-len(sh)):
+                    cshapes[i] = (1,) + cshapes[i]
             # Finds broadcast cshape without the axis to ignore
-            cshape = np.broadcast_shapes(*np.delete(data_shapes, ignore_caxis,
+            cshape = np.broadcast_shapes(*np.delete(cshapes, ignore_caxis,
                                          axis=-1))
             broad_signals = []
             for i, s in enumerate(signals):
                 # Appends the axis to ignore back into cshape to broadcast to.
                 if ignore_caxis in (-1, len(cshape)):
                     # Use append if ignore_axis is defined for last dimension
-                    cs = np.append(cshape, data_shapes[i][ignore_caxis])
+                    cs = np.append(cshape, cshapes[i][ignore_caxis])
                 else:
                     # Use insert if ignore_axis is not defined for last dim
                     axis = ignore_caxis+1 if ignore_caxis < 0 else ignore_caxis
-                    cs = np.insert(cshape, axis, data_shapes[i][ignore_caxis])
+                    cs = np.insert(cshape, axis, cshapes[i][ignore_caxis])
                 broad_signals.append(broadcast_cshape(s, tuple(cs)))
             return broad_signals
         else:

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -84,7 +84,6 @@ def broadcast_cshapes(signals, cshape=None, ignore_axis=None):
             return broad_signals
         else:
             cshape = np.broadcast_shapes(*[s.cshape for s in signals])
-
     return [broadcast_cshape(s, cshape) for s in signals]
 
 

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -49,8 +49,9 @@ def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
         ``None`` it is determined from the cshapes of the input signals using
         ``numpy.broadcast_shapes``. The default is ``None``.
     ignore_caxis : int, optional
-        Axis which will be ignore while broadcasting. Has to be ``None``, if
-        `cshape` is not ``None``. The default is ``None``.
+        Channel axis (:py:mod:`caxis <pyfar._concepts.audio_classes>`) which
+        will be ignore during broadcasting. Must be ``None``, if `cshape` is
+        not ``None``. The default is ``None``, which broadcasts all caxis.
 
     Returns
     -------

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -48,7 +48,7 @@ def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
         The cshape to which the signals are broadcasted. If `cshape` is
         ``None`` it is determined from the cshapes of the input signals using
         ``numpy.broadcast_shapes``. The default is ``None``.
-    ignore_axis : int, optional
+    ignore_caxis : int, optional
         Axis which will be ignore while broadcasting. Has to be ``None``, if
         `cshape` is not ``None``. The default is ``None``.
 

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -32,7 +32,7 @@ def broadcast_cshape(signal, cshape):
     return signal
 
 
-def broadcast_cshapes(signals, cshape=None, ignore_axis=None):
+def broadcast_cshapes(signals, cshape=None, ignore_caxis=None):
     """
     Broadcast multiple signals to a common cshape.
 
@@ -61,25 +61,25 @@ def broadcast_cshapes(signals, cshape=None, ignore_axis=None):
     for signal in signals:
         if not isinstance(signal, (pf.Signal, pf.TimeData, pf.FrequencyData)):
             raise TypeError("All input data must be pyfar audio objects")
-    if cshape is not None and ignore_axis is not None:
+    if cshape is not None and ignore_caxis is not None:
         raise ValueError(f"Use ignore_axis = 'None' to broadcast to cshape ="
                          f" {cshape}.")
     if cshape is None:
-        if ignore_axis is not None:
+        if ignore_caxis is not None:
             data_shapes = [s.cshape for s in signals]
             # Finds broadcast cshape without the axis to ignore
-            cshape = np.broadcast_shapes(*np.delete(data_shapes, ignore_axis,
+            cshape = np.broadcast_shapes(*np.delete(data_shapes, ignore_caxis,
                                          axis=-1))
             broad_signals = []
-            for idx, s in enumerate(signals):
+            for i, s in enumerate(signals):
                 # Appends the axis to ignore back into cshape to broadcast to.
-                if ignore_axis in (-1, len(cshape)):
+                if ignore_caxis in (-1, len(cshape)):
                     # Use append if ignore_axis is defined for last dimension
-                    cs = np.append(cshape, data_shapes[idx][ignore_axis])
+                    cs = np.append(cshape, data_shapes[i][ignore_caxis])
                 else:
                     # Use insert if ignore_axis is not defined for last dim
-                    axis = ignore_axis+1 if ignore_axis < 0 else ignore_axis
-                    cs = np.insert(cshape, axis, data_shapes[idx][ignore_axis])
+                    axis = ignore_caxis+1 if ignore_caxis < 0 else ignore_caxis
+                    cs = np.insert(cshape, axis, data_shapes[i][ignore_caxis])
                 broad_signals.append(broadcast_cshape(s, tuple(cs)))
             return broad_signals
         else:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import pyfar as pf
 import pytest
+import numpy as np
 
 
 @pytest.mark.parametrize("signal", [
@@ -38,6 +39,19 @@ def test_broadcast_cshapes(cshape, reference):
         assert signal.cshape == cshape
         assert broadcast.cshape == reference
         assert isinstance(broadcast, type(signal))
+
+
+@pytest.mark.parametrize("shape1, shape2, axis, reference1, reference2", [
+    ((1, 2, 3, 1), (1, 1, 2, 1), -1, (1, 2, 3), (1, 2, 2)),
+    ((1, 3, 2, 1), (1, 2, 1, 1), -2, (1, 3, 2), (1, 2, 2)),
+    ((1, 2, 1), (3, 1, 1), 0, (1, 2), (3, 2)),
+    ((1, 4, 3, 1000), (1, 1, 2, 1000), 2, (1, 4, 3), (1, 4, 2))])
+def test_broadcast_ignore_axis(shape1, shape2, axis, reference1, reference2):
+    signals = (pf.Signal(np.ones(shape1), 44100),
+               pf.Signal(np.ones(shape2), 44100))
+    broadcasted = pf.utils.broadcast_cshapes(signals, ignore_axis=axis)
+    assert broadcasted[0].cshape == reference1
+    assert broadcasted[1].cshape == reference2
 
 
 def test_broadcast_cshapes_assertions():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,15 +41,15 @@ def test_broadcast_cshapes(cshape, reference):
         assert isinstance(broadcast, type(signal))
 
 
-@pytest.mark.parametrize("shape1, shape2, n_samples, caxis, ref1, ref2", [
-    ((1, 2, 3), (1, 1, 2), 1, -1, (1, 2, 3), (1, 2, 2)),
-    ((1, 3, 2), (2, 1), 5, -2, (1, 3, 2), (1, 2, 2)),
-    ((1, 2), (3, 1), 10, 0, (1, 2), (3, 2)),
-    ((1, 4, 3), (2,), 1000, 2, (1, 4, 3), (1, 4, 2))])
-def test_broadcast_ignore_caxis(shape1, shape2, n_samples, caxis, ref1, ref2):
+@pytest.mark.parametrize("cshape1, cshape2, caxis, ref1, ref2", [
+    ((1, 2, 3), (1, 1, 2), -1, (1, 2, 3), (1, 2, 2)),
+    ((1, 3, 2), (2, 1), -2, (1, 3, 2), (1, 2, 2)),
+    ((1, 2), (3, 1), 0, (1, 2), (3, 2)),
+    ((1, 4, 3), (2,), 2, (1, 4, 3), (1, 4, 2))])
+def test_broadcast_ignore_caxis(cshape1, cshape2, caxis, ref1, ref2):
     # Test ignore_caxis broadcasting
-    signals = (pf.Signal(np.ones(shape1 + (n_samples, )), 44100),
-               pf.Signal(np.ones(shape2 + (n_samples, )), 44100))
+    signals = (pf.Signal(np.ones(cshape1 + (100, )), 44100),
+               pf.Signal(np.ones(cshape2 + (100, )), 44100))
     broadcasted = pf.utils.broadcast_cshapes(signals, ignore_caxis=caxis)
     assert broadcasted[0].cshape == ref1
     assert broadcasted[1].cshape == ref2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,9 +43,9 @@ def test_broadcast_cshapes(cshape, reference):
 
 @pytest.mark.parametrize("shape1, shape2, n_samples, caxis, ref1, ref2", [
     ((1, 2, 3), (1, 1, 2), 1, -1, (1, 2, 3), (1, 2, 2)),
-    ((1, 3, 2), (1, 2, 1), 5, -2, (1, 3, 2), (1, 2, 2)),
+    ((1, 3, 2), (2, 1), 5, -2, (1, 3, 2), (1, 2, 2)),
     ((1, 2), (3, 1), 10, 0, (1, 2), (3, 2)),
-    ((1, 4, 3), (1, 1, 2), 1000, 2, (1, 4, 3), (1, 4, 2))])
+    ((1, 4, 3), (2,), 1000, 2, (1, 4, 3), (1, 4, 2))])
 def test_broadcast_ignore_caxis(shape1, shape2, n_samples, caxis, ref1, ref2):
     # Test ignore_caxis broadcasting
     signals = (pf.Signal(np.ones(shape1 + (n_samples, )), 44100),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,16 +41,16 @@ def test_broadcast_cshapes(cshape, reference):
         assert isinstance(broadcast, type(signal))
 
 
-@pytest.mark.parametrize("shape1, shape2, axis, reference1, reference2", [
+@pytest.mark.parametrize("shape1, shape2, caxis, reference1, reference2", [
     ((1, 2, 3, 1), (1, 1, 2, 1), -1, (1, 2, 3), (1, 2, 2)),
     ((1, 3, 2, 1), (1, 2, 1, 1), -2, (1, 3, 2), (1, 2, 2)),
     ((1, 2, 1), (3, 1, 1), 0, (1, 2), (3, 2)),
     ((1, 4, 3, 1000), (1, 1, 2, 1000), 2, (1, 4, 3), (1, 4, 2))])
-def test_broadcast_ignore_axis(shape1, shape2, axis, reference1, reference2):
+def test_broadcast_ignore_axis(shape1, shape2, caxis, reference1, reference2):
     # Test ignore_axis broadcasting
     signals = (pf.Signal(np.ones(shape1), 44100),
                pf.Signal(np.ones(shape2), 44100))
-    broadcasted = pf.utils.broadcast_cshapes(signals, ignore_axis=axis)
+    broadcasted = pf.utils.broadcast_cshapes(signals, ignore_caxis=caxis)
     assert broadcasted[0].cshape == reference1
     assert broadcasted[1].cshape == reference2
 
@@ -61,10 +61,10 @@ def test_broadcast_cshapes_assertions():
     # invalid input type
     with pytest.raises(TypeError, match="All input data must be pyfar"):
         pf.utils.broadcast_cshapes([1, 2, 3], (1, ))
-    with pytest.raises(ValueError, match="Use ignore_axis = 'None'"):
+    with pytest.raises(ValueError, match="Use ignore_caxis = 'None'"):
         pf.utils.broadcast_cshapes((pf.Signal(np.ones((1, 2, 3, 1)), 44100),
                                     pf.Signal(np.ones((1, 1, 2, 1)), 44100)),
-                                   (1, 2, 3), ignore_axis=-1)
+                                   (1, 2, 3), ignore_caxis=-1)
 
 
 @pytest.mark.parametrize("signal", [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,18 +41,18 @@ def test_broadcast_cshapes(cshape, reference):
         assert isinstance(broadcast, type(signal))
 
 
-@pytest.mark.parametrize("shape1, shape2, caxis, reference1, reference2", [
-    ((1, 2, 3, 1), (1, 1, 2, 1), -1, (1, 2, 3), (1, 2, 2)),
-    ((1, 3, 2, 1), (1, 2, 1, 1), -2, (1, 3, 2), (1, 2, 2)),
-    ((1, 2, 1), (3, 1, 1), 0, (1, 2), (3, 2)),
-    ((1, 4, 3, 1000), (1, 1, 2, 1000), 2, (1, 4, 3), (1, 4, 2))])
-def test_broadcast_ignore_axis(shape1, shape2, caxis, reference1, reference2):
-    # Test ignore_axis broadcasting
-    signals = (pf.Signal(np.ones(shape1), 44100),
-               pf.Signal(np.ones(shape2), 44100))
+@pytest.mark.parametrize("shape1, shape2, n_samples, caxis, ref1, ref2", [
+    ((1, 2, 3), (1, 1, 2), 1, -1, (1, 2, 3), (1, 2, 2)),
+    ((1, 3, 2), (1, 2, 1), 5, -2, (1, 3, 2), (1, 2, 2)),
+    ((1, 2), (3, 1), 10, 0, (1, 2), (3, 2)),
+    ((1, 4, 3), (1, 1, 2), 1000, 2, (1, 4, 3), (1, 4, 2))])
+def test_broadcast_ignore_caxis(shape1, shape2, n_samples, caxis, ref1, ref2):
+    # Test ignore_caxis broadcasting
+    signals = (pf.Signal(np.ones(shape1 + (n_samples, )), 44100),
+               pf.Signal(np.ones(shape2 + (n_samples, )), 44100))
     broadcasted = pf.utils.broadcast_cshapes(signals, ignore_caxis=caxis)
-    assert broadcasted[0].cshape == reference1
-    assert broadcasted[1].cshape == reference2
+    assert broadcasted[0].cshape == ref1
+    assert broadcasted[1].cshape == ref2
 
 
 def test_broadcast_cshapes_assertions():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,7 @@ def test_broadcast_cshapes(cshape, reference):
     ((1, 2, 1), (3, 1, 1), 0, (1, 2), (3, 2)),
     ((1, 4, 3, 1000), (1, 1, 2, 1000), 2, (1, 4, 3), (1, 4, 2))])
 def test_broadcast_ignore_axis(shape1, shape2, axis, reference1, reference2):
+    # Test ignore_axis broadcasting
     signals = (pf.Signal(np.ones(shape1), 44100),
                pf.Signal(np.ones(shape2), 44100))
     broadcasted = pf.utils.broadcast_cshapes(signals, ignore_axis=axis)
@@ -60,6 +61,10 @@ def test_broadcast_cshapes_assertions():
     # invalid input type
     with pytest.raises(TypeError, match="All input data must be pyfar"):
         pf.utils.broadcast_cshapes([1, 2, 3], (1, ))
+    with pytest.raises(ValueError, match="Use ignore_axis = 'None'"):
+        pf.utils.broadcast_cshapes((pf.Signal(np.ones((1, 2, 3, 1)), 44100),
+                                    pf.Signal(np.ones((1, 1, 2, 1)), 44100)),
+                                   (1, 2, 3), ignore_axis=-1)
 
 
 @pytest.mark.parametrize("signal", [


### PR DESCRIPTION
We decided:

- that we want to have an `ignore_axis` parameter in `utils.broadcast_cshape` which will be used in #65.