### PR TITLE
Hot fixes for `pyfar.Coordinates.find_nearest`

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1420,7 +1420,7 @@ class Coordinates():
             ``'euclidean'``
                 distance is determined by the euclidean distance.
                 This is default.
-            ``'spherical_radiance'``
+            ``'spherical_radians'``
                 distance is determined by the great-circle distance
                 expressed in radians.
             ``'spherical_meter'``
@@ -1499,7 +1499,7 @@ class Coordinates():
         if not isinstance(find, Coordinates):
             raise ValueError("find must be an pf.Coordinates object.")
         allowed_measures = [
-                'euclidean', 'spherical_degree', 'spherical_meter']
+                'euclidean', 'spherical_radians', 'spherical_meter']
         if distance_measure not in allowed_measures:
             raise ValueError(
                 f"distance_measure needs to be in {allowed_measures} and "
@@ -1517,7 +1517,7 @@ class Coordinates():
         # nearest points
         distance, index = kdtree.query(points, k=k)
 
-        if distance_measure in ['spherical_radiance', 'spherical_meter']:
+        if distance_measure in ['spherical_radians', 'spherical_meter']:
             # determine validate radius
             radius = np.concatenate((self.radius, find.radius))
             delta_radius = np.max(radius) - np.min(radius)
@@ -1527,13 +1527,14 @@ class Coordinates():
                     radius. Differences are larger than 1e-15")
             radius = np.max(radius)
 
+            # convert cartesian coordinates to length on the great circle using
+            # the Haversine formula
+            distance = 2 * np.arcsin(distance / (2 * radius))
+
             if distance_measure == 'spherical_meter':
                 # convert angle in radiant to distance on the sphere
-                # d = 2r*pi*d/(2*pi) = r*d
-                distance = radius * distance
-
-            # convert cartesian coordinates to length on the great circle
-            distance = 2 * radius * np.arcsin(distance/(2*radius))
+                # distance = 2*radius*pi*distance/(2*pi) = radius*distance
+                distance *= radius
 
         if self.cdim == 1:
             if k > 1:
@@ -1583,7 +1584,7 @@ class Coordinates():
             ``'euclidean'``
                 distance is determined by the euclidean distance.
                 This is default.
-            ``'spherical_radiance'``
+            ``'spherical_radians'``
                 distance is determined by the great-circle distance
                 expressed in radians.
             ``'spherical_meter'``
@@ -1638,7 +1639,7 @@ class Coordinates():
         if not isinstance(return_sorted, bool):
             raise ValueError("return_sorted must be a bool.")
         allowed_measures = [
-            'euclidean', 'spherical_radiance', 'spherical_meter']
+            'euclidean', 'spherical_radians', 'spherical_meter']
         if distance_measure not in allowed_measures:
             raise ValueError(
                 f"distance_measure needs to be in {allowed_measures} and "
@@ -1657,7 +1658,7 @@ class Coordinates():
         if distance_measure == 'euclidean':
             index = kdtree.query_ball_point(
                 points, distance + atol, return_sorted=return_sorted)
-        if distance_measure == ['spherical_radiance', 'spherical_meter']:
+        if distance_measure == ['spherical_radians', 'spherical_meter']:
             # determine validate radius
             radius = self.radius
             delta_radius = np.max(radius) - np.min(radius)

--- a/tests/test_coordinates_find.py
+++ b/tests/test_coordinates_find.py
@@ -17,6 +17,23 @@ def test_find_nearest_simple():
     assert d == 0
 
 
+@pytest.mark.parametrize('azimuth,distance_measure,distance', [
+    (0, 'spherical_radians', 0),                        # radians match
+    (np.pi / 16, 'spherical_radians', np.pi / 16),      # radians no match
+    (0, 'spherical_meter', 0),                          # meters match
+    (np.pi / 16, 'spherical_meter', np.pi / 16 * 1.1)   # meters no match
+])
+def test_find_nearest_simple_spherical_distance(
+        azimuth, distance_measure, distance):
+    """Test spherical distance measures for find nearest"""
+    # 1D spherical coordinates points in front and to the left
+    coords = pf.Coordinates().from_spherical_elevation([0, np.pi/2], 0, 1.1)
+    find = pf.Coordinates().from_spherical_elevation(azimuth, 0, 1.1)
+    i, d = coords.find_nearest(find, distance_measure=distance_measure)
+    assert i[0] == 0
+    assert np.abs(d - distance) < 1e-15
+
+
 def test_find_nearest_1d_2d():
     # 1D spherical, nearest point
     coords = pf.Coordinates(np.arange(10), 0, 1)


### PR DESCRIPTION
### Changes proposed in this pull request:

- Fix typo in docstring and code: Rename distance measure `spherical_radiance` to `spherical_radians`
- Fix assertion for distance measure: Rename `spherical_degree` to `spherical_radians`
- Fix computation of spherical distance meausres
- Add tests for spherical distance measures
