### PR TITLE
Fix plots not showing in examples notebook

### DIFF
--- a/examples/pyfar_demo.ipynb
+++ b/examples/pyfar_demo.ipynb
@@ -70,7 +70,10 @@
    "source": [
     "# import packages\n",
     "import pyfar as pf\n",
-    "import numpy as np"
+    "import numpy as np\n",
+    "\n",
+    "# set matplotlib backend for plotting\n",
+    "%matplotlib inline"
    ]
   },
   {


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #390, i.e., plots don't show up in the [current](https://mybinder.org/v2/gh/pyfar/pyfar/main?filepath=examples%2Fpyfar_demo.ipynb) examples notebook on binder, which can be fixed if explicitly setting the Matplotlib backend to `inline` as done in the [suggested](https://mybinder.org/v2/gh/pyfar/pyfar/bug/plots_in_example_notebook?filepath=examples%2Fpyfar_demo.ipynb) examples notebook

### Changes proposed in this pull request:

- explicitly set Matplotlib backend