### PR TITLE
Enhance/force numeric data in audio objects

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -184,6 +184,29 @@ class _Audio():
         self._assert_matching_meta_data(value)
         self._data[key] = value._data
 
+    @staticmethod
+    def _check_input_type_is_numeric(data: np.ndarray):
+        """
+        Check if input data is numeric and raise TypeError if not.
+        """
+        # check if data type is numeric
+        if data.dtype.kind not in ["u", "i", "f", "c"]:
+            raise TypeError((f"The input data is {data.dtype} must be int, "
+                             "uint, float, or complex"))
+
+    @staticmethod
+    def _check_input_values_are_numeric(data: np.ndarray):
+        """
+        Check if input data contains only numeric values and raise TypeError
+        if not. This is only required for Signal objects but is kept here
+        to improve readability.
+        """
+        # check for non-numeric values
+        if np.any(np.isnan(data)) or np.any(np.isinf(data)):
+            raise ValueError((
+                "The input values must be numeric but contain at "
+                "least one non-numerical value (inf or NaN)"))
+
 
 class TimeData(_Audio):
     """Class for time data.
@@ -234,26 +257,23 @@ class TimeData(_Audio):
 
     @property
     def time(self):
-        """Return the data in the time domain."""
+        """Return or set the data in the time domain."""
         return self._data
 
     @time.setter
     def time(self, value):
-        """Set the time data."""
+        """Return or set the time data."""
         # check and set the data and meta data
         data = np.atleast_2d(np.asarray(value))
+        self._check_input_type_is_numeric(data)
         if self.complex:
             data = np.atleast_2d(np.asarray(value, dtype=complex))
         else:
-            if data.dtype.kind == "i":
+            if data.dtype.kind in ["i", "u"]:
                 data = np.atleast_2d(np.asarray(value, dtype=float))
             elif data.dtype.kind == "c":
                 raise ValueError("time data is complex, set is_complex "
                                  "flag or pass real-valued data.")
-            elif data.dtype.kind != "f":
-                raise ValueError(
-                    f"time data is {data.dtype} must be int, float, or "
-                    f"complex")
 
         self._data = data
         self._n_samples = data.shape[-1]
@@ -443,20 +463,18 @@ class FrequencyData(_Audio):
 
     @property
     def freq(self):
-        """Return the data in the frequency domain."""
+        """Return or set the data in the frequency domain."""
         return self._data
 
     @freq.setter
     def freq(self, value):
-        """Set the frequency data."""
+        """Return or set the data in the frequency domain."""
 
         # check data type
         data = np.atleast_2d(np.asarray(value))
-        if data.dtype.kind == "i":
+        self._check_input_type_is_numeric(data)
+        if data.dtype.kind in ["i", "u"]:
             data = data.astype("float")
-        elif data.dtype.kind not in ["f", "c"]:
-            raise ValueError((f"frequency data is {data.dtype} must be int, "
-                              "float, or complex"))
 
         # match shape of frequencies
         if self.frequencies.size != data.shape[-1]:
@@ -688,13 +706,29 @@ class Signal(FrequencyData, TimeData):
         else:
             raise ValueError("Invalid domain. Has to be 'time' or 'freq'.")
 
-    @TimeData.time.getter
+        # additional input data check required for Signal objects and not done
+        # in FrequencyData and TimeData __init__ methods
+        self._check_input_values_are_numeric(data)
+
+    @property
     def time(self):
-        """Return the data in the time domain."""
+        """Return or set the data in the time domain."""
+        # this overrides the setter TimeData.time
+
         # converts the data from 'freq' to 'time'
         self.domain = 'time'
 
         return super().time
+
+    @time.setter
+    def time(self, value):
+        """Return or set the data in the time domain."""
+        # this overrides the setter TimeData.time
+
+        # set data using parent class
+        TimeData.time.fset(self, value)
+        # additional check required for signal objects
+        self._check_input_values_are_numeric(self.time)
 
     @FrequencyData.freq.getter
     def freq(self):
@@ -716,12 +750,12 @@ class Signal(FrequencyData, TimeData):
 
     @freq.setter
     def freq(self, value):
-        """Set the normalized frequency domain data."""
+        """Return or set the normalized frequency domain data."""
         self._freq(value, raw=False)
 
     @property
     def freq_raw(self):
-        """Return the frequency domain data without normalization.
+        """Return or set the frequency domain data without normalization.
 
         Most processing operations, e.g., frequency
         domain convolution, require the non-normalized data.
@@ -734,16 +768,15 @@ class Signal(FrequencyData, TimeData):
 
     @freq_raw.setter
     def freq_raw(self, value):
-        """Set the frequency domain data without normalization."""
+        """Return or set the frequency domain data without normalization."""
         self._freq(value, raw=True)
 
     def _freq(self, value, raw):
         """Set the frequency domain data."""
         # check data type
         data = np.atleast_2d(np.asarray(value))
-        if data.dtype.kind not in ["i", "f", "c"]:
-            raise ValueError((f"frequency data is {data.dtype} must be int, "
-                              "float, or complex"))
+        self._check_input_type_is_numeric(data)
+        self._check_input_values_are_numeric(data)
         # Check n_samples
         if data.shape[-1] != self.n_bins:
             self._n_samples = fft._n_samples_from_n_bins(

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from pyfar.classes.audio import _Audio
 import pyfar as pf
@@ -25,6 +26,30 @@ def test_audio_comment():
 
     with pytest.raises(TypeError, match="comment has to be of type string."):
         pf.Signal([1, 2, 3], 44100, comment=[1, 2, 3])
+
+
+def test_check_input_type_is_numeric_error():
+    """Test if error is raised"""
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
+        _Audio._check_input_type_is_numeric(np.array(['1', '2', '3']))
+
+
+@pytest.mark.parametrize('dtype', ['int', 'uint', 'float', 'complex'])
+def test_check_input_type_is_numeric_no_error(dtype):
+    """Test if data passes as expected"""
+    _Audio._check_input_type_is_numeric(np.array([1, 2, 3], dtype=dtype))
+
+
+@pytest.mark.parametrize('value', [np.nan, np.inf, -np.inf])
+def test_check_input_values_are_numeric_error(value):
+    """Test if errors are raised"""
+    with pytest.raises(ValueError, match="input values must be numeric"):
+        _Audio._check_input_values_are_numeric(np.array([1, 2, value]))
+
+
+def test_check_input_values_are_numeric_no_error():
+    """Test if data passes as expected"""
+    _Audio._check_input_values_are_numeric(np.array([1, 2, 3]))
 
 
 def test_not_implemented():

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -58,7 +58,7 @@ def test_data_frequency_init_dtype():
     assert data.freq.dtype.kind == "c"
 
     # object array
-    with pytest.raises(ValueError, match="frequency data is"):
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
         FrequencyData(["1", "2", "3"], [1, 2, 3])
 
 

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -93,7 +93,7 @@ def test_data_frequency_init_dtype():
     assert signal.freq.dtype.kind == "c"
 
     # object array
-    with pytest.raises(ValueError, match="frequency data is"):
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
         Signal(["1", "2", "3"], 44100, 4, "freq")
 
 
@@ -559,7 +559,7 @@ def test_setter_freq_raw_dtype():
     assert signal.freq_raw.dtype.kind == "c"
 
     # object array
-    with pytest.raises(ValueError, match="frequency data is"):
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
         signal.freq_raw = ["1", "2", "3"]
 
 

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -73,6 +73,14 @@ def test_signal_init_time_dtype():
     signal = Signal([1+1j, 2+2j, 3+3j], 44100, is_complex=True)
     assert signal.time.dtype.kind == "c"
 
+    # pass array of invalid type
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
+        Signal(['1', '2', '3'], 44100)
+
+    # pass array with invalid value
+    with pytest.raises(ValueError, match="input values must be numeric"):
+        Signal(np.array([1, 2, np.nan]), 44100)
+
 
 def test_data_frequency_init_dtype():
     """
