### PR TITLE
Deprecate-s-secoonds

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -143,7 +143,7 @@ def wrap_to_2pi(x):
 
 
 def linear_phase(signal, group_delay, unit="samples"):
-    """
+    r"""
     Set the phase to a linear phase with a specified group delay.
 
     The linear phase signal is computed as
@@ -165,25 +165,33 @@ def linear_phase(signal, group_delay, unit="samples"):
         group delay is a list or array it must broadcast with the channel
         layout of the signal (``signal.cshape``).
     unit : string, optional
-        Unit of the group delay. Can be ``'samples'`` or ``'s'`` for seconds.
-        The default is ``'samples'``.
+        The ``'s'`` parameter will be deprecated in pyfar 0.9.0 in favor
+        of ``'seconds'``.
+        Unit of the group delay. Can be ``'samples'`` or ``'seconds'``
+        for seconds. The default is ``'samples'``.
 
     Returns
     -------
     signal: Signal
         linear phase copy of the input data
     """
-
     if not isinstance(signal, pyfar.Signal):
         raise TypeError("signal must be a pyfar Signal object.")
 
+    # test Deprecation warning
+    if unit == "s":
+        warnings.warn((
+            "The 's' parameter will be deprecated in pyfar 0.9.0 in favor"
+            "of 'seconds'."),
+                PyfarDeprecationWarning, stacklevel=2)
+        tau = np.asarray(group_delay)
     # group delay in seconds
-    if unit == "samples":
+    elif unit == "samples":
         tau = np.asarray(group_delay) / signal.sampling_rate
-    elif unit == "s":
+    elif unit == "seconds":
         tau = np.asarray(group_delay)
     else:
-        raise ValueError(f"unit is {unit} but must be 'samples' or 's'.")
+        raise ValueError(f"unit is {unit} but must be 'samples' or 'seconds'.")
 
     # linear phase
     phase = 2 * np.pi * signal.frequencies * tau[..., np.newaxis]
@@ -354,7 +362,9 @@ def time_window(signal, interval, window='hann', shape='symmetric',
 
         The default is ``'symmetric'``.
     unit : string, optional
-        Unit of `interval`. Can be set to ``'samples'`` or ``'s'`` (seconds).
+        The ``'s'`` parameter will be deprecated in pyfar 0.9.0 in favor
+        of ``'seconds'``.
+        Unit of `interval`. Can be set to ``'samples'`` or ``'seconds'``.
         Time values are rounded to the nearest sample. The default is
         ``'samples'``.
     crop : string, optional
@@ -465,13 +475,22 @@ def time_window(signal, interval, window='hann', shape='symmetric',
     interval = np.array(interval)
     if not np.array_equal(interval, np.sort(interval)):
         raise ValueError("Values in interval need to be in ascending order.")
+
+    # test Deprecation warning
+    if unit == "s":
+        warnings.warn((
+            "The 's' parameter will be deprecated in pyfar 0.9.0 in favor"
+            "of 'seconds'."),
+                PyfarDeprecationWarning, stacklevel=2)
+        interval = np.round(interval*signal.sampling_rate).astype(int)
     # Convert to samples
-    if unit == 's':
+    elif unit == 'seconds':
         interval = np.round(interval*signal.sampling_rate).astype(int)
     elif unit == 'samples':
         interval = interval.astype(int)
     else:
-        raise ValueError(f"unit is {unit} but has to be 'samples' or 's'.")
+        raise ValueError(
+            f"unit is {unit} but has to be 'samples' or 'seconds'.")
     # Check window size
     if interval[-1] > signal.n_samples:
         raise ValueError(
@@ -1075,6 +1094,8 @@ def time_shift(
 
         The default is ``"cyclic"``
     unit : str, optional
+        The ``'s'`` parameter will be deprecated in pyfar 0.9.0 in favor
+        of ``'seconds'``.
         Unit of the shift variable, this can be either ``'samples'`` or ``'s'``
         for seconds. By default ``'samples'`` is used. Note that in the case
         of specifying the shift time in seconds, the value is rounded to the
@@ -1141,13 +1162,20 @@ def time_shift(
         raise ValueError(f"mode is '{mode}' but mist be 'linear' or cyclic'")
 
     shift = np.broadcast_to(shift, signal.cshape)
+    # test Deprecation warning
     if unit == 's':
+        warnings.warn((
+            "The 's' parameter will be deprecated in pyfar 0.9.0 in favor"
+            "of 'seconds'."),
+                PyfarDeprecationWarning, stacklevel=2)
+        shift_samples = np.round(shift*signal.sampling_rate).astype(int)
+    elif unit == 'seconds':
         shift_samples = np.round(shift*signal.sampling_rate).astype(int)
     elif unit == 'samples':
         shift_samples = shift.astype(int)
     else:
         raise ValueError(
-            f"unit is '{unit}' but must be 'samples' or 's'.")
+            f"unit is '{unit}' but must be 'samples' or 'seconds'.")
 
     if np.any(np.abs(shift_samples) > signal.n_samples) and mode == "linear":
         raise ValueError(("Can not shift by more samples than signal.n_samples"
@@ -2128,9 +2156,11 @@ def normalize(signal, reference_method='max', domain='time',
         Also note that `limits` need to be ``(None, None)`` if
         `reference_method` is ``rms``, ``power`` or ``energy``.
     unit: string, optional
+        The ``'s'`` parameter will be deprecated in pyfar 0.9.0 in favor
+        of ``'seconds'``.
         Unit of `limits`.
 
-        ``'s'``
+        ``'seconds'``
             Set limits in seconds in case of time domain normalization. Uses
             :py:class:`~signal.find_nearest_time` to find the limits.
         ``'Hz'``
@@ -2241,8 +2271,14 @@ def normalize(signal, reference_method='max', domain='time',
     else:
         find = signal.find_nearest_frequency
 
-    if unit in ("Hz", "s"):
+    if unit in ('Hz', 's', 'seconds'):
         limits = [None if lim is None else find(lim) for lim in limits]
+        # test Deprecation warning
+        if unit == 's':
+            warnings.warn((
+                "The 's' parameter will be deprecated in pyfar 0.9.0 in favor"
+                "of 'seconds'."),
+                    PyfarDeprecationWarning, stacklevel=2)
 
     if limits[0] == limits[1] and None not in limits:
         raise ValueError(("Upper and lower limit are identical. Use a "

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2253,8 +2253,8 @@ def normalize(signal, reference_method='max', domain='time',
         raise ValueError(
             "limits must be (None, None) if reference_method  is "
             f"{reference_method}")
-    if (domain == "time" and unit not in ("s", None)) or \
-            (domain == "freq" and unit not in ("Hz", None)):
+    if (domain == "time" and unit not in ('seconds', 's', None)) or \
+            (domain == "freq" and unit not in ('Hz', None)):
         raise ValueError(f"'{unit}' is an invalid unit for domain {domain}")
     if nan_policy not in ('propagate', 'omit', 'raise'):
         raise ValueError("nan_policy has to be 'propagate', 'omit', or"

--- a/pyfar/dsp/interpolation.py
+++ b/pyfar/dsp/interpolation.py
@@ -8,6 +8,7 @@ from scipy.ndimage import generic_filter1d
 from fractions import Fraction
 from decimal import Decimal
 import warnings
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 
 def _weighted_moving_average(input, output, weights):
@@ -264,7 +265,10 @@ def fractional_time_shift(signal, shift, unit="samples", order=30,
         `Numpy broadcasting
         <https://numpy.org/doc/stable/user/basics.broadcasting.html>`_)
     unit : str, optional
-        The unit of the shift. Either 'samples' or 's'. Defaults to 'samples'.
+        The ``'s'`` parameter will be deprecated in pyfar 0.9.0 in favor
+        of ``'seconds'``.
+        The unit of the shift. Either 'samples' or 'seconds'.
+        Defaults to 'samples'.
     order : int, optional
         The order of the fractional shift (sinc) filter. The precision of the
         filter increases with the order. High frequency errors decrease with
@@ -365,10 +369,16 @@ def fractional_time_shift(signal, shift, unit="samples", order=30,
                           f"{signal.n_samples-1} (signal.n_samples-1)"))
 
     if unit == 's':
+        warnings.warn((
+            "The 's' parameter will be deprecated in pyfar 0.9.0 in favor"
+            "of 'seconds'."),
+                PyfarDeprecationWarning, stacklevel=2)
+        shift = shift*signal.sampling_rate
+    elif unit == 'seconds':
         shift = shift*signal.sampling_rate
     elif unit != 'samples':
         raise ValueError(
-            f"Unit is '{unit}' but has to be 'samples' or 's'.")
+            f"Unit is '{unit}' but has to be 'samples' or 'seconds'.")
 
     # separate integer and fractional shift -----------------------------------
     delay_int = np.atleast_1d(shift).astype(int)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -196,3 +196,67 @@ def test_deprecations_find_nearest_sph():
     if version.parse(pf.__version__) >= version.parse('0.8.0'):
         with pytest.raises(TypeError):
             coords.find_nearest_sph(1, 1, 1, 1)
+
+
+# deprecate in 0.9.0 ----------------------------------------------------------
+def test_deprecations_dsp_normalize():
+    signal = np.append(np.ones(1000), np.zeros(1000)+0.1)
+    signal = pf.Signal(signal, 2000)
+
+    with pytest.warns(
+            PyfarDeprecationWarning,
+            match="The 's' parameter will be deprecated in pyfar 0.9.0 in"):
+        pf.dsp.normalize(
+            signal, domain='time', target=2, limits=(0, 0.5), unit='s')
+
+    if version.parse(pf.__version__) >= version.parse('0.9.0'):
+        with pytest.raises(TypeError):
+            pf.dsp.normalize(
+                signal, domain='time', target=2, limits=(0, 0.5), unit='s')
+
+
+def test_deprecations_dsp_linear_phase():
+    # test signal
+    N = 64
+    fs = 44100
+    x = pf.signals.impulse(N, sampling_rate=fs)
+
+    with pytest.warns(
+            PyfarDeprecationWarning,
+            match="The 's' parameter will be deprecated in pyfar 0.9.0 in"):
+        pf.dsp.linear_phase(x, N / 2 / fs, unit="s")
+
+    if version.parse(pf.__version__) >= version.parse('0.9.0'):
+        with pytest.raises(TypeError):
+            pf.dsp.linear_phase(x, N / 2 / fs, unit="s")
+
+
+def test_deprecations_dsp_time_window():
+    sig = pf.Signal(np.ones(10), 2)
+
+    with pytest.warns(
+            PyfarDeprecationWarning,
+            match="The 's' parameter will be deprecated in pyfar 0.9.0 in"):
+        pf.dsp.time_window(
+            sig, interval=[0.5, 1.5], shape='symmetric', unit='s',
+            crop='end')
+
+    if version.parse(pf.__version__) >= version.parse('0.9.0'):
+        with pytest.raises(TypeError):
+            pf.dsp.time_window(
+                sig, interval=[0.5, 1.5], shape='symmetric', unit='s',
+                crop='end')
+
+
+def test_deprecations_dsp_fractional_time_shift():
+    impulse = pf.signals.impulse(128, 64)
+
+    with pytest.warns(
+            PyfarDeprecationWarning,
+            match="The 's' parameter will be deprecated in pyfar 0.9.0 in"):
+        pf.dsp.interpolation.fractional_time_shift(impulse, 1/44100, 'seconds')
+
+    if version.parse(pf.__version__) >= version.parse('0.9.0'):
+        with pytest.raises(TypeError):
+            pf.dsp.interpolation.fractional_time_shift(
+                impulse, 1/44100, 'seconds')

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -254,9 +254,9 @@ def test_deprecations_dsp_fractional_time_shift():
     with pytest.warns(
             PyfarDeprecationWarning,
             match="The 's' parameter will be deprecated in pyfar 0.9.0 in"):
-        pf.dsp.interpolation.fractional_time_shift(impulse, 1/44100, 'seconds')
+        pf.dsp.interpolation.fractional_time_shift(impulse, 1/44100, 's')
 
     if version.parse(pf.__version__) >= version.parse('0.9.0'):
         with pytest.raises(TypeError):
             pf.dsp.interpolation.fractional_time_shift(
-                impulse, 1/44100, 'seconds')
+                impulse, 1/44100, 's')

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -129,6 +129,10 @@ def test_linear_phase():
     y = dsp.linear_phase(x, N / 2 / fs, unit="s")
     npt.assert_allclose(dsp.group_delay(y), N / 2 * np.ones(y.n_bins))
 
+    # test group delay in seconds
+    y = dsp.linear_phase(x, N / 2 / fs, unit="seconds")
+    npt.assert_allclose(dsp.group_delay(y), N / 2 * np.ones(y.n_bins))
+
     # test assertion
     with pytest.raises(TypeError, match="signal must be a pyfar Signal"):
         dsp.linear_phase(1, 0)
@@ -394,6 +398,10 @@ def test_time_window_crop_interval():
         crop='window')
     assert sig_win.n_samples == 3
     sig_win = dsp.time_window(
+        sig, interval=[0.5, 1.5], shape='symmetric', unit='seconds',
+        crop='window')
+    assert sig_win.n_samples == 3
+    sig_win = dsp.time_window(
         sig, interval=[0.5, 1.5], shape='symmetric', unit='s',
         crop='window')
     assert sig_win.n_samples == 3
@@ -410,6 +418,10 @@ def test_time_window_crop_end():
     sig = pyfar.Signal(np.ones(10), 2)
     sig_win = dsp.time_window(
         sig, interval=[1, 3], shape='symmetric', unit='samples',
+        crop='end')
+    assert sig_win.n_samples == 4
+    sig_win = dsp.time_window(
+        sig, interval=[0.5, 1.5], shape='symmetric', unit='seconds',
         crop='end')
     assert sig_win.n_samples == 4
     sig_win = dsp.time_window(

--- a/tests/test_dsp_interpolation.py
+++ b/tests/test_dsp_interpolation.py
@@ -179,8 +179,11 @@ def test_fractional_time_shift_unit():
 
     impulse = pf.signals.impulse(128, 64)
     delayed_samples = fractional_time_shift(impulse, 1, 'samples')
-    delayed_seconds = fractional_time_shift(impulse, 1/44100, 's')
+    delayed_seconds = fractional_time_shift(impulse, 1/44100, 'seconds')
 
+    npt.assert_almost_equal(delayed_samples.time, delayed_seconds.time)
+
+    delayed_seconds = fractional_time_shift(impulse, 1/44100, 's')
     npt.assert_almost_equal(delayed_samples.time, delayed_seconds.time)
 
 

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -53,7 +53,8 @@ def test_domains_normalization():
 
 @pytest.mark.parametrize('unit, limit1, limit2', (
                          [None, (0, 1000), (1000, 2000)],
-                         ['s', (0, 0.5), (0.5, 1)]))
+                         ['s', (0, 0.5), (0.5, 1)],
+                         ['seconds', (0, 0.5), (0.5, 1)]))
 def test_time_limiting(unit, limit1, limit2):
     # Test for normalization with setting limits in samples(None) and seconds.
     signal = np.append(np.ones(1000), np.zeros(1000)+0.1)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #490

### Changes proposed in this pull request:

- deprecate ``unit='s'`` and replace by `ùnit='seconds'``
- did not touch ``pf.plot.time*``, where we have several options 'ms', 's', 'ns', 'samples'. How should we handle this?

