### PR TITLE
Fix warnings in tests

### DIFF
--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -350,12 +350,6 @@ def test_magic_setitem_wrong_type(audio):
         signal[0] = audio
 
 
-def test_magic_len():
-    """Test the magic function __len__."""
-    signal = Signal([1, 2, 3], 44100)
-    assert len(signal) == 3
-
-
 def test_find_nearest_time():
     sampling_rate = 100
     signal = Signal(np.zeros(100), sampling_rate)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -9,7 +9,7 @@ def test_import_importlib():
 
 def test_import_pyfar():
     import pyfar
-    isinstance(pyfar, ModuleType)
+    assert isinstance(pyfar, ModuleType)
 
 
 def test_import_classes():

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,4 +1,6 @@
 import importlib
+from types import ModuleType
+from inspect import isclass
 
 
 def test_import_importlib():
@@ -7,8 +9,7 @@ def test_import_importlib():
 
 def test_import_pyfar():
     import pyfar
-    __all__ = [pyfar]
-    return __all__
+    isinstance(pyfar, ModuleType)
 
 
 def test_import_classes():
@@ -23,25 +24,23 @@ def test_import_classes():
     from pyfar import FilterFIR
     from pyfar import FilterIIR
 
-    __all__ = [
-        Signal,
-        TimeData,
-        FrequencyData,
-        Coordinates,
-        Orientations,
-        FilterSOS,
-        FilterFIR,
-        FilterIIR
-    ]
-    return __all__
+    assert isclass(Signal)
+    assert isclass(TimeData)
+    assert isclass(FrequencyData)
+    assert isclass(Coordinates)
+    assert isclass(Orientations)
+    assert isclass(FilterSOS)
+    assert isclass(FilterFIR)
+    assert isclass(FilterIIR)
 
 
 def test_import_submodules():
     import pyfar
-    assert pyfar.dsp
-    assert pyfar.dsp.fft
-    assert pyfar.dsp.filter
-    assert pyfar.io
-    assert pyfar.samplings
-    assert pyfar.plot
-    assert pyfar.signals
+    assert isinstance(pyfar.dsp, ModuleType)
+    assert isinstance(pyfar.dsp.fft, ModuleType)
+    assert isinstance(pyfar.dsp.filter, ModuleType)
+    assert isinstance(pyfar.io, ModuleType)
+    assert isinstance(pyfar.samplings, ModuleType)
+    assert isinstance(pyfar.plot, ModuleType)
+    assert isinstance(pyfar.signals, ModuleType)
+    assert isinstance(pyfar.signals.files, ModuleType)

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,6 +1,9 @@
+"""
+Test imports separately for each module and top level functions/classes. These
+tests will give hints in case a single export breaks, whereas im `import pyfar`
+would fail completely and make possible issues harder to find.
+"""
 import importlib
-from types import ModuleType
-from inspect import isclass
 
 
 def test_import_importlib():
@@ -8,39 +11,37 @@ def test_import_importlib():
 
 
 def test_import_pyfar():
-    import pyfar
-    assert isinstance(pyfar, ModuleType)
+    import pyfar                             # noqa: F401
 
 
 def test_import_classes():
-    from pyfar import Signal
-    from pyfar import TimeData
-    from pyfar import FrequencyData
+    from pyfar import Signal                 # noqa: F401
+    from pyfar import TimeData               # noqa: F401
+    from pyfar import FrequencyData          # noqa: F401
 
-    from pyfar import Coordinates
-    from pyfar import Orientations
+    from pyfar import Coordinates            # noqa: F401
+    from pyfar import Orientations           # noqa: F401
 
-    from pyfar import FilterSOS
-    from pyfar import FilterFIR
-    from pyfar import FilterIIR
-
-    assert isclass(Signal)
-    assert isclass(TimeData)
-    assert isclass(FrequencyData)
-    assert isclass(Coordinates)
-    assert isclass(Orientations)
-    assert isclass(FilterSOS)
-    assert isclass(FilterFIR)
-    assert isclass(FilterIIR)
+    from pyfar import FilterSOS              # noqa: F401
+    from pyfar import FilterFIR              # noqa: F401
+    from pyfar import FilterIIR              # noqa: F401
 
 
 def test_import_submodules():
-    import pyfar
-    assert isinstance(pyfar.dsp, ModuleType)
-    assert isinstance(pyfar.dsp.fft, ModuleType)
-    assert isinstance(pyfar.dsp.filter, ModuleType)
-    assert isinstance(pyfar.io, ModuleType)
-    assert isinstance(pyfar.samplings, ModuleType)
-    assert isinstance(pyfar.plot, ModuleType)
-    assert isinstance(pyfar.signals, ModuleType)
-    assert isinstance(pyfar.signals.files, ModuleType)
+    from pyfar import dsp                    # noqa: F401
+    from pyfar.dsp import fft                # noqa: F401
+    from pyfar.dsp import filter             # noqa: F401
+    from pyfar import io                     # noqa: F401
+    from pyfar import plot                   # noqa: F401
+    from pyfar import samplings              # noqa: F401
+    from pyfar import signals                # noqa: F401
+    from pyfar.signals import files          # noqa: F401
+
+
+def test_import_functions():
+    from pyfar import add                    # noqa: F401
+    from pyfar import subtract               # noqa: F401
+    from pyfar import multiply               # noqa: F401
+    from pyfar import divide                 # noqa: F401
+    from pyfar import power                  # noqa: F401
+    from pyfar import matrix_multiplication  # noqa: F401


### PR DESCRIPTION
Fixes the following warnings raised during testing

```
tests/test_audio_signal.py::test_magic_len
  C:\Users\panik\Documents\Code\Python\pyfar\pyfar\pyfar\classes\audio.py:827: PyfarDeprecationWarning: 'len(Signal) will be deprecated in pyfar 0.8.0 Use Signal.n_samples instead'
    warnings.warn(

tests/test_imports.py::test_import_pyfar
  C:\Users\panik\anaconda3\envs\pyfar\lib\site-packages\_pytest\python.py:199: PytestReturnNotNoneWarning: Expected None, but tests/test_imports.py::test_import_pyfar returned [<module 'pyfar' from 'C:\\Users\\panik\\Documents\\Code\\Python\\pyfar\\pyfar\\pyfar\\__init__.py'>], which will be an error in a future version of pytest.  Did you mean to use `assert` instead of `return`?
    warnings.warn(

tests/test_imports.py::test_import_classes
.audio.Signal'>, <class 'pyfar.classes.audio.TimeData'>, <class 'pyfar.classes.audio.FrequencyData'>, <class 'pyfar.classes.coordinates.Coordinates'>, <class 'pyfar.classes.orientations.Orientations'>, <class 'pyfar.classes.filter.FilterSOS'>, <class 'pyfar.classes.filter.FilterFIR'>, <class 'pyfar.classes.filter.FilterIIR'>], which will be an error in a future version of pytest.  Did you mean to 
use `assert` instead of `return`?
    warnings.warn(
```