### PR TITLE
Bug/single frequency signals

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -654,24 +654,7 @@ class Signal(FrequencyData, TimeData):
     @freq.setter
     def freq(self, value):
         """Set the normalized frequency domain data."""
-        # check data type
-        data = np.atleast_2d(np.asarray(value))
-        if data.dtype.kind not in ["i", "f", "c"]:
-            raise ValueError((f"frequency data is {data.dtype} must be int, "
-                              "float, or complex"))
-        # Check n_samples
-        if data.shape[-1] != self.n_bins:
-            self._n_samples = max(1, (data.shape[-1] - 1)*2)
-            warnings.warn(
-                f"Number of samples not given, assuming {self.n_samples} "
-                f"samples from {data.shape[-1]} frequency bins.")
-        # set domain
-        self._domain = 'freq'
-        # remove normalization
-        data_denorm = fft.normalization(
-                data, self._n_samples, self._sampling_rate,
-                self._fft_norm, inverse=True)
-        self._data = data_denorm.astype(complex)
+        self._freq(value, raw=False)
 
     @property
     def freq_raw(self):
@@ -689,6 +672,11 @@ class Signal(FrequencyData, TimeData):
     @freq_raw.setter
     def freq_raw(self, value):
         """Set the frequency domain data without normalization."""
+        self._freq(value, raw=True)
+
+    def _freq(self, value, raw):
+        """Set the frequency domain data."""
+        # check data type
         data = np.atleast_2d(np.asarray(value))
         if data.dtype.kind not in ["i", "f", "c"]:
             raise ValueError((f"frequency data is {data.dtype} must be int, "
@@ -699,7 +687,13 @@ class Signal(FrequencyData, TimeData):
             warnings.warn(
                 f"Number of samples not given, assuming {self.n_samples} "
                 f"samples from {data.shape[-1]} frequency bins.")
+        # set domain
         self._domain = 'freq'
+        if not raw:
+            # remove normalization
+            data = fft.normalization(
+                    data, self._n_samples, self._sampling_rate,
+                    self._fft_norm, inverse=True)
         self._data = data.astype(complex)
 
     @_Audio.domain.setter

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -614,9 +614,9 @@ class Signal(FrequencyData, TimeData):
             # check and set n_samples
             if n_samples is None:
                 warnings.warn(
-                    "Number of time samples not given, assuming an even "
-                    "number of samples from the number of frequency bins.")
-                n_samples = (data.shape[-1] - 1)*2
+                    f"Number of samples not given, assuming {n_samples} "
+                    f"samples from {data.shape[-1]} frequency bins.")
+                n_samples = max(1, (data.shape[-1] - 1)*2)
             elif n_samples > 2 * data.shape[-1] - 1:
                 raise ValueError(("n_samples can not be larger than "
                                   "2 * data.shape[-1] - 2"))
@@ -661,10 +661,10 @@ class Signal(FrequencyData, TimeData):
                               "float, or complex"))
         # Check n_samples
         if data.shape[-1] != self.n_bins:
-            warnings.warn(UserWarning((
-                "Number of frequency bins changed, assuming an even "
-                "number of samples from the number of frequency bins.")))
-            self._n_samples = (data.shape[-1] - 1)*2
+            self._n_samples = max(1, (data.shape[-1] - 1)*2)
+            warnings.warn(
+                f"Number of samples not given, assuming {self.n_samples} "
+                f"samples from {data.shape[-1]} frequency bins.")
         # set domain
         self._domain = 'freq'
         # remove normalization
@@ -695,10 +695,10 @@ class Signal(FrequencyData, TimeData):
                               "float, or complex"))
         # Check n_samples
         if data.shape[-1] != self.n_bins:
-            warnings.warn(UserWarning((
-                "Number of frequency bins changed, assuming an even "
-                "number of samples from the number of frequency bins.")))
-            self._n_samples = (data.shape[-1] - 1)*2
+            self._n_samples = max(1, (data.shape[-1] - 1)*2)
+            warnings.warn(
+                f"Number of samples not given, assuming {self.n_samples} "
+                f"samples from {data.shape[-1]} frequency bins.")
         self._domain = 'freq'
         self._data = data.astype(complex)
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -613,10 +613,10 @@ class Signal(FrequencyData, TimeData):
         elif domain == 'freq':
             # check and set n_samples
             if n_samples is None:
