### PR TITLE
draft for SamplingSphere

### DIFF
--- a/pyfar/__init__.py
+++ b/pyfar/__init__.py
@@ -10,7 +10,7 @@ __version__ = '0.5.3'
 from .classes.audio import Signal, TimeData, FrequencyData
 from .classes.audio import (add, subtract, multiply, divide, power,
                             matrix_multiplication)
-from .classes.coordinates import Coordinates
+from .classes.coordinates import Coordinates, SamplingSphere
 from .classes.orientations import Orientations
 from .classes.filter import FilterFIR, FilterIIR, FilterSOS
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -2630,6 +2630,7 @@ class SamplingSphere(Coordinates):
     @sh_order.setter
     def sh_order(self, value):
         """Set the maximum spherical harmonic order."""
+        assert value > 0
         if value is None:
             self._sh_order = None
         else:

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -2630,7 +2630,7 @@ class SamplingSphere(Coordinates):
     @sh_order.setter
     def sh_order(self, value):
         """Set the maximum spherical harmonic order."""
-        assert value > 0
+        assert value >= 0
         if value is None:
             self._sh_order = None
         else:

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -119,7 +119,7 @@ class Coordinates():
             The default is ``None``.
         sh_order : int, optional
             This property will be deprecated in pyfar 0.8.0 in favor of
-            :py:class:`spharpy.samplings.SamplingSphere`
+            :py:class:`SamplingSphere`
 
             Maximum spherical harmonic order of the sampling grid.
             The default is ``None``.
@@ -165,7 +165,7 @@ class Coordinates():
         if sh_order is not None:
             warnings.warn((
                 "This function will be deprecated in pyfar 0.8.0 in favor "
-                "of spharpy.samplings.SamplingSphere."),
+                "of SamplingSphere."),
                     PyfarDeprecationWarning)
 
     @classmethod
@@ -908,11 +908,11 @@ class Coordinates():
     @property
     def sh_order(self):
         """This function will be deprecated in pyfar 0.8.0 in favor
-            of :py:class:`spharpy.samplings.SamplingSphere`.
+            of :py:class:`SamplingSphere`.
             Get the maximum spherical harmonic order."""
         warnings.warn((
             "This function will be deprecated in pyfar 0.8.0 in favor "
-            "of spharpy.samplings.SamplingSphere."),
+            "of pf.SamplingSphere."),
                 PyfarDeprecationWarning)
 
         return self._sh_order
@@ -920,11 +920,11 @@ class Coordinates():
     @sh_order.setter
     def sh_order(self, value):
         """This function will be deprecated in pyfar 0.8.0 in favor
-            of :py:class:`spharpy.samplings.SamplingSphere`.
+            of :py:class:`SamplingSphere`.
             Set the maximum spherical harmonic order."""
         warnings.warn((
             "This function will be deprecated in pyfar 0.8.0 in favor "
-            "of spharpy.samplings.SamplingSphere."),
+            "of pf.SamplingSphere."),
                 PyfarDeprecationWarning)
 
         self._sh_order = int(value)
@@ -2320,6 +2320,320 @@ class Coordinates():
         """check if object is empty"""
         if self.cshape == (0,):
             raise ValueError('Object is empty.')
