### PR TITLE
Add concatenate function

### DIFF
--- a/docs/concepts/resources/plot_shortcuts.rst
+++ b/docs/concepts/resources/plot_shortcuts.rst
@@ -23,7 +23,7 @@
    * - 8, ctrl+shift+g
      - :py:func:`~pyfar.plot.freq_group_delay`
 
-Note that not all plots are available for TimeData and FrequencyData objects as detailed in the :py:mod:`plots module <pyfar.plot>` documentation.
+Note that not all plots are available for TimeData and FrequencyData objects as detailed in the :py:mod:`plot module <pyfar.plot>` documentation.
 
 **Use these shortcuts to control the plot**
 

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -201,7 +201,8 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
     data = np.concatenate([s._data for s in signals], axis=axis)
     # append comments in signals to comment to return
     if comment != "":
-        comment = comment + '\n' + f'Signals concatenated in caxis={caxis}.\n'
+        comment = comment + '\n'
+    comment = comment + f'Signals concatenated in caxis={caxis}.\n'
     sig_channel = 0
     for s in signals:
         if s.comment != "":

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -129,7 +129,7 @@ def broadcast_cdims(signals, cdim=None):
     return [broadcast_cdim(s, cdim) for s in signals]
 
 
-def concatenate(signals, caxis=0, broadcasting=False):
+def concatenate_channels(signals, caxis=0, broadcasting=False):
     """
     Merge multiple Signal, Timedata or Frequencydata objects along a given
     caxis.
@@ -156,7 +156,7 @@ def concatenate(signals, caxis=0, broadcasting=False):
         The default is ``False``.
     Returns
     -------
-    merged : Signal
+    merged : Signal, TimeData, FrequencyData
         The merged signal object.
     """
     # check input

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -139,7 +139,7 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
     signals : tuple of Signal, TimeData or FrequencyData
         The signals to concatenate. All signals must be of the same object type
         and either have the same cshape or be broadcastable to the same cshape,
-        except in the dimension corresponding to axis (the first, by default).
+        except in the dimension corresponding to caxis (the first, by default).
         If this is the case, set ``broadcasting=True``.
     caxis : int
         The caxis along which the signals are concatenated. More details and

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -146,11 +146,12 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
         broadcastable to the same cshape, except in the dimension corresponding
         to axis (the first, by default). If this is the case, set
         ``broadcasting=True``.
-    axis : int
-        The axis along which the signals are concatenated. The default is 0.
+    caxis : int
+        The axis along which the signals are concatenated.
+        The default is ``0``.
     broadcasting: bool
         If this is ``True``, the signals will be broadcasted into largest
-        dimension and into a common cshape, except of the axis along which the
+        dimension and into a common cshape, except of the caxis along which the
         signals are concatenated. The default is ``False``.
     comment: string
         A comment related to the merged `data`. The default is ``""``, which
@@ -175,7 +176,6 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
     # broadcast signals into largest dimension and common cshapes
     if broadcasting is True:
         # broadcast signals into common cshape
-        # signals = pf.utils.broadcast_cshapes(signals, ignore_axis=caxis)
         cshapes = [s.cshape for s in signals]
         max_cdim = np.max([len(sh) for sh in cshapes])
         for i, sh in enumerate(cshapes):
@@ -188,10 +188,10 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
         for i, s in enumerate(signals):
             # Appends the axis to ignore back into cshape to broadcast to.
             if caxis in (-1, len(cshape)):
-                # Use append if ignore_axis is defined for last dimension
+                # Use append if caxis is defined for last dimension
                 cs = np.append(cshape, cshapes[i][caxis])
             else:
-                # Use insert if ignore_axis is not defined for last dim
+                # Use insert if caxis is not defined for last dim
                 axis = caxis+1 if caxis < 0 else caxis
                 cs = np.insert(cshape, axis, cshapes[i][caxis])
             broad_signals.append(broadcast_cshape(s, tuple(cs)))

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -129,7 +129,7 @@ def broadcast_cdims(signals, cdim=None):
     return [broadcast_cdim(s, cdim) for s in signals]
 
 
