### PR TITLE
Empty dicts to use current active plotstyle

### DIFF
--- a/pyfar/_concepts/plots.py
+++ b/pyfar/_concepts/plots.py
@@ -19,6 +19,40 @@ the axis limits using the Matplotlib axis object:
     >>> ax = pf.plot.freq(noise, color=(.3, .3, .3))
     >>> ax.set_ylim(-60, -20)
 
+
+Plot styles
+-----------
+
+Pyfar contains a `light` and `dark` plot style and applies the `light` plot
+style by default in its :py:mod:`plot functions <pyfar.plot>`. If you want to
+apply the style to code outside these functions you can use
+
+::
+
+    pyfar.plot.use()
+
+to overwrite the currently used plot style or
+
+::
+
+    with pyfar.plot.context():
+        # everything inside the with statement
+        # uses the pyfar plot style
+
+If you want do not want to use the pyfar plot style, you can pass an empty
+dictionary to the plot functions
+
+::
+
+    pyfar.plot.time(signal, style={})
+
+This can also be used to overwrite specific parameters of the pyfar plot styles
+
+::
+
+    pyfar.plot.time(signal, style={axes.facecolor='black'})
+
+
 Interactive plots
 -----------------
 

--- a/pyfar/_concepts/plots.py
+++ b/pyfar/_concepts/plots.py
@@ -39,7 +39,7 @@ to overwrite the currently used plot style or
         # everything inside the with statement
         # uses the pyfar plot style
 
-If you want do not want to use the pyfar plot style, you can pass an empty
+If you do not want to use the pyfar plot style, you can pass an empty
 dictionary to the plot functions
 
 ::

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -49,7 +49,7 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit="s",
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
@@ -120,7 +120,7 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     xscale : str
 
@@ -201,7 +201,7 @@ def phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     xscale : str
 