+
+
+class SamplingSphere(Coordinates):
+    """Class for samplings on a sphere"""
+
+    def __init__(
+            self, x=None, y=None, z=None, weights: np.array = None,
+            comment: str = "", sh_order=None):
+        """
+        Create a SamplingSphere class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        x : ndarray, number
+            X coordinate of a right handed Cartesian coordinate system in
+            meters (-\infty < x < \infty).
+        y : ndarray, number
+            Y coordinate of a right handed Cartesian coordinate system in
+            meters (-\infty < y < \infty).
+        z : ndarray, number
+            Z coordinate of a right handed Cartesian coordinate system in
+            meters (-\infty < z < \infty).
+        weights: array like, number, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+        """
+        Coordinates.__init__(self, x, y, z, weights=weights, comment=comment)
+        self.sh_order = sh_order
+
+    @classmethod
+    def from_cartesian(
+            cls, x, y, z, weights: np.array = None, comment: str = "",
+            sh_order=None):
+        r"""
+        Create a Coordinates class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        x : ndarray, number
+            X coordinate of a right handed Cartesian coordinate system in
+            meters (-\infty < x < \infty).
+        y : ndarray, number
+            Y coordinate of a right handed Cartesian coordinate system in
+            meters (-\infty < y < \infty).
+        z : ndarray, number
+            Z coordinate of a right handed Cartesian coordinate system in
+            meters (-\infty < z < \infty).
+        weights: array like, number, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+
+        Examples
+        --------
+
+        Create a SamplingSphere object
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere.from_cartesian(0, 0, 1)
+
+        Or the using init
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere(0, 0, 1)
+        """
+        return cls(
+            x, y, z, weights=weights, comment=comment, sh_order=sh_order)
+
+    @classmethod
+    def from_spherical_elevation(
+            cls, azimuth, elevation, radius, weights: np.array = None,
+            comment: str = "", sh_order=None):
+        """Create a Coordinates class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        azimuth : ndarray, double
+            Angle in radiant of rotation from the x-y-plane facing towards
+            positive x direction. Used for spherical and cylindrical coordinate
+            systems.
+        elevation : ndarray, double
+            Angle in radiant with respect to horizontal plane (x-z-plane).
+            Used for spherical coordinate systems.
+        radius : ndarray, double
+            Distance to origin for each point. Used for spherical coordinate
+            systems.
+        weights: array like, float, None, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+
+        Examples
+        --------
+
+        Create a SamplingSphere object
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere.from_spherical_elevation(0, 0, 1)
+        """
+
+        x, y, z = sph2cart(azimuth, np.pi / 2 - elevation, radius)
+        return cls(
+            x, y, z, weights=weights, comment=comment, sh_order=sh_order)
+
+    @classmethod
+    def from_spherical_colatitude(
+            cls, azimuth, colatitude, radius, weights: np.array = None,
+            comment: str = "", sh_order=None):
+        """Create a Coordinates class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        azimuth : ndarray, double
+            Angle in radiant of rotation from the x-y-plane facing towards
+            positive x direction. Used for spherical and cylindrical coordinate
+            systems.
+        colatitude : ndarray, double
+            Angle in radiant with respect to polar axis (z-axis). Used for
+            spherical coordinate systems.
+        radius : ndarray, double
+            Distance to origin for each point. Used for spherical coordinate
+            systems.
+        weights: array like, number, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+
+        Examples
+        --------
+
+        Create a SamplingSphere object
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere.from_spherical_colatitude(0, 0, 1)
+        """
+
+        x, y, z = sph2cart(azimuth, colatitude, radius)
+        return cls(
+            x, y, z, weights=weights, comment=comment, sh_order=sh_order)
+
+    @classmethod
+    def from_spherical_side(
+            cls, lateral, polar, radius, weights: np.array = None,
+            comment: str = "", sh_order=None):
+        """Create a Coordinates class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        lateral : ndarray, double
+            Angle in radiant with respect to horizontal plane (x-y-plane).
+            Used for spherical coordinate systems.
+        polar : ndarray, double
+            Angle in radiant of rotation from the x-z-plane facing towards
+            positive x direction. Used for spherical coordinate systems.
+        radius : ndarray, double
+            Distance to origin for each point. Used for spherical coordinate
+            systems.
+        weights: array like, number, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+
+        Examples
+        --------
+
+        Create a SamplingSphere object
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere.from_spherical_side(0, 0, 1)
+        """
+
+        x, z, y = sph2cart(polar, np.pi / 2 - lateral, radius)
+        return cls(
+            x, y, z, weights=weights, comment=comment, sh_order=sh_order)
+
+    @classmethod
+    def from_spherical_front(
+            cls, frontal, upper, radius, weights: np.array = None,
+            comment: str = "", sh_order=None):
+        """Create a Coordinates class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        frontal : ndarray, double
+            Angle in radiant of rotation from the y-z-plane facing towards
+            positive y direction. Used for spherical coordinate systems.
+        upper : ndarray, double
+            Angle in radiant with respect to polar axis (x-axis). Used for
+            spherical coordinate systems.
+        radius : ndarray, double
+            Distance to origin for each point. Used for spherical coordinate
+            systems.
+        weights: array like, number, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+
+        Examples
+        --------
+
+        Create a SamplingSphere object
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere.from_spherical_front(0, 0, 1)
+        """
+
+        y, z, x = sph2cart(frontal, upper, radius)
+        return cls(
+            x, y, z, weights=weights, comment=comment, sh_order=sh_order)
+
+    @classmethod
+    def from_cylindrical(
+            cls, azimuth, z, rho, weights: np.array = None,
+            comment: str = "", sh_order=None):
+        """Create a Coordinates class object from a set of points on a sphere.
+        See :py:mod:`coordinates concepts <pyfar._concepts.coordinates>` for
+        more information.
+
+        Parameters
+        ----------
+        azimuth : ndarray, double
+            Angle in radiant of rotation from the x-y-plane facing towards
+            positive x direction. Used for spherical and cylindrical coordinate
+            systems.
+        z : ndarray, double
+            The z coordinate
+        rho : ndarray, double
+            Distance to origin for each point in the x-y-plane. Used for
+            cylindrical coordinate systems.
+        weights: array like, number, optional
+            Weighting factors for coordinate points. The `shape` of the array
+            must match the `shape` of the individual coordinate arrays.
+            The default is ``None``.
+        comment : str, optional
+            Comment about the stored coordinate points. The default is
+            ``""``, which initializes an empty string.
+        sh_order : int, optional
+            Maximum spherical harmonic order of the sampling grid.
+            The default is ``None``.
+
+        Examples
+        --------
+
+        Create a SamplingSphere object
+
+        >>> import pyfar as pf
+        >>> sampling = pf.SamplingSphere.from_cylindrical(0, 0, 1, sh_order=1)
+        """
+
+        x, y, z = cyl2cart(azimuth, z, rho)
+        return cls(
+            x, y, z, weights=weights, comment=comment, sh_order=sh_order)
+
+    @property
+    def sh_order(self):
+        """Get the maximum spherical harmonic order."""
+        return self._sh_order
+
+    @sh_order.setter
+    def sh_order(self, value):
+        """Set the maximum spherical harmonic order."""
+        if value is None:
+            self._sh_order = None
+        else:
+            self._sh_order = int(value)
 
 
 def cart2sph(x, y, z):

