### PR TITLE
allow indices for Coordinates.show

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1357,8 +1357,9 @@ class Coordinates():
         Parameters
         ----------
         mask : boolean numpy array, None, optional
-            Mask or indexes to plot. Plot points in red if ``mask==True``.
-            The default is ``None``, which the same color for all points.
+            Mask or indexes to highlight. Highlight points in red if
+            ``mask==True``.
+            The default is ``None``, which plots all points in the same color.
         kwargs : optional
             Keyword arguments are passed to ``matplotlib.pyplot.scatter()``.
             If a mask is provided and the key `c` is contained in kwargs, it
@@ -1374,8 +1375,6 @@ class Coordinates():
             pf.plot.scatter(self, **kwargs)
         else:
             mask = np.asarray(mask)
-            # assert mask.shape == self.cshape,\
-            #     "'mask.shape' must be self.cshape"
             colors = np.full(self.cshape, pf.plot.color('b'))
             colors[mask] = pf.plot.color('r')
             pf.plot.scatter(self, c=colors.flatten(), **kwargs)

--- a/tests/test_coordinates.py
+++ b/tests/test_coordinates.py
@@ -257,11 +257,12 @@ def test_show():
     coords.show()
     # show with mask as list
     coords.show([1, 0, 1])
+    # show with index as list
+    coords.show([0, 1])
     # show with mask as ndarray
     coords.show(np.array([1, 0, 1], dtype=bool))
-    # test assertion
-    with raises(AssertionError):
-        coords.show(np.array([1, 0], dtype=bool))
+    # show with index as ndarray
+    coords.show(np.array([0, 1], dtype=int))
 
     plt.close("all")
 


### PR DESCRIPTION
first Coordinates.show just allow a mask, since we dont support masks for the find functions (#478) anymore we allow indexes as well.

- [x] requieres #483 for flake8