### PR TITLE
Samplings deprecation and shift to spharpy

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     'sphinx.ext.autosummary',
     'matplotlib.sphinxext.plot_directive',
     'sphinx.ext.mathjax',
+    'sphinx.ext.intersphinx',
     'autodocsumm']
 
 # show tocs for classes and functions of modules using the autodocsumm

--- a/examples/pyfar_demo.ipynb
+++ b/examples/pyfar_demo.ipynb
@@ -475,7 +475,7 @@
    "source": [
     "## Entering coordinate points<a class=\"anchor\" id=\"coordinates_enter\"></a>\n",
     "\n",
-    "Coordinate points can be entered manually or by using one of the available sampling schemes contained in `pyfar.samplings`. We will do the latter using an equal angle sampling and look at the information provided by the coordinates object:"
+    "Coordinate points can be entered manually."
    ]
   },
   {
@@ -484,7 +484,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = pf.samplings.sph_equal_angle((20, 10))\n",
+    "c = pf.Coordinates(np.arange(-5., 6), 0, 0)\n",
     "# show general information\n",
     "print(c)\n",
     "# plot the sampling points\n",
@@ -513,7 +513,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Inside the `Coordinates` object, the Coordinates are stored in a cartesian coordinate system for each `x`, `y` and `z`. Information about coordinate array can be obtained by `c.cshape`, `c.csize`, and `c.cdim`. These properties are similar to numpy's `shape`, `size`, and `dim` of each `x`, `y` and `z`."
+    "Inside the `Coordinates` object, the Coordinates are stored in a cartesian coordinate system for each `x`, `y` and `z`. Information about coordinate array can be obtained by `c.cshape`, `c.csize`, and `c.cdim`. These properties are similar to numpy's `shape`, `size`, and `dim` of each `x`, `y` and `z`.\n",
+    "Additionally we can use available sampling schemes contained in https://spharpy.readthedocs.io/en/latest/spharpy.samplings.html."
    ]
   },
   {
@@ -782,7 +783,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1646,7 +1646,7 @@ class Coordinates():
             >>> import pyfar as pf
             >>> import numpy as np
             >>> coords = pf.Coordinates.from_spherical_elevation(
-            >>>     np.arange(-10, 10)*np.pi/180, 0, 1)
+            >>>     np.arange(-30, 30, 5)*np.pi/180, 0, 1)
             >>> result = coords.find_slice('azimuth', 'deg', 0, 5, show=True)
 
         """

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -2,7 +2,7 @@
 The following documents the pyfar coordinates class and functions for
 coordinate conversion. More background information is given in
 :py:mod:`coordinates concepts <pyfar._concepts.coordinates>`.
-Available sampling schemes are listed at :py:mod:`~pyfar.samplings`.
+Available sampling schemes are listed at :py:mod:`~spharpy.samplings`.
 """
 
 import numpy as np
