### PR TITLE
add check for fft_norm in complex setter

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -886,6 +886,9 @@ class Signal(FrequencyData, TimeData):
             raise ValueError(("Invalid FFT normalization. Has to be "
                               f"{', '.join(self._VALID_FFT_NORMS)}, but found "
                               f"'{value}'"))
+        if self._complex and value is "rms":
+            raise ValueError(("'rms' normalization is not valid for "
+                                  "complex time signals"))
         self._fft_norm = value
 
     def _assert_matching_meta_data(self, other):

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -829,6 +829,9 @@ class Signal(FrequencyData, TimeData):
                 self._complex = value
         # from complex=False to complex=True
         if not self._complex and value:
+            if self._fft_norm == "rms":
+                raise ValueError(("'rms' normalization is not valid for "
+                                  "complex time signals"))
             if self._domain == 'time':
                 # call complex setter of timeData
                 super(Signal, self.__class__).complex.fset(self, value)

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -886,9 +886,9 @@ class Signal(FrequencyData, TimeData):
             raise ValueError(("Invalid FFT normalization. Has to be "
                               f"{', '.join(self._VALID_FFT_NORMS)}, but found "
                               f"'{value}'"))
-        if self._complex and value is "rms":
+        if self._complex and value == "rms":
             raise ValueError(("'rms' normalization is not valid for "
-                                  "complex time signals"))
+                              "complex time signals"))
         self._fft_norm = value
 
     def _assert_matching_meta_data(self, other):

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -315,6 +315,14 @@ def test_setter_fft_norm():
     with pytest.raises(ValueError):
         signal.fft_norm = 'bullshit'
 
+    # setting fft_norm for complex time signals
+    signal = pf.Signal([1, 2, 3], 44100,
+                       fft_norm='power', is_complex=True)
+    with pytest.raises(ValueError,
+                       match="'rms' normalization is not valid for "
+                             "complex time signals"):
+        signal.fft_norm = "rms"
+
 
 def test_fft_selection():
     """Test if appropriate FFT is computed"""

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -638,6 +638,16 @@ def test_setter_complex():
         signal.complex = False
 
 
+def test_setter_complex_invalid_fft_norm():
+    # test setting complex from False to True
+    # for frequency domain signals
+    signal = Signal([0, 1, 2], 44100, 4, "time", fft_norm="rms")
+    with pytest.raises(ValueError,
+                       match="'rms' normalization is not valid for "
+                             "complex time signals"):
+        signal.complex = True
+
+
 def test_frequencies():
     """
     Test computing the discrete frequencies of the rfft/fft


### PR DESCRIPTION
### Changes proposed in this pull request:

- check the fft normalization in complex setter
- throw error if complex flag is to be set and fft norm is `rms`
