### PR TITLE
Hotfix: Spectrum interpolation on logarithmic frequency axis avoiding zero frequency.

### DIFF
--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -640,7 +640,7 @@ class InterpolateSpectrum():
     Parameters
     ----------
     data : FrequencyData
-        Input data to be interpolated. `data.fft_norm` must be `'none'`.
+        Input data to be interpolated.
     method : string
         Specifies the input data for the interpolation
 
@@ -680,8 +680,8 @@ class InterpolateSpectrum():
         ``'log'``
             Interpolate on a logarithmic frequency axis. Note that 0 Hz can
             not be interpolated on a logarithmic scale because the logarithm
-            of 0 does not exist. Frequencies of 0 Hz are thus replaced by the
-            next highest frequency before interpolation.
+            of 0 does not exist. Instead of 0 Hz, 1 Hz or the half of the
+            second lowest frequency are used (whatever is smaller).
 
         The default is ``'linear'``.
     clip : bool, tuple

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -714,34 +714,39 @@ class InterpolateSpectrum():
         >>> import pyfar as pf
         >>> import matplotlib.pyplot as plt
         >>> import numpy as np
+        >>>
+        >>> pf.plot.use()
+        >>> _, ax = plt.subplots(2, 3)
+        >>>
         >>> # generate data
         >>> data = pf.FrequencyData([1, 0], [5e3, 20e3])
-        >>> interpolator = pf.dsp.InterpolateSpectrum(
-        ...     data, 'magnitude', ('nearest', 'linear', 'nearest'))
-        >>> # interpolate 64 samples at a sampling rate of 44100
-        >>> signal = interpolator(64, 44100)
-        >>> # add linear phase
-        >>> signal = pf.dsp.linear_phase(signal, 32)
-        >>> # plot input and output data
-        >>> with pf.plot.context():
-        >>>     _, ax = plt.subplots(2, 2)
+        >>>
+        >>> # interpolate and plot
+        >>> for ff, fscale in enumerate(["linear", "log"]):
+        >>>     interpolator = pf.dsp.InterpolateSpectrum(
+        ...         data, 'magnitude', ('nearest', 'linear', 'nearest'),
+        ...         fscale)
+        >>>
+        >>>     # interpolate to 64 samples linear phase impulse response
+        >>>     signal = interpolator(64, 44100)
+        >>>     signal = pf.dsp.linear_phase(signal, 32)
+        >>>
         >>>     # time signal (linear and logarithmic amplitude)
-        >>>     pf.plot.time(signal, ax=ax[0, 0])
-        >>>     pf.plot.time(signal, ax=ax[1, 0], dB=True)
+        >>>     pf.plot.time(signal, ax=ax[ff, 0], unit='ms', dB=True)
         >>>     # frequency plot (linear x-axis)
-        >>>     pf.plot.freq(signal, dB=False, freq_scale="linear",
-        ...                  ax=ax[0, 1])
+        >>>     pf.plot.freq(
+        ...         signal, dB=False, freq_scale="linear", ax=ax[ff, 1])
         >>>     pf.plot.freq(data, dB=False, freq_scale="linear",
-        ...                  ax=ax[0, 1], c='r', ls='', marker='.')
-        >>>     ax[0, 1].set_xlim(0, signal.sampling_rate/2)
+        ...                  ax=ax[ff, 1], c='r', ls='', marker='.')
+        >>>     ax[ff, 1].set_xlim(0, signal.sampling_rate/2)
+        >>>     ax[ff, 1].set_title(
+        ...         f"Interpolated on {fscale} frequency scale")
         >>>     # frequency plot (log x-axis)
