### PR TITLE
Replace tests for Filter with non-abstract class stubs

### DIFF
--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,12 +1,17 @@
 import pyfar
 
 
-def test_copy(sphericalvoronoi, time_data, frequency_data):
+def test_copy(
+        sphericalvoronoi, time_data, frequency_data,
+        filterFIR, filterIIR, filterSOS):
     """ Test copy method used by several classes."""
     obj_list = [pyfar.Signal(1000, 44100),
                 pyfar.Orientations(),
                 pyfar.Coordinates(),
-                pyfar.classes.filter.Filter(),
+                # pyfar.classes.filter.Filter(),
+                filterFIR,
+                filterIIR,
+                filterSOS,
                 sphericalvoronoi,
                 time_data,
                 frequency_data]


### PR DESCRIPTION
Tests on CircleCI are failing due to faulty test implementations.

Replace the copy test for the abstract class Filter with tests for the subclasses
