### PR TITLE
add transpose method to _Audio

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -114,8 +114,9 @@ class _Audio():
         if axes is None or len(axes) == 0:
             axes = tuple(range(len(self.cshape)))[::-1]
         else:
-            tuple([a-1 if a<0 else a for a in axes])
-        np.empty(np.ones(len(self.cshape), dtype=int)).transpose(axes) # throw exception before deepcopy
+            tuple([a-1 if a < 0 else a for a in axes])
+        # throw exception before deepcopy
+        np.empty(np.ones(len(self.cshape), dtype=int)).transpose(axes)
         transposed = deepcopy(self)
         transposed._data = transposed._data.transpose(*axes, len(self.cshape))
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -106,10 +106,9 @@ class _Audio():
         Parameters
         ----------
         axes : `None`, iterable of ints, or n ints
-            leaving the argument empty will reverse the order of `self.caxes`.
+            `None`(default): reverses the order of `self.caxes`.
             iterable of ints: `i` in the `j`-th place of the interable means
-            that `self._data`'s `i`-th axis becomes the transposed datas `j`-th
-            axis. Defaults to `None`.
+            that the `i`-th axis becomes transposed object's `j`-th axis.
             n ints: same as 'iterable of ints'.
         """
         axes = tuple(range(len(self.cshape)))[::-1] if axes is None else tuple([a-1 if a<0 else a for a in axes])

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -112,11 +112,8 @@ class _Audio():
             axis. Defaults to `None`.
             n ints: same as 'iterable of ints'.
         """
-        axes = tuple(range(len(self.cshape)))[::-1] if len(axes) == 0 else tuple(axes)
-        assert all([isinstance(ax, int) for ax in axes]), "axes must be defined as integers"
-        assert len(axes) == len(set(axes)), "axes have to be unique"
-        assert len(axes) == max(axes) + 1 == len(self.cshape), "axes have to match caxes"
-
+        axes = tuple(range(len(self.cshape)))[::-1] if axes is None else tuple([a-1 if a<0 else a for a in axes])
+        np.empty(np.ones(len(self.cshape))).transpose(axes, -1) # throw exception before deepcopy
         transposed = deepcopy(self)
         transposed._data = transposed._data.transpose(*axes, len(self.cshape))
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -95,7 +95,7 @@ class _Audio():
                 newshape + (length_last_dimension, ))
         except ValueError:
             if np.prod(newshape) != np.prod(self.cshape):
