### PR TITLE
Enforce numeric data in signals

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -601,13 +601,9 @@ class Signal(FrequencyData, TimeData):
             raise ValueError(("Invalid FFT normalization. Has to be "
                               f"{', '.join(self._VALID_FFT_NORMS)}, but "
                               f"found '{fft_norm}'"))
-        # time / normalized frequency data (depending on domain)
-        data = np.atleast_2d(data)
         # check input
-        if data.dtype.kind not in ["u", "i", "f", "c"] or \
-                np.any(np.isnan(data)) or np.any(np.isinf(data)):
-            raise ValueError(("The input data contains at least one non-"
-                              "numerical value (NaN, inf, string, etc.)"))
+        data = np.atleast_2d(data)
+        self._check_input(data)
 
         # initialize domain specific parameters
         if domain == 'time':
@@ -632,6 +628,14 @@ class Signal(FrequencyData, TimeData):
             delattr(self, '_frequencies')
         else:
             raise ValueError("Invalid domain. Has to be 'time' or 'freq'.")
+
+    @staticmethod
+    def _check_input(data: np.ndarray):
+        """Check if input data is numeric."""
+        if data.dtype.kind not in ["u", "i", "f", "c"] or \
+                np.any(np.isnan(data)) or np.any(np.isinf(data)):
+            raise ValueError(("The input data contains at least one non-"
+                              "numerical value (NaN, inf, string, etc.)"))
 
     @TimeData.time.getter
     def time(self):
@@ -679,10 +683,12 @@ class Signal(FrequencyData, TimeData):
         """Set the frequency domain data without normalization."""
         self._freq(value, raw=True)
 
-    def _freq(self, value, raw):
+    def _freq(self, data, raw):
         """Set the frequency domain data."""
         # check data type
-        data = np.atleast_2d(np.asarray(value))
+        data = np.atleast_2d(np.asarray(data))
+        self._check_input(data)
+
         if data.dtype.kind not in ["i", "f", "c"]:
             raise ValueError((f"frequency data is {data.dtype} must be int, "
                               "float, or complex"))

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -645,6 +645,16 @@ class Signal(FrequencyData, TimeData):
 
         return super().time
 
+    @time.setter
+    def time(self, data):
+
+        # check data type
+        data = np.atleast_2d(np.asarray(data))
+        self._check_input(data)
+
+        # call setter from parent class
+        TimeData.time.fset(self, data)
+
     @FrequencyData.freq.getter
     def freq(self):
         """Return the normalized frequency domain data.

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -603,6 +603,11 @@ class Signal(FrequencyData, TimeData):
                               f"found '{fft_norm}'"))
         # time / normalized frequency data (depending on domain)
         data = np.atleast_2d(data)
+        # check input
+        if data.dtype.kind not in ["u", "i", "f", "c"] or \
+                np.any(np.isnan(data)) or np.any(np.isinf(data)):
+            raise ValueError(("The input data contains at least one non-"
+                              "numerical value (NaN, inf, string, etc.)"))
 
         # initialize domain specific parameters
         if domain == 'time':

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -531,6 +531,16 @@ def test_setter_freq_raw_dtype():
     signal.freq_raw = [1+1j, 2+2j, 3+3j]
     assert signal.freq_raw.dtype.kind == "c"
 
-    # object array
-    with pytest.raises(ValueError, match="frequency data is"):
-        signal.freq_raw = ["1", "2", "3"]
+
+def test_setter_assertions():
+    """
+    Test assertions for the freq setter. Other cases are already checked in
+    ``test_signal_init_assertions``."""
+
+    signal = Signal([1, 2, 3], 44100)
+
+    with pytest.raises(ValueError, match="The input data contains at least"):
+        signal.freq = [1, 2, "3"]
+
+    with pytest.raises(ValueError, match="The input data contains at least"):
+        signal.freq_raw = [1, 2, "3"]

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -38,6 +38,16 @@ def test_signal_init_assertions():
     with pytest.raises(ValueError, match="Invalid domain"):
         Signal(1, 44100, domain="space")
 
+    # invalid data: object array
+    with pytest.raises(ValueError, match="The input data contains at least"):
+        Signal([1, 2, "3"], 44100)
+    # invalid data: NaN
+    with pytest.raises(ValueError, match="The input data contains at least"):
+        Signal([1, 2, np.nan], 44100)
+    # invalid data: infinity
+    with pytest.raises(ValueError, match="The input data contains at least"):
+        Signal([1, 2, np.inf], 44100)
+
 
 def test_signal_init_time_dtype():
     """
@@ -74,10 +84,6 @@ def test_data_frequency_init_dtype():
     # complex
     signal = Signal([1+1j, 2+2j, 3+3j], 44100, 4, "freq")
     assert signal.freq.dtype.kind == "c"
-
-    # object array
-    with pytest.raises(ValueError, match="frequency data is"):
-        Signal(["1", "2", "3"], 44100, 4, "freq")
 
 
 def test_signal_comment():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #431, requires #436 / #453

### Changes proposed in this pull request:

- Check for non-numerical data in `Signal.__init__`

I did not find a way to check for boolean data, because it is converted to float when calling `np.atleast_2d(data)`. Any ideas?
