### PR TITLE
fix flake 8

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1374,7 +1374,7 @@ class Coordinates():
             pf.plot.scatter(self, **kwargs)
         else:
             mask = np.asarray(mask)
-            assert mask.shape == self.cshape,\
+            assert mask.shape == self.cshape, \
                 "'mask.shape' must be self.cshape"
             colors = np.full(mask.shape, pf.plot.color('b'))
             colors[mask] = pf.plot.color('r')
@@ -1437,7 +1437,7 @@ class Coordinates():
         """
 
         # check the input
-        assert isinstance(k, int) and k > 0 and k <= self.csize,\
+        assert isinstance(k, int) and k > 0 and k <= self.csize, \
             "k must be an integer > 0 and <= self.csize."
 
         # get the points
@@ -1658,7 +1658,7 @@ class Coordinates():
 
         # check if  value is within the range of coordinate
         if c_info[0] in ["bound", "cyclic"]:
-            assert c_info[1][0] <= value <= c_info[1][1],\
+            assert c_info[1][0] <= value <= c_info[1][1], \
                 f"'value' is {value} but must be in the range {c_info[1]}."
 
         # get the search range
@@ -2034,7 +2034,7 @@ class Coordinates():
 
         # check if convention exists in domain
         if convention is not None:
-            assert convention in systems[domain] or convention is None,\
+            assert convention in systems[domain] or convention is None, \
                 f"{convention} does not exist in {domain}. Convention must "\
                 f"be one of the following: {', '.join(list(systems[domain]))}."
 
@@ -2172,7 +2172,7 @@ class Coordinates():
         weights = np.asarray(weights, dtype=np.float64)
 
         # reshape according to self._points
-        assert weights.size == self.csize,\
+        assert weights.size == self.csize, \
             "weights must have same size as self.csize"
         weights = weights.reshape(self.cshape)
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1973,7 +1973,7 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False,
                                pyfar.TimeData)):
         raise TypeError(("Input data has to be of type 'Signal', 'TimeData' "
                          "or 'FrequencyData'."))
-    if isinstance(signal, pyfar.TimeData) and mode in (
+    if type(signal) is pyfar.TimeData and mode in (
             'log_magnitude_zerophase', 'magnitude_zerophase',
             'magnitude_phase', 'power',):
         raise ValueError((
@@ -2208,11 +2208,11 @@ def normalize(signal, reference_method='max', domain='time',
 
     if domain not in ('time', 'freq'):
         raise ValueError("domain must be 'time' or 'freq'.")
-    if isinstance(signal, pyfar.FrequencyData) and domain == 'time':
+    if type(signal) is pyfar.FrequencyData and domain == 'time':
         raise ValueError((
             f"domain is '{domain}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'TimeData'."))
-    if isinstance(signal, pyfar.TimeData) and domain == 'freq':
+    if type(signal) is pyfar.TimeData and domain == 'freq':
         raise ValueError((
             f"domain is '{domain}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'FrequencyData'."))

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1975,7 +1975,7 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False,
                          "or 'FrequencyData'."))
     if type(signal) is pyfar.TimeData and mode in (
             'log_magnitude_zerophase', 'magnitude_zerophase',
-            'magnitude_phase', 'power',):
+            'magnitude_phase', 'power'):
         raise ValueError((
             f"mode is '{mode}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'FrequencyData'."))

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1973,10 +1973,9 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False,
                                pyfar.TimeData)):
         raise TypeError(("Input data has to be of type 'Signal', 'TimeData' "
                          "or 'FrequencyData'."))
-    if type(signal) == pyfar.TimeData and mode in ('log_magnitude_zerophase',
-                                                   'magnitude_zerophase',
-                                                   'magnitude_phase',
-                                                   'power',):
+    if isinstance(signal, pyfar.TimeData) and mode in (
+            'log_magnitude_zerophase', 'magnitude_zerophase',
+            'magnitude_phase', 'power',):
         raise ValueError((
             f"mode is '{mode}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'FrequencyData'."))
@@ -2209,11 +2208,11 @@ def normalize(signal, reference_method='max', domain='time',
 
     if domain not in ('time', 'freq'):
         raise ValueError("domain must be 'time' or 'freq'.")
-    if type(signal) == pyfar.FrequencyData and domain == 'time':
+    if isinstance(signal, pyfar.FrequencyData) and domain == 'time':
         raise ValueError((
             f"domain is '{domain}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'TimeData'."))
-    if type(signal) == pyfar.TimeData and domain == 'freq':
+    if isinstance(signal, pyfar.TimeData) and domain == 'freq':
         raise ValueError((
             f"domain is '{domain}' and signal is type '{signal.__class__}'"
             " but must be of type 'Signal' or 'FrequencyData'."))

--- a/pyfar/plot/_utils.py
+++ b/pyfar/plot/_utils.py
@@ -198,7 +198,7 @@ def _get_quad_mesh_from_axis(ax):
     """
     quad_mesh_found = False
     for qm in ax.get_children():
-        if isinstance(qm, mpl.collections.QuadMesh):
+        if type(qm) is mpl.collections.QuadMesh:
             quad_mesh_found = True
             break
 

--- a/pyfar/plot/_utils.py
+++ b/pyfar/plot/_utils.py
@@ -198,7 +198,7 @@ def _get_quad_mesh_from_axis(ax):
     """
     quad_mesh_found = False
     for qm in ax.get_children():
-        if type(qm) == mpl.collections.QuadMesh:
+        if isinstance(qm, mpl.collections.QuadMesh):
             quad_mesh_found = True
             break
 

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -286,7 +286,7 @@ def test_time_shift_linear(shift, pad_value):
         ref.time[0, -2:] = pad_value
 
     npt.assert_allclose(shifted.time, ref.time)
-    assert type(shifted) == type(ref)
+    assert type(shifted) is type(ref)
 
 
 @pytest.mark.parametrize("shift_samples", [(

--- a/tests/test_plot_interaction.py
+++ b/tests/test_plot_interaction.py
@@ -317,7 +317,7 @@ def test_move_and_zoom_linear():
             ax, *_ = pf.plot.spectrogram(signal, dB=False)
             ax = ax[0]
             for cm in ax.get_children():
-                if type(cm) == mpl.collections.QuadMesh:
+                if isinstance(cm, mpl.collections.QuadMesh):
                     break
             getter = cm.get_clim
 


### PR DESCRIPTION
latest flake8 version throws new errors:
```
pyfar/classes/coordinates.py:1742:64: E231 missing whitespace after ','
pyfar/classes/coordinates.py:1982:57: E231 missing whitespace after ','
pyfar/classes/coordinates.py:2358:71: E231 missing whitespace after ','
pyfar/classes/coordinates.py:2496:42: E231 missing whitespace after ','
pyfar/dsp/dsp.py:1976:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
pyfar/dsp/dsp.py:2212:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
pyfar/dsp/dsp.py:2216:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
pyfar/plot/_utils.py:201:12: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```
they are fixed now