-        >>>     pf.plot.freq(signal, dB=False, ax=ax[1, 1], label='input')
-        >>>     pf.plot.freq(data, dB=False, ax=ax[1, 1],
+        >>>     pf.plot.freq(signal, dB=False, ax=ax[ff, 2], label='input')
+        >>>     pf.plot.freq(data, dB=False, ax=ax[ff, 2],
         ...                  c='r', ls='', marker='.', label='output')
-        >>>     min_freq = np.min([signal.sampling_rate / signal.n_samples,
-        ...                        data.frequencies[0]])
-        >>>     ax[1, 1].set_xlim(min_freq, signal.sampling_rate/2)
-        >>>     ax[1, 1].legend(loc='best')
+        >>>     ax[ff, 2].set_xlim(2e3, signal.sampling_rate/2)
+        >>>     ax[ff, 2].legend(loc='best')
 
     """
 

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -678,10 +678,7 @@ class InterpolateSpectrum():
         ``'linear'``
             Interpolate on a linear frequency axis.
         ``'log'``
-            Interpolate on a logarithmic frequency axis. Note that 0 Hz can
-            not be interpolated on a logarithmic scale because the logarithm
-            of 0 does not exist. Instead of 0 Hz, 1 Hz or the half of the
-            second lowest frequency are used (whatever is smaller).
+            Interpolate on a logarithmic frequency axis.
 
         The default is ``'linear'``.
     clip : bool, tuple
@@ -900,19 +897,3 @@ class InterpolateSpectrum():
                 ax[1, 1].legend(loc='best')
 
         return signal
-
-    def _get_frequencies(self, frequencies):
-        """
-        Return frequencies for creating or quering interpolation objects.
-
-        In case logfrequencies are requested, 0 Hz can not be used, because the
-        logarithm of 0 does not exist. 0 Hz is replaced with a frequency close
-        (but not too close) to 0 Hz to avoid numerical issues during the
-        interpolation.
-        """
-        if self._fscale == "log":
-            if frequencies[0] == 0:
-                frequencies[0] = min(1, frequencies[1]/2)
-            frequencies = np.log(frequencies)
-
-        return frequencies

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -895,12 +895,14 @@ class InterpolateSpectrum():
         """
         Return frequencies for creating or quering interpolation objects.
 
-        In case logfrequencies are requested, 0 Hz entries are replaced by
-        the next highest frequency, because the logarithm of 0 does not exist.
+        In case logfrequencies are requested, 0 Hz can not be used, because the
+        logarithm of 0 does not exist. 0 Hz is replaced with a frequency close
+        (but not too close) to 0 Hz to avoid numerical issues during the
+        interpolation.
         """
         if self._fscale == "log":
             if frequencies[0] == 0:
-                frequencies[0] = frequencies[1]
+                frequencies[0] = min(1, frequencies[1]/2)
             frequencies = np.log(frequencies)
 
         return frequencies

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -750,8 +750,7 @@ class InterpolateSpectrum():
 
     """
 
-    def __init__(self, data, method, kind, fscale='linear',
-                 clip=False):
+    def __init__(self, data, method, kind, fscale='linear', clip=False):
 
         # check input ---------------------------------------------------------
         # ... data

--- a/tests/test_dsp_interpolation.py
+++ b/tests/test_dsp_interpolation.py
@@ -332,23 +332,25 @@ def test_interpolate_spectrum_fscale():
 
     # test parametres and data
     f_in_lin = [0, 10, 20]
-    f_in_log = np.log([10, 10, 20])
+    f_in_log = np.log([1, 10, 20])
     n_samples = 10
     sampling_rate = 40
     f_query_lin = pf.dsp.fft.rfftfreq(n_samples, sampling_rate)
     f_query_log = f_query_lin.copy()
-    f_query_log[0] = f_query_log[1]
+    f_query_log[0] = 1
     f_query_log = np.log(f_query_log)
     data = pf.FrequencyData([1, 1, 1], f_in_lin)
 
     # generate interpolator with linear frequency
     interpolator_lin = InterpolateSpectrum(
         data, "magnitude", ("linear", "linear", "linear"), fscale="linear")
-    _ = interpolator_lin(n_samples, sampling_rate)
+    signal = interpolator_lin(n_samples, sampling_rate)
+    npt.assert_allclose(signal.time, pf.signals.impulse(n_samples).time)
     # generate interpolator with logarithmic frequency
     interpolator_log = InterpolateSpectrum(
         data, "magnitude", ("linear", "linear", "linear"), fscale="log")
-    _ = interpolator_log(n_samples, sampling_rate)
+    signal = interpolator_log(n_samples, sampling_rate)
+    npt.assert_allclose(signal.time, pf.signals.impulse(n_samples).time)
 
     # test frequency vectors
     npt.assert_allclose(interpolator_lin._f_in, f_in_lin)

--- a/tests/test_dsp_interpolation.py
+++ b/tests/test_dsp_interpolation.py
@@ -325,39 +325,33 @@ def test_interpolate_spectrum_clip():
            np.all(np.abs(signal_clip.freq) <= 2)
 
 
-def test_interpolate_spectrum_fscale():
+@pytest.mark.parametrize(
+    'fscale,n_samples,sampling_rate,f_in,f_base,f_query',
+    [('linear', 10, 40, [0, 10, 20], [0, 10, 20],
+     pf.dsp.fft.rfftfreq(10, 40)),
+     ('log', 10, 40, [0, 10, 20], [0, .544, .778],
+      [0, .301, .477, .602, .699, .778])])
+def test_interpolate_spectrum_fscale(
+        fscale, n_samples, sampling_rate, f_in, f_base, f_query):
     """
     Test frequency vectors for linear and logarithmic frequency interpolation.
     """
 
-    # test parametres and data
-    f_in_lin = [0, 10, 20]
-    f_in_log = np.log([1, 10, 20])
-    n_samples = 10
-    sampling_rate = 40
-    f_query_lin = pf.dsp.fft.rfftfreq(n_samples, sampling_rate)
-    f_query_log = f_query_lin.copy()
-    f_query_log[0] = 1
-    f_query_log = np.log(f_query_log)
-    data = pf.FrequencyData([1, 1, 1], f_in_lin)
+    # test data
+    data = pf.FrequencyData([1, 1, 1], f_in)
 
-    # generate interpolator with linear frequency
-    interpolator_lin = InterpolateSpectrum(
-        data, "magnitude", ("linear", "linear", "linear"), fscale="linear")
-    signal = interpolator_lin(n_samples, sampling_rate)
+    # generate interpolator
+    interpolator = InterpolateSpectrum(
+        data, "magnitude", ("linear", "linear", "linear"), fscale=fscale)
+    signal = interpolator(n_samples, sampling_rate)
+
+    # test time and frequency vectors
     npt.assert_allclose(signal.time, pf.signals.impulse(n_samples).time)
-    # generate interpolator with logarithmic frequency
-    interpolator_log = InterpolateSpectrum(
-        data, "magnitude", ("linear", "linear", "linear"), fscale="log")
-    signal = interpolator_log(n_samples, sampling_rate)
-    npt.assert_allclose(signal.time, pf.signals.impulse(n_samples).time)
-
-    # test frequency vectors
-    npt.assert_allclose(interpolator_lin._f_in, f_in_lin)
-    npt.assert_allclose(interpolator_lin._f_query, f_query_lin)
-
-    npt.assert_allclose(interpolator_log._f_in, f_in_log)
-    npt.assert_allclose(interpolator_log._f_query, f_query_log)
+    npt.assert_almost_equal(interpolator._f_in, f_in)
+    npt.assert_almost_equal(interpolator._f_base, f_base, 3)
+    npt.assert_almost_equal(interpolator._f_query, f_query, 3)
+    npt.assert_almost_equal(interpolator._f_query[[0, -1]],
+                            interpolator._f_base[[0, -1]])
 
 
 def test_interpolate_spectrum_show():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

`dsp.InterpolateSpectrum` resulted in Signals containing NaN values if interpolating on a log. frequency axis. The problem was caused by passing two identical frequencies to the interpolation object. This is now fixed by a better choice for f=0 Hz, which has to be treated because log(0) = -inf. The fix is required because NaN's are not allowed anymore (#435).

### Changes proposed in this pull request:

- calculate log. frequencies based on an arbitrary equidistant frequency scale starting at 1 not 0 to avoid log(0). This required to move code from the class initialization to the interpolation stage, because the new algorithm needs to know the number of frequency bins to which it interpolates.
- update tests

Is a cherry-pick of PR #436 