--- a/pyfar/samplings/samplings.py
+++ b/pyfar/samplings/samplings.py
@@ -222,8 +222,8 @@ def sph_equiangular(n_points=None, sh_order=None, radius=1.):
     w = w / np.sum(w)
 
     # make Coordinates object
-    sampling = pyfar.Coordinates(
-        phi.reshape(-1), theta.reshape(-1), rad, 'sph', 'top_colat',
+    sampling = pyfar.SamplingSphere.from_spherical_colatitude(
+        phi.reshape(-1), theta.reshape(-1), rad,
         comment='equiangular spherical sampling grid',
         weights=w, sh_order=n_max)
 
@@ -301,8 +301,8 @@ def sph_gaussian(n_points=None, sh_order=None, radius=1.):
     weights = weights / np.sum(weights)
 
     # make Coordinates object
-    sampling = pyfar.Coordinates(
-        phi.reshape(-1), theta.reshape(-1), rad, 'sph', 'top_colat',
+    sampling = pyfar.SamplingSphere.from_spherical_colatitude(
+        phi.reshape(-1), theta.reshape(-1), rad,
         comment='gaussian spherical sampling grid',
         weights=weights, sh_order=n_max)
 
@@ -392,7 +392,7 @@ def sph_extremal(n_points=None, sh_order=None, radius=1.):
     weights = file_data[:, 3] / 4 / np.pi
 
     # generate Coordinates object
-    sampling = pyfar.Coordinates(
+    sampling = pyfar.SamplingSphere(
         file_data[:, 0] * radius,
         file_data[:, 1] * radius,
         file_data[:, 2] * radius,
@@ -523,7 +523,7 @@ def sph_t_design(degree=None, sh_order=None, criterion='const_energy',
         sep=' ').reshape((n_points, 3))
 
     # generate Coordinates object
-    sampling = pyfar.Coordinates(
+    sampling = pyfar.SamplingSphere(
         points[..., 0] * radius,
         points[..., 1] * radius,
         points[..., 2] * radius,
@@ -772,7 +772,7 @@ def sph_lebedev(n_points=None, sh_order=None, radius=1.):
     weights = leb["w"] / (4 * np.pi)
 
     # generate Coordinates object
-    sampling = pyfar.Coordinates(
+    sampling = pyfar.SamplingSphere(
         leb["x"] * radius,
         leb["y"] * radius,
         leb["z"] * radius,
@@ -928,11 +928,10 @@ def sph_fliege(n_points=None, sh_order=None, radius=1.):
     fliege = fliege[f"Fliege_{int(n_points)}"]
 
     # generate Coordinates object
-    sampling = pyfar.Coordinates(
+    sampling = pyfar.SamplingSphere.from_spherical_colatitude(
         fliege[:, 0],
         fliege[:, 1],
         radius,
-        'sph', 'top_colat',
         sh_order=sh_order, weights=fliege[:, 2],
         comment='spherical Fliege sampling grid')
 

--- a/tests/test_coordinates_new.py
+++ b/tests/test_coordinates_new.py
@@ -2,7 +2,7 @@ import numpy as np
 import numpy.testing as npt
 import pytest
 
-from pyfar import Coordinates
+from pyfar import Coordinates, SamplingSphere
 from pyfar.classes.coordinates import sph2cart, cart2sph, cyl2cart
 
 
@@ -591,3 +591,20 @@ def test_coordinates_init_from_cylindrical(azimuth, z, radius_z):
     npt.assert_allclose(coords._x, x, atol=1e-15)
     npt.assert_allclose(coords._y, y, atol=1e-15)
     npt.assert_allclose(coords._z, z, atol=1e-15)
+
+
+def test_samplingsSphere():
+    sampling = SamplingSphere([1, 2], 0, 0, sh_order=5)
+    assert isinstance(sampling, SamplingSphere)
+    new_sampling = sampling[0]
+    assert isinstance(new_sampling, SamplingSphere)
+    assert sampling.sh_order == 5
+    assert new_sampling.sh_order == 5
+    new_sampling.sh_order = 6
+    assert sampling.sh_order == 5
+    assert new_sampling.sh_order == 6
+
+
+def test_samplingsSphere_fail():
+    with pytest.raises(AssertionError):
+        SamplingSphere([1, 2], 0, 0, sh_order=-5)


### PR DESCRIPTION
main problem is deprection of sh_order in Coordinates and refereing to spharpy.SamplingSphere  which is not ready yet is not so nice.
- propose class for SamplingSphere instead of ref to spharpy (the problem is that spharpy.samplingSphere does not inherit from pyfar.Coordinates, it has its own implementation.) after this is established we could shift pyfar.samplings and pyfar.SamplingSphere to spharpy directly
- fix deprection warnings in pf.samplings

please comment :)