### PR TITLE
Reading frequency domain signals

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -782,8 +782,9 @@ class Signal(FrequencyData, TimeData):
 
     def _encode(self):
         """Return dictionary for the encoding."""
-        self.domain = "time"
-        class_dict = self.copy().__dict__
+        selfcopy = self.copy()
+        selfcopy.domain = "time"
+        class_dict = selfcopy.__dict__
         return class_dict
 
     @classmethod

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -611,7 +611,6 @@ class Signal(FrequencyData, TimeData):
                 raise ValueError(("n_samples can not be larger than "
                                   "2 * data.shape[-1] - 2"))
             self._n_samples = n_samples
-            self._n_bins = data.shape[-1]
             # Init remaining parameters
             FrequencyData.__init__(self, data, self.frequencies, comment)
             delattr(self, '_frequencies')
@@ -787,7 +786,9 @@ class Signal(FrequencyData, TimeData):
         obj = cls(
             obj_dict['_data'],
             obj_dict['_sampling_rate'],
-            obj_dict['_n_samples'])
+            obj_dict['_n_samples'],
+            obj_dict['_domain'],
+            obj_dict['_fft_norm'])
         obj.__dict__.update(obj_dict)
         return obj
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -780,15 +780,19 @@ class Signal(FrequencyData, TimeData):
                       fft_norm=self.fft_norm, comment=self.comment)
         return item
 
+    def _encode(self):
+        """Return dictionary for the encoding."""
+        self.domain = "time"
+        class_dict = self.copy().__dict__
+        return class_dict
+
     @classmethod
     def _decode(cls, obj_dict):
         """Decode object based on its respective `_encode` counterpart."""
         obj = cls(
             obj_dict['_data'],
             obj_dict['_sampling_rate'],
-            obj_dict['_n_samples'],
-            obj_dict['_domain'],
-            obj_dict['_fft_norm'])
+            obj_dict['_n_samples'])
         obj.__dict__.update(obj_dict)
         return obj
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -187,11 +187,13 @@ def test_write_read_coordinates(coordinates, tmpdir):
     assert actual == coordinates
 
 
-def test_write_read_signal(sine, tmpdir):
+@pytest.mark.parametrize("domain", ["time", "freq"])
+def test_write_read_signal(domain, sine, tmpdir):
     """ Signal
     Make sure `read` understands the bits written by `write`
     """
     filename = os.path.join(tmpdir, 'signal.far')
+    sine.domain = domain
     io.write(filename, signal=sine)
     actual = io.read(filename)['signal']
     assert isinstance(actual, Signal)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -197,6 +197,8 @@ def test_write_read_signal(domain, sine, tmpdir):
     io.write(filename, signal=sine)
     actual = io.read(filename)['signal']
     assert isinstance(actual, Signal)
+    # io.write encodes in domain = 'time'
+    sine.domain = "time"
     assert actual == sine
 
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #442

### Changes proposed in this pull request:
-  `Signal._decode` always assumed time domain data. So we added
```python
obj_dict['_domain'],
obj_dict['_fft_norm']
```
- Signals initialized `self._n_bins = data.shape[-1]` if `domain =='freq'`, but it was never used.
- parametrized test for read and write a Signal