### PR TITLE
tmporarily fix matplotlib version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,7 +12,7 @@ pytest-runner
 pytest-cov
 numpy>=1.23.0
 scipy>=1.5.0
-matplotlib
+matplotlib<=3.7
 urllib3
 deepdiff
 insipid-sphinx-theme

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'numpy>=1.23.0',
     'scipy>=1.5.0',
-    'matplotlib',
+    'matplotlib<=3.7',
     'sofar>=0.1.2',
     'urllib3',
     'deepdiff',


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Hotfix #496 still requires removing the tight_layout module from pyfar after this

### Changes proposed in this pull request:

- fix Matplotlib dependency