+                n_samples = max(1, (data.shape[-1] - 1)*2)
                 warnings.warn(
                     f"Number of samples not given, assuming {n_samples} "
                     f"samples from {data.shape[-1]} frequency bins.")
-                n_samples = max(1, (data.shape[-1] - 1)*2)
             elif n_samples > 2 * data.shape[-1] - 1:
                 raise ValueError(("n_samples can not be larger than "
                                   "2 * data.shape[-1] - 2"))

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -134,7 +134,7 @@ def test_domain_setter_time_when_time():
 
 
 def test_domain_setter_time_when_freq():
-    with pytest.warns(UserWarning, match="Number of time samples"):
+    with pytest.warns(UserWarning, match="Number of samples"):
         signal = Signal([1, 2, 3, 4], 44100, domain='freq', fft_norm='rms')
     domain = 'time'
     signal.domain = domain
@@ -150,12 +150,18 @@ def test_signal_init_val():
 
 def test_signal_init_freq():
     """Test to init Signal with spectrum."""
+    # full parameters
     signal = Signal(
         [1, 2, 3], 44100, n_samples=4, domain='freq', fft_norm='amplitude')
     assert isinstance(signal, Signal)
     npt.assert_allclose(signal.freq, np.array([[1., 2., 3.]]), atol=1e-15)
     desired = np.array([[1., 2./2, 3.]]) * 4
     npt.assert_allclose(signal._data, desired, atol=1e-15)
+
+    # minimal parameters single frequency data
+    with pytest.warns(UserWarning, match="Number of samples not given"):
+        signal = Signal([1], 44100, domain='freq')
+    npt.assert_allclose(signal._data, np.array([[1]]), atol=1e-15)
 
 
 def test_n_samples():
@@ -207,12 +213,23 @@ def test_setter_freq():
     """Test if attribute freq is set correctly and for the warning for
     estimating the number of samples from n_bins."""
     signal = Signal([1, 2, 3], 44100, fft_norm='amplitude')
-    with pytest.warns(UserWarning, match="Number of frequency bins"):
+    with pytest.warns(UserWarning, match="Number of samples not given"):
         signal.freq = np.array([[1., 2., 3.]])
     assert signal.domain == 'freq'
     desired = signal.n_samples * np.array([[1., 2./2, 3.]])
     npt.assert_allclose(signal._data, desired)
     npt.assert_allclose(signal.freq, np.array([[1., 2., 3.]]))
+
+
+def test_setter_freq_single_frequency():
+    """Test if attribute freq is set correctly for single frequency data."""
+    signal = Signal([1, 2, 3], 44100, fft_norm='amplitude')
+    with pytest.warns(UserWarning, match="Number of samples not given"):
+        signal.freq = np.array([[1.]])
+    assert signal.domain == 'freq'
+    desired = signal.n_samples * np.array([[1.]])
+    npt.assert_allclose(signal._data, desired)
+    npt.assert_allclose(signal.freq, np.array([[1.]]))
 
 
 def test_getter_sampling_rate():
@@ -471,10 +488,21 @@ def test_freq_raw():
 def test_setter_freq_raw():
     """Test if attribute freq_raw is set correctly."""
     signal = Signal([1, 2, 3], 44100, fft_norm='amplitude', n_samples=4)
-    with pytest.warns(UserWarning, match="Number of frequency bins"):
+    with pytest.warns(UserWarning, match="Number of samples not given"):
         signal.freq_raw = np.array([[1., 2., 3.]])
     assert signal.domain == 'freq'
     npt.assert_allclose(signal._data, np.array([[1., 2., 3.]]))
+
+
+def test_setter_freq_raw_single_frequency():
+    """
+    Test if attribute freq_raw is set correctly for single frequency data.
+    """
+    signal = Signal([1, 2, 3], 44100, fft_norm='amplitude')
+    with pytest.warns(UserWarning, match="Number of samples not given"):
+        signal.freq_raw = np.array([[1.]])
+    assert signal.domain == 'freq'
+    npt.assert_allclose(signal._data, np.array([[1.]]))
 
 
 def test_setter_freq_raw_dtype():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #360 

### Changes proposed in this pull request:

- fix `Signal.__init__`, `Signal.freq`, and `Signal.freq_raw` for the case of passing single frequency data but not the number of samples
- Reduce code redundancy in `Signal.freq`, and `Signal.freq_raw` though shared functions `Signal._freq`