@@ -289,7 +289,7 @@ def group_delay(signal, unit="s", freq_scale='log', ax=None, style='light',
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     xscale : str
 
@@ -397,7 +397,7 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     xscale : str
 
@@ -491,7 +491,7 @@ def freq_phase(signal, dB=True, log_prefix=None, log_reference=1,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     xscale : str
 
@@ -592,7 +592,7 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     xscale : str
 
@@ -668,7 +668,7 @@ def custom_subplots(signal, plots, ax=None, style='light', **kwargs):
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -47,8 +47,10 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit="s",
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
 
@@ -116,8 +118,10 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -195,8 +199,10 @@ def phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -281,8 +287,10 @@ def group_delay(signal, unit="s", freq_scale='log', ax=None, style='light',
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -387,8 +395,10 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         uses the current axis or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -478,9 +488,11 @@ def freq_phase(signal, dB=True, log_prefix=None, log_reference=1,
         Array or list with two axes to plot on. The default is ``None``, which
         uses the current axis or creates a new figure if none exists.
     style : str
-        ``light`` or ``dark`` to use the pyfar plot styles or style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -578,8 +590,10 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
         uses the current axis or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -652,8 +666,10 @@ def custom_subplots(signal, plots, ax=None, style='light', **kwargs):
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
 

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -48,7 +48,7 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit="s",
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
 
@@ -117,7 +117,7 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -196,7 +196,7 @@ def phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -282,7 +282,7 @@ def group_delay(signal, unit="s", freq_scale='log', ax=None, style='light',
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -388,7 +388,7 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -479,7 +479,8 @@ def freq_phase(signal, dB=True, log_prefix=None, log_reference=1,
         uses the current axis or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+        to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -578,7 +579,7 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -652,7 +653,7 @@ def custom_subplots(signal, plots, ax=None, style='light', **kwargs):
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
 

--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -47,7 +47,8 @@ def time(signal, dB=False, log_prefix=20, log_reference=1, unit="s",
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
 
@@ -115,7 +116,8 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -193,7 +195,8 @@ def phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -278,7 +281,8 @@ def group_delay(signal, unit="s", freq_scale='log', ax=None, style='light',
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -383,7 +387,8 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         uses the current axis or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -572,7 +577,8 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
         uses the current axis or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     xscale : str
 
         .. deprecated:: 0.4.0
@@ -645,7 +651,8 @@ def custom_subplots(signal, plots, ax=None, style='light', **kwargs):
         or creates a new figure if none exists.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to ``matplotlib.pyplot.plot()``.
 

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -92,7 +92,7 @@ def time_2d(signal, dB=False, log_prefix=None, log_reference=1, unit="s",
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -223,7 +223,7 @@ def freq_2d(signal, dB=True, log_prefix=None, log_reference=1,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -348,7 +348,7 @@ def phase_2d(signal, deg=False, unwrap=False, freq_scale='log', indices=None,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -481,7 +481,7 @@ def group_delay_2d(signal, unit="s", freq_scale='log', indices=None,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -629,7 +629,7 @@ def time_freq_2d(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -765,7 +765,7 @@ def freq_phase_2d(signal, dB=True, log_prefix=None, log_reference=1,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -908,7 +908,7 @@ def freq_group_delay_2d(signal, dB=True, log_prefix=None, log_reference=1,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -1038,7 +1038,7 @@ def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-         to use the current active plotstyle. The default is ``light``.
+        to use the current active plotstyle. The default is ``light``.
     yscale : str
 
         .. deprecated:: 0.4.0

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -93,7 +93,7 @@ def time_2d(signal, dB=False, log_prefix=None, log_reference=1, unit="s",
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -226,7 +226,7 @@ def freq_2d(signal, dB=True, log_prefix=None, log_reference=1,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -353,7 +353,7 @@ def phase_2d(signal, deg=False, unwrap=False, freq_scale='log', indices=None,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -488,7 +488,7 @@ def group_delay_2d(signal, unit="s", freq_scale='log', indices=None,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -638,7 +638,7 @@ def time_freq_2d(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -776,7 +776,7 @@ def freq_phase_2d(signal, dB=True, log_prefix=None, log_reference=1,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -921,7 +921,7 @@ def freq_group_delay_2d(signal, dB=True, log_prefix=None, log_reference=1,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
@@ -1053,7 +1053,7 @@ def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
         ``matplotlib.style.available``. Pass a dictonary to set specific plot
         parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
-        empty dictonary ``style = {}`` to use the current active plotstyle.
+        empty dictonary ``style = {}`` to use the currently active plotstyle.
         The default is ``light``.
     yscale : str
 

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -91,7 +91,8 @@ def time_2d(signal, dB=False, log_prefix=None, log_reference=1, unit="s",
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -221,7 +222,8 @@ def freq_2d(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -345,7 +347,8 @@ def phase_2d(signal, deg=False, unwrap=False, freq_scale='log', indices=None,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -477,7 +480,8 @@ def group_delay_2d(signal, unit="s", freq_scale='log', indices=None,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -624,7 +628,8 @@ def time_freq_2d(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -759,7 +764,8 @@ def freq_phase_2d(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -901,7 +907,8 @@ def freq_group_delay_2d(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -1030,7 +1037,8 @@ def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. The default is ``light``.
+        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
+         to use the current active plotstyle. The default is ``light``.
     yscale : str
 
         .. deprecated:: 0.4.0

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -91,8 +91,10 @@ def time_2d(signal, dB=False, log_prefix=None, log_reference=1, unit="s",
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -222,8 +224,10 @@ def freq_2d(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -347,8 +351,10 @@ def phase_2d(signal, deg=False, unwrap=False, freq_scale='log', indices=None,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -480,8 +486,10 @@ def group_delay_2d(signal, unit="s", freq_scale='log', indices=None,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -628,8 +636,10 @@ def time_freq_2d(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -764,8 +774,10 @@ def freq_phase_2d(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -907,8 +919,10 @@ def freq_group_delay_2d(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     **kwargs
         Keyword arguments that are passed to
         ``matplotlib.pyplot.pcolormesh()`` or ``matplotlib.pyplot.contourf()``.
@@ -1037,8 +1051,10 @@ def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         The default is ``None``.
     style : str
         ``light`` or ``dark`` to use the pyfar plot styles or a plot style from
-        ``matplotlib.style.available``. Pass an empty dictonary ``style = {}``
-        to use the current active plotstyle. The default is ``light``.
+        ``matplotlib.style.available``. Pass a dictonary to set specific plot
+        parameters, for example ``style = {'axes.facecolor':'black'}``. Pass an
+        empty dictonary ``style = {}`` to use the current active plotstyle.
+        The default is ``light``.
     yscale : str
 
         .. deprecated:: 0.4.0

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -562,3 +562,15 @@ def test_title_style(style, handsome_signal):
     save_and_compare(create_baseline, baseline_path, output_path, filename,
                      file_type, compare_output)
     plt.close('all')
+
+
+@pytest.mark.parametrize('rcParams, value', [
+    ['lines.linestyle', ':'],
+    ['axes.facecolor', 'black'],
+    ['axes.grid', False]])
+def test_context_manager_empty_dicts(rcParams, value):
+    # Test calling empty dict to use current active plotstyle
+    with pf.plot.context({rcParams: value}):
+        pf.plot.time(pf.TimeData([0, 1, 0, -1], range(4)), style={})
+        assert plt.rcParams[rcParams] == value
+    plt.close('all')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from pytest import raises
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 import pyfar as pf
 import pyfar.plot as plot
 from pyfar.testing.plot_utils import create_figure, save_and_compare
@@ -576,4 +577,14 @@ def test_pyfar_plot_with_empty_style(rcParams, value):
     with pf.plot.context({rcParams: value}):
         pf.plot.time(pf.TimeData([0, 1, 0, -1], range(4)), style={})
         assert plt.rcParams[rcParams] == value
+    plt.close('all')
+
+
+def test_set_specific_plot_parameters():
+    # Test pass a dictonary to set specific plot parameters
+    with pf.plot.context("light"):
+        pf.plot.time(pf.TimeData([0, 1, 0, -1], range(4)),
+                     style={'axes.facecolor': '#000000'})
+        facecolor = mcolors.to_hex(plt.gca().patch.get_facecolor())
+        assert facecolor == '#000000'  # #000000 is hex for black
     plt.close('all')

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -568,8 +568,8 @@ def test_title_style(style, handsome_signal):
     ['lines.linestyle', ':'],
     ['axes.facecolor', 'black'],
     ['axes.grid', False]])
-def test_context_manager_empty_dicts(rcParams, value):
-    # Test calling empty dict to use current active plotstyle
+def test_pyfar_plot_with_empty_style(rcParams, value):
+    # Test passing an empty style to a pyfar plot function to check if the currently active plot stlye remains active
     with pf.plot.context({rcParams: value}):
         pf.plot.time(pf.TimeData([0, 1, 0, -1], range(4)), style={})
         assert plt.rcParams[rcParams] == value

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -569,7 +569,10 @@ def test_title_style(style, handsome_signal):
     ['axes.facecolor', 'black'],
     ['axes.grid', False]])
 def test_pyfar_plot_with_empty_style(rcParams, value):
-    # Test passing an empty style to a pyfar plot function to check if the currently active plot stlye remains active
+    """
+    Test passing an empty style to a pyfar plot function to check if the
+    currently active plot stlye remains active.
+    """
     with pf.plot.context({rcParams: value}):
         pf.plot.time(pf.TimeData([0, 1, 0, -1], range(4)), style={})
         assert plt.rcParams[rcParams] == value


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #400

### Changes proposed in this pull request:

- Expanded docstring to  pass an empty dictonary ``style = {}`` to use the current active plotstyle.
- Implemented Test


