### PR TITLE
Interpolate spectrum on logarithmic frequency axis

### DIFF
--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -895,12 +895,14 @@ class InterpolateSpectrum():
         """
         Return frequencies for creating or quering interpolation objects.
 
-        In case logfrequencies are requested, 0 Hz entries are replaced by
-        the next highest frequency, because the logarithm of 0 does not exist.
+        In case logfrequencies are requested, 0 Hz can not be used, because the
+        logarithm of 0 does not exist. 0 Hz is replaced with a frequency close
+        (but not too close) to 0 Hz to avoid numerical issues during the
+        interpolation.
         """
         if self._fscale == "log":
             if frequencies[0] == 0:
-                frequencies[0] = frequencies[1]
+                frequencies[0] = min(1, frequencies[1]/2)
             frequencies = np.log(frequencies)
 
         return frequencies

--- a/tests/test_dsp_interpolation.py
+++ b/tests/test_dsp_interpolation.py
@@ -332,24 +332,25 @@ def test_interpolate_spectrum_fscale():
 
     # test parametres and data
     f_in_lin = [0, 10, 20]
-    f_in_log = np.log([10, 10, 20])
+    f_in_log = np.log([1, 10, 20])
     n_samples = 10
     sampling_rate = 40
     f_query_lin = pf.dsp.fft.rfftfreq(n_samples, sampling_rate)
     f_query_log = f_query_lin.copy()
-    f_query_log[0] = f_query_log[1]
+    f_query_log[0] = 1
     f_query_log = np.log(f_query_log)
     data = pf.FrequencyData([1, 1, 1], f_in_lin)
 
     # generate interpolator with linear frequency
     interpolator_lin = InterpolateSpectrum(
         data, "magnitude", ("linear", "linear", "linear"), fscale="linear")
-    _ = interpolator_lin(n_samples, sampling_rate)
+    signal = interpolator_lin(n_samples, sampling_rate)
+    npt.assert_allclose(signal.time, pf.signals.impulse(n_samples).time)
     # generate interpolator with logarithmic frequency
     interpolator_log = InterpolateSpectrum(
         data, "magnitude", ("linear", "linear", "linear"), fscale="log")
-    with pytest.warns(RuntimeWarning):
-        _ = interpolator_log(n_samples, sampling_rate)
+    signal = interpolator_log(n_samples, sampling_rate)
+    npt.assert_allclose(signal.time, pf.signals.impulse(n_samples).time)
 
     # test frequency vectors
     npt.assert_allclose(interpolator_lin._f_in, f_in_lin)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

`dsp.InterpolateSpectrum` resulted in Signals containing NaN values if interpolating on a log. frequency axis. The problem was caused by passing two identical frequencies to the interpolation object. This is now fixed by a better choice for f=0 Hz, which has to be treated because log(0) = -inf. The fix is required because NaN's are not allowed anymore (#435).

### Changes proposed in this pull request:

- Replace 0 Hz with small positive value
- add test for output value