-                raise ValueError((f"Can not reshape audio object of cshape "
+                raise ValueError((f"Cannot reshape audio object of cshape "
                                   f"{self.cshape} to {newshape}"))
 
         return reshaped

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -122,6 +122,11 @@ class _Audio():
 
         return transposed
 
+    @property
+    def T(self):
+        """Shorthand for `Signal.transpose()`."""
+        return self.transpose()
+
     def flatten(self):
         """Return flattened copy of the audio object.
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -12,7 +12,7 @@ import deepdiff
 import numpy as np
 import pyfar.dsp.fft as fft
 from typing import Callable
-from .warnings import PyfarDeprecationWarning
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 
 class _Audio():
@@ -100,19 +100,22 @@ class _Audio():
 
         return reshaped
 
-    def transpose(self, axes=None):
+    def transpose(self, *axes):
         """Transpose time/frequency data and return copy of the audio object.
 
         Parameters
         ----------
-        axes : `None`, iterable of ints, or n ints
-            `None`(default): reverses the order of `self.caxes`.
+        axes : empty, `None`, iterable of ints, or n ints
+            empty (default) or `None`: reverses the order of `self.caxes`.
             iterable of ints: `i` in the `j`-th place of the interable means
             that the `i`-th axis becomes transposed object's `j`-th axis.
             n ints: same as 'iterable of ints'.
         """
-        axes = tuple(range(len(self.cshape)))[::-1] if axes is None else tuple([a-1 if a<0 else a for a in axes])
-        np.empty(np.ones(len(self._data.shape))).transpose(axes, -1) # throw exception before deepcopy
+        if axes is None or len(axes) == 0:
+            axes = tuple(range(len(self.cshape)))[::-1]
+        else:
+            tuple([a-1 if a<0 else a for a in axes])
+        np.empty(np.ones(len(self.cshape), dtype=int)).transpose(axes) # throw exception before deepcopy
         transposed = deepcopy(self)
         transposed._data = transposed._data.transpose(*axes, len(self.cshape))
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -105,11 +105,20 @@ class _Audio():
 
         Parameters
         ----------
-        axes : empty, `None`, iterable of ints, or n ints
-            empty (default) or `None`: reverses the order of `self.caxes`.
-            iterable of ints: `i` in the `j`-th place of the interable means
-            that the `i`-th axis becomes transposed object's `j`-th axis.
-            n ints: same as 'iterable of ints'.
+        caxes : empty, ``None``, iterable of ints, or n ints
+            Define how the :py:mod:` caxes <pyfar._concepts.audio_classes>`
+            are ordered in the transposed audio object.
+            Note that the last dimension of the data in the audio object
+            always contains the time samples or frequency bins and can not
+            be transposed.
+            
+            empty (default) or ``None``
+                reverses the order of ``self.caxes``.
+            iterable of ints
+                `i` in the `j`-th place of the interable means
+                that the `i`-th caxis becomes transposed object's `j`-th caxis.
+            n ints
+                same as 'iterable of ints'.
         """
         if hasattr(axes, '__iter__'):
             axes = axes[0] if len(axes) == 1 else axes

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -125,7 +125,9 @@ class _Audio():
         if axes is None or len(axes) == 0:
             axes = tuple(range(len(self.cshape)))[::-1]
         else:
-            tuple([a-1 if a < 0 else a for a in axes])
+            assert all([a > -len(self.cshape) - 1 for a in axes]), "Negative axes index out of bounds."
+            axes = tuple([a % len(self.cshape) if a < 0 else a for a in axes])
+
         # throw exception before deepcopy
         np.empty(np.ones(len(self.cshape), dtype=int)).transpose(axes)
         transposed = deepcopy(self)

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -101,7 +101,7 @@ class _Audio():
         return reshaped
 
     def transpose(self, axes=None):
-        """Return a transposed copy of the audio object.
+        """Transpose time/frequency data and return copy of the audio object.
 
         Parameters
         ----------

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -105,10 +105,11 @@ class _Audio():
 
         Parameters
         ----------
-        axes : None, iterable of ints, or n ints
-            `None`: will reverse the order of `self.caxes`.
+        axes : empty, iterable of ints, or n ints
+            leaving the argument empty will reverse the order of `self.caxes`.
             iterable of ints: `i` in the `j`-th place of the interable means
-            that `self._data`'s `i`-th axis becomes the transposed datas `j`-th axis.
+            that `self._data`'s `i`-th axis becomes the transposed datas `j`-th
+            axis.
             n ints: same as 'iterable of ints'.
         """
         axes = tuple(range(len(self.cshape)))[::-1] if len(axes) == 0 else tuple(axes)

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -100,16 +100,16 @@ class _Audio():
 
         return reshaped
 
-    def transpose(self, *axes):
+    def transpose(self, axes=None):
         """Return a transposed copy of the audio object.
 
         Parameters
         ----------
-        axes : empty, iterable of ints, or n ints
+        axes : `None`, iterable of ints, or n ints
             leaving the argument empty will reverse the order of `self.caxes`.
             iterable of ints: `i` in the `j`-th place of the interable means
             that `self._data`'s `i`-th axis becomes the transposed datas `j`-th
-            axis.
+            axis. Defaults to `None`.
             n ints: same as 'iterable of ints'.
         """
         axes = tuple(range(len(self.cshape)))[::-1] if len(axes) == 0 else tuple(axes)

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -112,7 +112,7 @@ class _Audio():
             n ints: same as 'iterable of ints'.
         """
         axes = tuple(range(len(self.cshape)))[::-1] if axes is None else tuple([a-1 if a<0 else a for a in axes])
-        np.empty(np.ones(len(self.cshape))).transpose(axes, -1) # throw exception before deepcopy
+        np.empty(np.ones(len(self._data.shape))).transpose(axes, -1) # throw exception before deepcopy
         transposed = deepcopy(self)
         transposed._data = transposed._data.transpose(*axes, len(self.cshape))
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -111,7 +111,7 @@ class _Audio():
             Note that the last dimension of the data in the audio object
             always contains the time samples or frequency bins and can not
             be transposed.
-            
+
             empty (default) or ``None``
                 reverses the order of ``self.caxes``.
             iterable of ints
@@ -125,7 +125,8 @@ class _Audio():
         if axes is None or len(axes) == 0:
             axes = tuple(range(len(self.cshape)))[::-1]
         else:
-            assert all([a > -len(self.cshape) - 1 for a in axes]), "Negative axes index out of bounds."
+            assert all([a > -len(self.cshape) - 1 for a in axes]), \
+                "Negative axes index out of bounds."
             axes = tuple([a % len(self.cshape) if a < 0 else a for a in axes])
 
         # throw exception before deepcopy

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -111,6 +111,8 @@ class _Audio():
             that the `i`-th axis becomes transposed object's `j`-th axis.
             n ints: same as 'iterable of ints'.
         """
+        if hasattr(axes, '__iter__'):
+            axes = axes[0] if len(axes) == 1 else axes
         if axes is None or len(axes) == 0:
             axes = tuple(range(len(self.cshape)))[::-1]
         else:

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -100,6 +100,27 @@ class _Audio():
 
         return reshaped
 
+    def transpose(self, *axes):
+        """Return a transposed copy of the audio object.
+
+        Parameters
+        ----------
+        axes : None, iterable of ints, or n ints
+            `None`: will reverse the order of `self.caxes`.
+            iterable of ints: `i` in the `j`-th place of the interable means
+            that `self._data`'s `i`-th axis becomes the transposed datas `j`-th axis.
+            n ints: same as 'iterable of ints'.
+        """
+        axes = tuple(range(len(self.cshape)))[::-1] if len(axes) == 0 else tuple(axes)
+        assert all([isinstance(ax, int) for ax in axes]), "axes must be defined as integers"
+        assert len(axes) == len(set(axes)), "axes have to be unique"
+        assert len(axes) == max(axes) + 1 == len(self.cshape), "axes have to match caxes"
+
+        transposed = deepcopy(self)
+        transposed._data = transposed._data.transpose(*axes, len(self.cshape))
+
+        return transposed
+
     def flatten(self):
         """Return flattened copy of the audio object.
 

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -110,10 +110,14 @@ def test_reshape_exceptions():
 
 def test_transpose():
     signal_in = FrequencyData(np.random.rand(6, 2, 5, 256), range(256))
-    npt.assert_allclose(signal_in.transpose()._data, signal_in.T._data)
     signal_out = signal_in.transpose()
+    npt.assert_allclose(signal_in.T._data, signal_out._data)
     npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
-    taxis = (2, 0, 1)
+
+
+@pytest.mark.parametrize('taxis', [(2, 0, 1), (-2, 0, -1)])
+def test_transpose_args(taxis):
+    signal_in = FrequencyData(np.random.rand(6, 2, 5, 256), range(256))
     signal_out = signal_in.transpose(taxis)
     npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
     signal_out = signal_in.transpose(*taxis)

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -115,13 +115,13 @@ def test_transpose():
     npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
 
 
-@pytest.mark.parametrize('taxis', [(2, 0, 1), (-2, 0, -1)])
+@pytest.mark.parametrize('taxis', [(2, 0, 1), (-1, 0, -2)])
 def test_transpose_args(taxis):
     signal_in = FrequencyData(np.random.rand(6, 2, 5, 256), range(256))
     signal_out = signal_in.transpose(taxis)
-    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    npt.assert_allclose(signal_in._data.transpose(2, 0, 1, 3), signal_out._data)
     signal_out = signal_in.transpose(*taxis)
-    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    npt.assert_allclose(signal_in._data.transpose(2, 0, 1, 3), signal_out._data)
 
 
 def test_flatten():

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -104,7 +104,7 @@ def test_reshape_exceptions():
         data_out = data_in.reshape([3, 2])
 
     # test assertion for wrong dimension
-    with pytest.raises(ValueError, match='Can not reshape audio object'):
+    with pytest.raises(ValueError, match='Cannot reshape audio object'):
         data_out = data_in.reshape((3, 4))
 
 

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -108,6 +108,18 @@ def test_reshape_exceptions():
         data_out = data_in.reshape((3, 4))
 
 
+def test_transpose():
+    signal_in = FrequencyData(np.random.rand(6, 2, 5, 256), range(256))
+    npt.assert_allclose(signal_in.transpose()._data, signal_in.T._data)
+    signal_out = signal_in.transpose()
+    npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
+    taxis = (2, 0, 1)
+    signal_out = signal_in.transpose(taxis)
+    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    signal_out = signal_in.transpose(*taxis)
+    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+
+
 def test_flatten():
 
     # test 2D signal (flatten should not change anything)

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -430,13 +430,13 @@ def test_transpose():
     npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
 
 
-@pytest.mark.parametrize('taxis', [(2, 0, 1), (-2, 0, -1)])
+@pytest.mark.parametrize('taxis', [(2, 0, 1), (-1, 0, -2)])
 def test_transpose_args(taxis):
     signal_in = Signal(np.random.rand(6, 2, 5, 256), 44100)
     signal_out = signal_in.transpose(taxis)
-    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    npt.assert_allclose(signal_in._data.transpose(2, 0, 1, 3), signal_out._data)
     signal_out = signal_in.transpose(*taxis)
-    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    npt.assert_allclose(signal_in._data.transpose(2, 0, 1, 3), signal_out._data)
 
 
 def test_flatten():

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -425,10 +425,14 @@ def test_reshape_exceptions():
 
 def test_transpose():
     signal_in = Signal(np.random.rand(6, 2, 5, 256), 44100)
-    npt.assert_allclose(signal_in.transpose()._data, signal_in.T._data)
     signal_out = signal_in.transpose()
+    npt.assert_allclose(signal_in.T._data, signal_out._data)
     npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
-    taxis = (2, 0, 1)
+
+
+@pytest.mark.parametrize('taxis', [(2, 0, 1), (-2, 0, -1)])
+def test_transpose_args(taxis):
+    signal_in = Signal(np.random.rand(6, 2, 5, 256), 44100)
     signal_out = signal_in.transpose(taxis)
     npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
     signal_out = signal_in.transpose(*taxis)

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -419,7 +419,7 @@ def test_reshape_exceptions():
         signal_out = signal_in.reshape([3, 2])
 
     # test assertion for wrong dimension
-    with pytest.raises(ValueError, match='Can not reshape audio object'):
+    with pytest.raises(ValueError, match='Cannot reshape audio object'):
         signal_out = signal_in.reshape((3, 4))
 
 

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -423,6 +423,18 @@ def test_reshape_exceptions():
         signal_out = signal_in.reshape((3, 4))
 
 
+def test_transpose():
+    signal_in = Signal(np.random.rand(6, 2, 5, 256), 44100)
+    npt.assert_allclose(signal_in.transpose()._data, signal_in.T._data)
+    signal_out = signal_in.transpose()
+    npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
+    taxis = (2, 0, 1)
+    signal_out = signal_in.transpose(taxis)
+    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    signal_out = signal_in.transpose(*taxis)
+    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+
+
 def test_flatten():
 
     # test 2D signal (flatten should not change anything)

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -88,7 +88,7 @@ def test_reshape_exceptions():
         data_out = data_in.reshape([3, 2])
 
     # test assertion for wrong dimension
-    with pytest.raises(ValueError, match='Can not reshape audio object'):
+    with pytest.raises(ValueError, match='Cannot reshape audio object'):
         data_out = data_in.reshape((3, 4))
 
 

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -94,10 +94,14 @@ def test_reshape_exceptions():
 
 def test_transpose():
     signal_in = TimeData(np.random.rand(6, 2, 5, 256), range(256))
-    npt.assert_allclose(signal_in.transpose()._data, signal_in.T._data)
     signal_out = signal_in.transpose()
+    npt.assert_allclose(signal_in.T._data, signal_out._data)
     npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
-    taxis = (2, 0, 1)
+
+
+@pytest.mark.parametrize('taxis', [(2, 0, 1), (-2, 0, -1)])
+def test_transpose_args(taxis):
+    signal_in = TimeData(np.random.rand(6, 2, 5, 256), range(256))
     signal_out = signal_in.transpose(taxis)
     npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
     signal_out = signal_in.transpose(*taxis)

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -99,13 +99,13 @@ def test_transpose():
     npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
 
 
-@pytest.mark.parametrize('taxis', [(2, 0, 1), (-2, 0, -1)])
+@pytest.mark.parametrize('taxis', [(2, 0, 1), (-1, 0, -2)])
 def test_transpose_args(taxis):
     signal_in = TimeData(np.random.rand(6, 2, 5, 256), range(256))
     signal_out = signal_in.transpose(taxis)
-    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    npt.assert_allclose(signal_in._data.transpose(2, 0, 1, 3), signal_out._data)
     signal_out = signal_in.transpose(*taxis)
-    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    npt.assert_allclose(signal_in._data.transpose(2, 0, 1, 3), signal_out._data)
 
 
 def test_flatten():

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -92,6 +92,18 @@ def test_reshape_exceptions():
         data_out = data_in.reshape((3, 4))
 
 
+def test_transpose():
+    signal_in = TimeData(np.random.rand(6, 2, 5, 256), range(256))
+    npt.assert_allclose(signal_in.transpose()._data, signal_in.T._data)
+    signal_out = signal_in.transpose()
+    npt.assert_allclose(signal_in._data.transpose(2, 1, 0, 3), signal_out._data)
+    taxis = (2, 0, 1)
+    signal_out = signal_in.transpose(taxis)
+    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+    signal_out = signal_in.transpose(*taxis)
+    npt.assert_allclose(signal_in._data.transpose(*taxis, 3), signal_out._data)
+
+
 def test_flatten():
 
     # test 2D signal (flatten should not change anything)


### PR DESCRIPTION
This PR adds a `transpose` method to all `Signals`, very similar to `np.ndarray.transpose`.