@@ -1432,7 +1432,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> coords = pf.Coordinates(np.arange(-5, 5)
             >>> result = coords.find_nearest_k(1, 0, 0, show=True)
         """
 
@@ -1502,7 +1502,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
             >>> result = coords.find_nearest_cart(1, 0, 0, 0.5, show=True)
 
         """
@@ -1572,7 +1572,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
             >>> result = coords.find_nearest_sph(0, 0, 1, 45, show=True)
         """
 
@@ -1641,7 +1641,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.samplings.sph_lebedev(sh_order=10)
+            >>> coords = pf.Coordinates(np.arange(-5, 5)
             >>> result = coords.find_slice('elevation', 'deg', 0, 5, show=True)
 
         """
@@ -1737,7 +1737,7 @@ class Coordinates():
         Get a coordinates object
 
         >>> import pyfar as pf
-        >>> coordinates = pf.samplings.sph_gaussian(sh_order=3)
+        >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
 
         Rotate 45 degrees about the y-axis using
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1427,13 +1427,13 @@ class Coordinates():
         Examples
         --------
 
-        Find frontal point from a spherical coordinate system
+        Find the nearest point in a line
 
         .. plot::
 
             >>> import pyfar as pf
             >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
-            >>> result = coords.find_nearest_k(1, 0, 0, show=True)
+            >>> result = coords.find_nearest_k(0, 0, 0, show=True)
         """
 
         # check the input
@@ -1502,8 +1502,8 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
-            >>> result = coords.find_nearest_cart(1, 0, 0, 0.5, show=True)
+            >>> coords = pf.Coordinates(np.arange(0, 5), 0, 0)
+            >>> result = coords.find_nearest_cart(2, 0, 0, 0.5, show=True)
 
         """
 
@@ -1573,9 +1573,10 @@ class Coordinates():
 
             >>> import pyfar as pf
             >>> import numpy as np
-            >>> coords = pf.Coordinates.from_spherical_colatitude(
-            >>>     np.arange(-10, 10)*np.pi/180, 0, 0)
-            >>> result = coords.find_nearest_sph(0, 0, 1, 45, show=True)
+            >>> coords = pf.Coordinates.from_spherical_elevation(
+            >>>     0, np.arange(-90, 91, 10)*np.pi/180, 1)
+            >>> result = coords.find_nearest_sph(0, np.pi/2, 1, 45, show=True)
+
         """
 
         # check the input
@@ -1643,8 +1644,10 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
-            >>> result = coords.find_slice('elevation', 'deg', 0, 5, show=True)
+            >>> import numpy as np
+            >>> coords = pf.Coordinates.from_spherical_colatitude(
+            >>>     np.arange(-10, 10)*np.pi/180, 0, 1)
+            >>> result = coords.find_slice('azimuth', 'deg', 0, 5, show=True)
 
         """
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1502,7 +1502,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.Coordinates(np.arange(0, 5), 0, 0)
+            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
             >>> result = coords.find_nearest_cart(2, 0, 0, 0.5, show=True)
 
         """

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1645,7 +1645,7 @@ class Coordinates():
 
             >>> import pyfar as pf
             >>> import numpy as np
-            >>> coords = pf.Coordinates.from_spherical_colatitude(
+            >>> coords = pf.Coordinates.from_spherical_elevation(
             >>>     np.arange(-10, 10)*np.pi/180, 0, 1)
             >>> result = coords.find_slice('azimuth', 'deg', 0, 5, show=True)
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -2,7 +2,8 @@
 The following documents the pyfar coordinates class and functions for
 coordinate conversion. More background information is given in
 :py:mod:`coordinates concepts <pyfar._concepts.coordinates>`.
-Available sampling schemes are listed at :py:mod:`~spharpy.samplings`.
+Available sampling schemes are listed at
+:py:mod:`spharpy.samplings <spharpy.samplings>`.
 """
 
 import numpy as np

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1432,7 +1432,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.Coordinates(np.arange(-5, 5)
+            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
             >>> result = coords.find_nearest_k(1, 0, 0, show=True)
         """
 
@@ -1572,7 +1572,9 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
+            >>> import numpy as np
+            >>> coords = pf.Coordinates.from_spherical_colatitude(
+            >>>     np.arange(-10, 10)*np.pi/180, 0, 0)
             >>> result = coords.find_nearest_sph(0, 0, 1, 45, show=True)
         """
 
@@ -1641,7 +1643,7 @@ class Coordinates():
         .. plot::
 
             >>> import pyfar as pf
-            >>> coords = pf.Coordinates(np.arange(-5, 5)
+            >>> coords = pf.Coordinates(np.arange(-5, 5), 0, 0)
             >>> result = coords.find_slice('elevation', 'deg', 0, 5, show=True)
 
         """

--- a/pyfar/samplings/samplings.py
+++ b/pyfar/samplings/samplings.py
@@ -5,6 +5,7 @@ import warnings
 import os
 import scipy.io as sio
 import pyfar
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 from . import external
 
@@ -12,6 +13,9 @@ from . import external
 def cart_equidistant_cube(n_points):
     """
     Create a cuboid sampling with equidistant spacings in x, y, and z.
+
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.cube_equidistant`.
 
     The cube will have dimensions 1 x 1 x 1.
 
@@ -29,6 +33,11 @@ def cart_equidistant_cube(n_points):
         Sampling positions. Does not contain sampling weights.
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.cube_equidistant."),
+            PyfarDeprecationWarning)
+
     if np.size(n_points) == 1:
         n_x = n_points
         n_y = n_points
@@ -61,6 +70,9 @@ def sph_dodecahedron(radius=1.):
     Generate a sampling based on the center points of the twelve
     dodecahedron faces.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.dodecahedron`.
+
     Parameters
     ----------
     radius : number, optional
@@ -71,8 +83,11 @@ def sph_dodecahedron(radius=1.):
     sampling : Coordinates
         Sampling positions. Sampling weights can be obtained from
         :py:func:`calculate_sph_voronoi_weights`.
-
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.dodecahedron."),
+            PyfarDeprecationWarning)
 
     dihedral = 2 * np.arcsin(np.cos(np.pi / 3) / np.sin(np.pi / 5))
     R = np.tan(np.pi / 3) * np.tan(dihedral / 2)
@@ -116,6 +131,9 @@ def sph_icosahedron(radius=1.):
     """
     Generate a sampling from the center points of the twenty icosahedron faces.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.icosahedron`.
+
     Parameters
     ----------
     radius : number, optional
@@ -128,6 +146,11 @@ def sph_icosahedron(radius=1.):
         :py:func:`calculate_sph_voronoi_weights`.
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.icosahedron."),
+            PyfarDeprecationWarning)
+
     gamma_R_r = np.arccos(np.cos(np.pi / 3) / np.sin(np.pi / 5))
     gamma_R_rho = np.arccos(1 / (np.tan(np.pi / 5) * np.tan(np.pi / 3)))
 
@@ -149,6 +172,9 @@ def sph_icosahedron(radius=1.):
 def sph_equiangular(n_points=None, sh_order=None, radius=1.):
     """
     Generate an equiangular sampling of the sphere.
+
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.equiangular`.
 
     For detailed information, see [#]_, Chapter 3.2.
     This sampling does not contain points at the North and South Pole and is
@@ -179,6 +205,11 @@ def sph_equiangular(n_points=None, sh_order=None, radius=1.):
            Berlin, Heidelberg, Germany: Springer, 2015.
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.equiangular."),
+            PyfarDeprecationWarning)
+
     if (n_points is None) and (sh_order is None):
         raise ValueError(
             "Either the n_points or sh_order needs to be specified.")
@@ -234,6 +265,9 @@ def sph_gaussian(n_points=None, sh_order=None, radius=1.):
     """
     Generate sampling of the sphere based on the Gaussian quadrature.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.gaussian`.
+
     For detailed information, see [#]_ (Section 3.3).
     This sampling does not contain points at the North and South Pole and is
     typically used for spherical harmonics processing. See
@@ -263,6 +297,11 @@ def sph_gaussian(n_points=None, sh_order=None, radius=1.):
            Berlin, Heidelberg, Germany: Springer, 2015.
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.gaussian."),
+            PyfarDeprecationWarning)
+
     if (n_points is None) and (sh_order is None):
         raise ValueError(
             "Either the n_points or sh_order needs to be specified.")
@@ -313,6 +352,9 @@ def sph_extremal(n_points=None, sh_order=None, radius=1.):
     """
     Return a Hyperinterpolation sampling grid.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.hyperinterpolation`.
+
     After Sloan and Womersley [#]_. The samplings are available for
     1 <= `sh_order` <= 200 (``n_points = (sh_order + 1)^2``).
 
@@ -348,6 +390,10 @@ def sph_extremal(n_points=None, sh_order=None, radius=1.):
     .. [#]  https://web.maths.unsw.edu.au/~rsw/Sphere/MaxDet/
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.hyperinterpolation."),
+            PyfarDeprecationWarning)
 
     if (n_points is None) and (sh_order is None):
         for o in range(1, 100):
@@ -407,6 +453,9 @@ def sph_t_design(degree=None, sh_order=None, criterion='const_energy',
     """
     Return spherical t-design sampling grid.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.spherical_t_design`.
+
     For detailed information, see [#]_.
     For a spherical harmonic order :math:`n_{sh}`, a t-Design of degree
     :math:`t=2n_{sh}` for constant energy or :math:`t=2n_{sh}+1` additionally
@@ -464,6 +513,10 @@ def sph_t_design(degree=None, sh_order=None, criterion='const_energy',
     .. [#]  http://web.maths.unsw.edu.au/~rsw/Sphere/EffSphDes/sf.html
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.spherical_t_design."),
+            PyfarDeprecationWarning)
 
     # check input
     if (degree is None) and (sh_order is None):
@@ -537,6 +590,9 @@ def sph_equal_angle(delta_angles, radius=1.):
     """
     Generate sampling of the sphere with equally spaced angles.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.equal_angle`.
+
     This sampling contain points at the North and South Pole. See
     :py:func:`sph_equiangular`, :py:func:`sph_gaussian`, and
     :py:func:`sph_great_circle` for samplings that do not contain points at the
@@ -559,6 +615,10 @@ def sph_equal_angle(delta_angles, radius=1.):
         :py:func:`calculate_sph_voronoi_weights`.
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.equal_angle."),
+            PyfarDeprecationWarning)
 
     # get the angles
     delta_angles = np.asarray(delta_angles)
@@ -601,6 +661,9 @@ def sph_great_circle(elevation=np.linspace(-90, 90, 19), gcd=10, radius=1,
     """
     Spherical sampling grid according to the great circle distance criterion.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.great_circle`.
+
     Sampling grid where neighboring points of the same elevation have approx.
     the same great circle distance across elevations [#]_.
 
@@ -637,8 +700,11 @@ def sph_great_circle(elevation=np.linspace(-90, 90, 19), gcd=10, radius=1,
             the head-related transfer functions of an artificial head with a
             high directional resolution,” 109th AES Convention, Los Angeles,
             USA, Sep. 2000.
-
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.great_circle."),
+            PyfarDeprecationWarning)
 
     # check input
     assert 1 / azimuth_res % 1 == 0, "1/azimuth_res must be an integer."
@@ -689,8 +755,11 @@ def sph_lebedev(n_points=None, sh_order=None, radius=1.):
     """
     Return Lebedev spherical sampling grid.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.lebedev`.
+
     For detailed information, see [#]_. For a list of available values
-    for `n_points` and `sh_order` call :py:func:`sph_lebedev`.
+    for `n_points` and `sh_order` call :py:func:`lebedev`.
 
     Parameters
     ----------
@@ -724,6 +793,10 @@ def sph_lebedev(n_points=None, sh_order=None, radius=1.):
         getlebedevsphere
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.hyperinterpolation."),
+            PyfarDeprecationWarning)
 
     # possible degrees
     degrees = np.array([6, 14, 26, 38, 50, 74, 86, 110, 146, 170, 194, 230,
@@ -785,6 +858,9 @@ def sph_lebedev(n_points=None, sh_order=None, radius=1.):
 def sph_fliege(n_points=None, sh_order=None, radius=1.):
     """
     Return Fliege-Maier spherical sampling grid.
+
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.fliege`.
 
     For detailed information, see [#]_. Call :py:func:`sph_fliege`
     for a list of possible values for `n_points` and `sh_order`.
@@ -880,8 +956,11 @@ def sph_fliege(n_points=None, sh_order=None, radius=1.):
            and corresponding cubature formulae,” IMA J. Numerical Analysis,
            Vol. 19, pp. 317–334, Apr. 1999, doi: 10.1093/imanum/19.2.317.
     .. [#] https://audiogroup.web.th-koeln.de/SOFiA_wiki/DOWNLOAD.html
-
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.fliege."),
+            PyfarDeprecationWarning)
 
     # possible values for n_points and sh_order
     points = np.array([4, 9, 16, 25, 36, 49, 64, 81, 100, 121, 144, 169, 196,
@@ -950,6 +1029,9 @@ def sph_equal_area(n_points, radius=1.):
     """
     Sampling based on partitioning into faces with equal area.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.equal_area`.
+
     For detailed information, see [#]_.
 
     Parameters
@@ -971,8 +1053,11 @@ def sph_equal_area(n_points, radius=1.):
     .. [#]  P. Leopardi, “A partition of the unit sphere into regions of equal
             area and small diameter,” Electronic Transactions on Numerical
             Analysis, vol. 25, no. 12, pp. 309–327, 2006.
-
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.equal_area."),
+            PyfarDeprecationWarning)
 
     point_set = external.eq_point_set(2, n_points)
     sampling = pyfar.Coordinates(

--- a/pyfar/samplings/samplings.py
+++ b/pyfar/samplings/samplings.py
@@ -15,7 +15,7 @@ def cart_equidistant_cube(n_points):
     Create a cuboid sampling with equidistant spacings in x, y, and z.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.cube_equidistant`.
+    of :py:func:`spharpy.samplings.cube_equidistant`.
 
     The cube will have dimensions 1 x 1 x 1.
 
@@ -71,7 +71,7 @@ def sph_dodecahedron(radius=1.):
     dodecahedron faces.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.dodecahedron`.
+    of :py:func:`spharpy.samplings.dodecahedron`.
 
     Parameters
     ----------
@@ -132,7 +132,7 @@ def sph_icosahedron(radius=1.):
     Generate a sampling from the center points of the twenty icosahedron faces.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.icosahedron`.
+    of :py:func:`spharpy.samplings.icosahedron`.
 
     Parameters
     ----------
@@ -174,7 +174,7 @@ def sph_equiangular(n_points=None, sh_order=None, radius=1.):
     Generate an equiangular sampling of the sphere.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.equiangular`.
+    of :py:func:`spharpy.samplings.equiangular`.
 
     For detailed information, see [#]_, Chapter 3.2.
     This sampling does not contain points at the North and South Pole and is
@@ -266,7 +266,7 @@ def sph_gaussian(n_points=None, sh_order=None, radius=1.):
     Generate sampling of the sphere based on the Gaussian quadrature.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.gaussian`.
+    of :py:func:`spharpy.samplings.gaussian`.
 
     For detailed information, see [#]_ (Section 3.3).
     This sampling does not contain points at the North and South Pole and is
@@ -353,7 +353,7 @@ def sph_extremal(n_points=None, sh_order=None, radius=1.):
     Return a Hyperinterpolation sampling grid.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.hyperinterpolation`.
+    of :py:func:`spharpy.samplings.hyperinterpolation`.
 
     After Sloan and Womersley [#]_. The samplings are available for
     1 <= `sh_order` <= 200 (``n_points = (sh_order + 1)^2``).
@@ -454,7 +454,7 @@ def sph_t_design(degree=None, sh_order=None, criterion='const_energy',
     Return spherical t-design sampling grid.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.spherical_t_design`.
+    of :py:func:`spharpy.samplings.spherical_t_design`.
 
     For detailed information, see [#]_.
     For a spherical harmonic order :math:`n_{sh}`, a t-Design of degree
@@ -591,7 +591,7 @@ def sph_equal_angle(delta_angles, radius=1.):
     Generate sampling of the sphere with equally spaced angles.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.equal_angle`.
+    of :py:func:`spharpy.samplings.equal_angle`.
 
     This sampling contain points at the North and South Pole. See
     :py:func:`sph_equiangular`, :py:func:`sph_gaussian`, and
@@ -662,7 +662,7 @@ def sph_great_circle(elevation=np.linspace(-90, 90, 19), gcd=10, radius=1,
     Spherical sampling grid according to the great circle distance criterion.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.great_circle`.
+    of :py:func:`spharpy.samplings.great_circle`.
 
     Sampling grid where neighboring points of the same elevation have approx.
     the same great circle distance across elevations [#]_.
@@ -756,7 +756,7 @@ def sph_lebedev(n_points=None, sh_order=None, radius=1.):
     Return Lebedev spherical sampling grid.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.lebedev`.
+    of :py:func:`spharpy.samplings.lebedev`.
 
     For detailed information, see [#]_. For a list of available values
     for `n_points` and `sh_order` call :py:func:`lebedev`.
@@ -860,7 +860,7 @@ def sph_fliege(n_points=None, sh_order=None, radius=1.):
     Return Fliege-Maier spherical sampling grid.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.fliege`.
+    of :py:func:`spharpy.samplings.fliege`.
 
     For detailed information, see [#]_. Call :py:func:`sph_fliege`
     for a list of possible values for `n_points` and `sh_order`.
@@ -1030,7 +1030,7 @@ def sph_equal_area(n_points, radius=1.):
     Sampling based on partitioning into faces with equal area.
 
     This function will be deprecated in pyfar 0.8.0 in favor
-    of :py:class:`spharpy.samplings.equal_area`.
+    of :py:func:`spharpy.samplings.equal_area`.
 
     For detailed information, see [#]_.
 

--- a/pyfar/samplings/spatial.py
+++ b/pyfar/samplings/spatial.py
@@ -3,6 +3,8 @@ import numpy as np
 from scipy import spatial as spat
 from pyfar import Coordinates
 from copy import deepcopy
+import warnings
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 
 class SphericalVoronoi(spat.SphericalVoronoi):
@@ -15,6 +17,9 @@ class SphericalVoronoi(spat.SphericalVoronoi):
         """
         Calculate a Voronoi diagram on the sphere for the given samplings
         points.
+
+        This function will be deprecated in pyfar 0.8.0 in favor
+        of :py:class:`spharpy.samplings.spherical_voronoi`.
 
         Parameters
         ----------
@@ -36,6 +41,11 @@ class SphericalVoronoi(spat.SphericalVoronoi):
         :py:func:`calculate_sph_voronoi_weights`
 
         """
+        warnings.warn((
+            "This function will be deprecated in pyfar 0.8.0 in favor "
+            "of spharpy.samplings.spherical_voronoi."),
+                PyfarDeprecationWarning)
+
         points = sampling.cartesian
         radius = sampling.radius
         radius_round = np.unique(np.round(radius, decimals=round_decimals))
@@ -74,6 +84,9 @@ def calculate_sph_voronoi_weights(
     """
     Calculate sampling weights for numeric integration.
 
+    This function will be deprecated in pyfar 0.8.0 in favor
+    of :py:class:`spharpy.samplings.calculate_sampling_weights`.
+
     Uses the class method ``calculate_areas`` from :py:class:`SphericalVoronoi`
     to calculate the weights. It requires a spherical sampling grid with a
     single radius and uses ``scipy.spatial.SphericalVoronoi`` in the
@@ -99,6 +112,11 @@ def calculate_sph_voronoi_weights(
         Sampling weights of size `samplings.csize`.
 
     """
+    warnings.warn((
+        "This function will be deprecated in pyfar 0.8.0 in favor "
+        "of spharpy.samplings.calculate_sampling_weights."),
+            PyfarDeprecationWarning)
+
     # get Voronoi diagram
     if sampling.csize <= 3:
         raise ValueError(

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -198,6 +198,18 @@ def test_pad_zero_modi():
         ("pf.Coordinates(0, 0, 0, domain='sph')"),
         ("pf.Coordinates(0, 0, 0, domain='sph', unit='deg')"),
         ("pf.Coordinates(0, 0, 0, domain='sph', convention='top_colat')"),
+        ("pf.samplings.cart_equidistant_cube(2)"),
+        ("pf.samplings.sph_dodecahedron()"),
+        ("pf.samplings.sph_icosahedron()"),
+        ("pf.samplings.sph_equiangular(sh_order=5)"),
+        ("pf.samplings.sph_gaussian(sh_order=5)"),
+        ("pf.samplings.sph_extremal(sh_order=5)"),
+        ("pf.samplings.sph_t_design(sh_order=5)"),
+        ("pf.samplings.sph_equal_angle(5)"),
+        ("pf.samplings.sph_great_circle()"),
+        ("pf.samplings.sph_lebedev(sh_order=5)"),
+        ("pf.samplings.sph_fliege(sh_order=5)"),
+        ("pf.samplings.sph_equal_area(5)"),
     ])
 def test_deprecations_0_8_0(statement):
     coords = pf.Coordinates.from_spherical_colatitude(np.arange(6), 0, 0)


### PR DESCRIPTION
As discussed earlier we want to shift the samplings to spharpy. therefore we deprecate it now.
https://github.com/pyfar/spharpy/pull/33