-def concatenate(signals, caxis=0, broadcasting=False, comment=""):
+def concatenate(signals, caxis=0, broadcasting=False):
     """
     Merge multiple Signal, Timedata or Frequencydata objects along a given
     caxis.
@@ -154,11 +154,6 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
         broadcasted following the `numpy broadcasting rules
         <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_
         The default is ``False``.
-    comment: string
-        A comment related to the merged `data`. The default is ``""``, which
-        initializes an empty string. Comments of the input signals will also
-        be returned in the new Signal object. These comments are marked with
-        their corresponding signal position in the input tuple.
     Returns
     -------
     merged : Signal
@@ -169,8 +164,6 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
         if not isinstance(signal, (pf.Signal, pf.TimeData, pf.FrequencyData)):
             raise TypeError("All input data must be of type pf.Signal, "
                             "pf.TimeData or pf.FrequencyData.")
-    if not isinstance(comment, str):
-        raise TypeError("'comment' needs to be a string.")
     if not isinstance(broadcasting, bool):
         raise TypeError("'broadcasting' needs to be False or True.")
     # check matching meta data of input signals.
@@ -201,25 +194,13 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
     # merge the signals along axis
     axis = caxis-1 if caxis < 0 else caxis
     data = np.concatenate([s._data for s in signals], axis=axis)
-    # append comments in signals to comment to return
-    if comment != "":
-        comment = comment + '\n'
-    comment = comment + f'Signals concatenated in caxis={caxis}.\n'
-    sig_channel = 0
-    for s in signals:
-        if s.comment != "":
-            comment += f"Channel {sig_channel+1}-"\
-                       f"{sig_channel + s.cshape[caxis]}: "\
-                       + s.comment + '\n'
-        sig_channel += s.cshape[caxis]
     # return merged Signal
     if isinstance(signals[0], pf.Signal):
         return pf.Signal(data, signals[0].sampling_rate,
                          n_samples=signals[0].n_samples,
                          domain=signals[0].domain,
-                         fft_norm=signals[0].fft_norm,
-                         comment=comment)
+                         fft_norm=signals[0].fft_norm)
     elif isinstance(signals[0], pf.TimeData):
-        return pf.TimeData(data, signals[0].times, comment)
+        return pf.TimeData(data, signals[0].times)
     else:
-        return pf.FrequencyData(data, signals[0].frequencies, comment)
+        return pf.FrequencyData(data, signals[0].frequencies)

--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -201,10 +201,14 @@ def concatenate(signals, caxis=0, broadcasting=False, comment=""):
     data = np.concatenate([s._data for s in signals], axis=axis)
     # append comments in signals to comment to return
     if comment != "":
-        comment = comment + '\n'
-    for idx, s in enumerate(signals):
+        comment = comment + '\n' + f'Signals concatenated in caxis={caxis}.\n'
+    sig_channel = 0
+    for s in signals:
         if s.comment != "":
-            comment += str(idx+1) + ". " + s.comment + '\n'
+            comment += f"Channel {sig_channel+1}-"\
+                       f"{sig_channel + s.cshape[caxis]}: "\
+                       + s.comment + '\n'
+        sig_channel += s.cshape[caxis]
     # return merged Signal
     return pf.Signal(data, signals[0].sampling_rate,
                      n_samples=signals[0].n_samples,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,7 +104,7 @@ def test_broadcast_cdims_assertions():
     (np.random.randn(512)),
     (np.random.randn(2, 512))])
 def test_concatenate(data_second):
-    # Parametrized concatenation test for singel and multichannel signal
+    # Parametrized concatenation test for single- and multichannel signal
     sr = 48e3
 
     # Get random data with 512 samples

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,8 +138,9 @@ def test_concatenate_comments():
                pf.Signal(np.ones((1, 2) + (n_samples, )), sr, comment="three"))
     conc = pf.utils.concatenate(signals, caxis=-1, comment="Conc Signal")
     assert conc.comment == "Conc Signal\n"\
-                           "1. one\n"\
-                           "3. three\n"
+                           "Signals concatenated in caxis=-1.\n"\
+                           "Channel 1-2: one\n"\
+                           "Channel 5-6: three\n"
 
 
 def test_concatenate_assertions():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -103,7 +103,7 @@ def test_broadcast_cdims_assertions():
 @pytest.mark.parametrize("data_second", [
     (np.random.randn(512)),
     (np.random.randn(2, 512))])
-def test_concatenate(data_second):
+def test_concatenate_channels(data_second):
     # Parametrized concatenation test for single- and multichannel signal
     sr = 48e3
 
@@ -111,21 +111,21 @@ def test_concatenate(data_second):
     data_first = np.random.randn(512)
     signals = (pf.Signal(data_first, sr), pf.Signal(data_second, sr))
 
-    res = pf.utils.concatenate(signals, caxis=0)
+    res = pf.utils.concatenate_channels(signals, caxis=0)
     ideal = np.concatenate(
         (np.atleast_2d(data_first), np.atleast_2d(data_second)), axis=0)
 
     npt.assert_allclose(res._data, ideal)
 
 
-def test_broadcasting_in_concatenate():
+def test_broadcasting_in_concatenate_channels():
     # Test broadcasting into largest dimension and shape, while ignoring caxis.
     sr = 48e3
     n_samples = 512
     signals = (pf.Signal(np.ones((1, 2, 3) + (n_samples, )), sr),
                pf.Signal(np.ones((2,) + (n_samples, )), sr),
                pf.Signal(np.ones((1, 1, 2) + (n_samples, )), sr))
-    conc = pf.utils.concatenate(signals, caxis=-1, broadcasting=True)
+    conc = pf.utils.concatenate_channels(signals, caxis=-1, broadcasting=True)
     assert conc.cshape == (1, 2, 7)
 
 
@@ -136,7 +136,7 @@ def test_broadcasting_in_concatenate():
     (pf.TimeData([1, 2, 3], [1, 2, 3]), pf.TimeData([4, 5, 6], [1, 2, 3]))])
 def test_pyfar_object_types(signals):
     # Test concatenation for all pyfar object types
-    conc = pf.utils.concatenate(signals)
+    conc = pf.utils.concatenate_channels(signals)
     ideal = [[1, 2, 3], [4, 5, 6]]
     npt.assert_equal(conc._data, ideal)
 
@@ -144,12 +144,12 @@ def test_pyfar_object_types(signals):
 def test_concatenate_assertions():
     """Test assertions"""
     with pytest.raises(TypeError, match="All input data must be"):
-        pf.utils.concatenate(([1, 2], [3, 4]))
+        pf.utils.concatenate_channels(([1, 2], [3, 4]))
     signals = (pf.Signal(np.ones((1, 2, 512)), 44100),
                pf.Signal(np.ones((1, 1, 512)), 44100))
     with pytest.raises(TypeError, match="'broadcasting' needs to be"):
-        pf.utils.concatenate(signals, caxis=-1, broadcasting=1)
+        pf.utils.concatenate_channels(signals, caxis=-1, broadcasting=1)
     signals = (pf.Signal([1, 2, 3], 44100),
                pf.TimeData([1, 2, 3], [1, 2, 3]))
     with pytest.raises(ValueError, match="Comparison only valid against"):
-        pf.utils.concatenate(signals)
+        pf.utils.concatenate_channels(signals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -141,28 +141,12 @@ def test_pyfar_object_types(signals):
     npt.assert_equal(conc._data, ideal)
 
 
-def test_concatenate_comments():
-    # Test for comment concatenation
-    sr = 48e3
-    n_samples = 512
-    signals = (pf.Signal(np.ones((1, 2) + (n_samples, )), sr, comment="one"),
-               pf.Signal(np.ones((1, 2) + (n_samples, )), sr),
-               pf.Signal(np.ones((1, 2) + (n_samples, )), sr, comment="three"))
-    conc = pf.utils.concatenate(signals, caxis=-1, comment="Conc Signal")
-    assert conc.comment == "Conc Signal\n"\
-                           "Signals concatenated in caxis=-1.\n"\
-                           "Channel 1-2: one\n"\
-                           "Channel 5-6: three\n"
-
-
 def test_concatenate_assertions():
     """Test assertions"""
     with pytest.raises(TypeError, match="All input data must be"):
         pf.utils.concatenate(([1, 2], [3, 4]))
     signals = (pf.Signal(np.ones((1, 2, 512)), 44100),
                pf.Signal(np.ones((1, 1, 512)), 44100))
-    with pytest.raises(TypeError, match="'comment' needs to be a string."):
-        pf.utils.concatenate(signals, caxis=-1, comment=1)
     with pytest.raises(TypeError, match="'broadcasting' needs to be"):
         pf.utils.concatenate(signals, caxis=-1, broadcasting=1)
     signals = (pf.Signal([1, 2, 3], 44100),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -129,6 +129,19 @@ def test_broadcasting_in_concatenate():
     assert conc.cshape == (1, 2, 7)
 
 
+@pytest.mark.parametrize("signals", [
+    (pf.Signal([1, 2, 3], 44100), pf.Signal([4, 5, 6], 44100)),
+    (pf.FrequencyData([1, 2, 3], [1, 2, 3]),
+     pf.FrequencyData([4, 5, 6], [1, 2, 3])),
+    (pf.TimeData([1, 2, 3], [1, 2, 3]), pf.TimeData([4, 5, 6], [1, 2, 3]))])
+def test_pyfar_object_types(signals):
+    # Test concatenation for all pyfar object types
+    conc = pf.utils.concatenate(signals)
+    ideal = [[1, 2, 3], [4, 5, 6]]
+    # assert conc._data == ideal
+    npt.assert_equal(conc._data, ideal)
+
+
 def test_concatenate_comments():
     # Test for comment concatenation
     sr = 48e3
@@ -153,3 +166,7 @@ def test_concatenate_assertions():
         pf.utils.concatenate(signals, caxis=-1, comment=1)
     with pytest.raises(TypeError, match="'broadcasting' needs to be"):
         pf.utils.concatenate(signals, caxis=-1, broadcasting=1)
+    signals = (pf.Signal([1, 2, 3], 44100),
+               pf.TimeData([1, 2, 3], [1, 2, 3]))
+    with pytest.raises(ValueError, match="Comparison only valid against"):
+        pf.utils.concatenate(signals)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -138,7 +138,6 @@ def test_pyfar_object_types(signals):
     # Test concatenation for all pyfar object types
     conc = pf.utils.concatenate(signals)
     ideal = [[1, 2, 3], [4, 5, 6]]
-    # assert conc._data == ideal
     npt.assert_equal(conc._data, ideal)
 
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #

### Changes proposed in this pull request:

- Add a concatenation function, concatenating Signals along specified channels.
- Add broadcasting parameter, which broadcasts the signals into largest cdim and a common shape, ignoring caxis. 

- [x] Please rename to concatenate_channles

Otherwise approved