@@ -95,6 +103,14 @@ def test_data_frequency_init_dtype():
     # object array
     with pytest.raises(TypeError, match="int, uint, float, or complex"):
         Signal(["1", "2", "3"], 44100, 4, "freq")
+
+    # pass array of invalid type
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
+        Signal(['1', '2', '3'], 44100, 4, "freq")
+
+    # pass array with invalid value
+    with pytest.raises(ValueError, match="input values must be numeric"):
+        Signal(np.array([1, 2, np.nan]), 44100, 4, "freq")
 
 
 def test_signal_comment():

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -31,6 +31,10 @@ def test_data_time_init_wrong_dtype():
     with pytest.raises(ValueError, match="time data is complex"):
         TimeData(np.arange(2).astype(complex), [0, 1])
 
+    # pass array of invalid type
+    with pytest.raises(TypeError, match="int, uint, float, or complex"):
+        TimeData(['1', '2'], [0, 1])
+
 
 def test_time_init_complex_flag():
     """
@@ -91,7 +95,7 @@ def test_setter_complex():
     time = TimeData(data=[1 + 1j, 0 + 1j, -1 + 2j], times=[0, .1, .3],
                     is_complex=True)
     with pytest.raises(ValueError, match="Signal has complex-valued time data"
-                                         " is_complex flag cannot be `False`."):
+                                         " is_complex flag cannot be `False`"):
         time.complex = False
 
 

--- a/tests/test_dsp_average.py
+++ b/tests/test_dsp_average.py
@@ -96,5 +96,5 @@ def test_error_raises():
         pf.dsp.average(pf.Signal(np.zeros((5, 2)), 44100),
                        nan_policy='invalid')
     with raises(ValueError, match=("The signal includes NaNs.")):
-        pf.dsp.average(pf.Signal([[0, np.nan], [1, 2]], 44100),
+        pf.dsp.average(pf.TimeData([[0, np.nan], [1, 2]], [0, 1]),
                        nan_policy='raise')

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -154,4 +154,5 @@ def test_error_raises():
     with raises(ValueError, match=("nan_policy has to be 'propagate',")):
         pf.dsp.normalize(pf.Signal([0, 1, 0], 44100), nan_policy='invalid')
     with raises(ValueError, match=("The signal includes NaNs.")):
-        pf.dsp.normalize(pf.Signal([0, np.nan, 0], 44100), nan_policy='raise')
+        pf.dsp.normalize(pf.TimeData([0, np.nan, 0], [0, 1, 3]),
+                         nan_policy='raise')


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #431, requires #436 (merged) and #453 (merged)

### Changes proposed in this pull request:

- add tests for type and values of input data in `_Audio` class
- apply tests in `__init__` and `time`/`freq` setters of all audio classes
- adapt old tests
- add new tests

I did not find a way to check for boolean data, because it is converted to float when calling np.atleast_2d(data). Any ideas?
