### PR TITLE
Fix deprecation warnings in `pyfar.signals.files.head_related_impulse_responses`

### DIFF
--- a/pyfar/signals/files.py
+++ b/pyfar/signals/files.py
@@ -326,7 +326,11 @@ def head_related_impulse_responses(
     Get HRIRs for specified source positions and sampling rate.
 
     The head-related impulse responses (HRIRs) are taken from the FABIAN
-    database [#]_. They are shortened to 128 samples for convenience.
+    database [#]_. They are shortened to 128 samples for convenience. HRIRs are
+    available on the horizontal plane (elevation equals zero degrees, azimuth
+    angles available between 0 and 360 degrees in steps of two degrees) and
+    median plane (azimuth equals 0 or 180 degrees, elevation angles available
+    between -90 and 90 degrees in steps of two degrees).
 
     .. note ::
 
@@ -337,8 +341,7 @@ def head_related_impulse_responses(
     Parameters
     ----------
     position : list, str, optional
-        The positions for which HRIRs are returned. HRIRs are available on the
-        horizontal and median plane in an angular resolution of 2 degrees.
+        The positions for which HRIRs are returned.
 
         ``'horizontal'``
             Return horizontal plane HRIRs with an angular resolution of 2
@@ -381,26 +384,33 @@ def head_related_impulse_responses(
     # load HRIRs
     hrirs, sources, _ = pf.io.read_sofa(os.path.join(file_dir, files[0]))
 
+    # tolerance in radians for finding source positions. If this tolerance is
+    # exceeded, an error is raised to inform the user
+    tolerance_rad = 0.1 / 180 * np.pi
+
     # get indices of source positions
     if position == "horizontal":
-        idx, _ = sources.find_slice('elevation', 'deg', 0)
+        idx = sources.elevation == 0
     elif position == "median":
-        idx, _ = sources.find_slice('lateral', 'deg', 0)
+        idx = sources.lateral == 0
+        idx = np.where(idx)[0]
         # sort positions according to polar angle
         polar = sources.polar[idx].flatten()
-        idx = (idx[0][np.argsort(polar)], )
+        idx = (idx[np.argsort(polar)], )
     else:
         idx = []
         for pos in position:
-            idx_current, _ = sources.find_nearest_sph(
-                pos[0], pos[1], 1.7, distance=0,
-                domain="sph", convention="top_elev", unit="deg")
-            if idx_current:
+            find = pf.Coordinates().from_spherical_elevation(
+                pos[0] / 180 * np.pi, pos[1] / 180 * np.pi, 1.7)
+            idx_current, distance = sources.find_nearest(
+                find, distance_measure='spherical_radians')
+            if distance < tolerance_rad:
                 idx.append(idx_current[0])
             else:
                 raise ValueError((
                     f"HRIR for azimuth={pos[0]} and elevation={pos[1]} degrees"
-                    " is not available. See help for more information."))
+                    " is not available. See documentation for more "
+                    "information."))
 
     # select data for desired source positions
     hrirs.time = hrirs.time[idx]

--- a/pyfar/signals/files.py
+++ b/pyfar/signals/files.py
@@ -400,7 +400,7 @@ def head_related_impulse_responses(
     else:
         idx = []
         for pos in position:
-            find = pf.Coordinates().from_spherical_elevation(
+            find = pf.Coordinates.from_spherical_elevation(
                 pos[0] / 180 * np.pi, pos[1] / 180 * np.pi, 1.7)
             idx_current, distance = sources.find_nearest(
                 find, distance_measure='spherical_radians')


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #517, requires #519 

### Changes proposed in this pull request:

- Update for new `pyfar.Coordinates` class to avoid deprecation warnings
- Updating tests not required. Everything tested in `tests/test_signals_files.py`
