### PR TITLE
Switch to the PyData Sphinx theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,7 @@ intersphinx_mapping = {
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'insipid'
+html_theme = 'pydata_sphinx_theme'
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,8 +14,8 @@ scipy>=1.5.0
 matplotlib<=3.7
 urllib3
 deepdiff
-insipid-sphinx-theme
 autodocsumm
 soundfile>=0.11.0
 sofar>=1.1.1
 nbmake>=0.7.0
+pydata-sphinx-theme

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,8 @@ test_requirements = [
     'flake8',
     'coverage',
     'Sphinx',
-    'twine'
+    'twine',
+    'pydata-sphinx-theme'
 ]
 
 setup(


### PR DESCRIPTION
I find this theme a bit easier to navigate and also easier on the eyes. But I guess it boils down to personal preference. Have a look at it yourselves.

https://pyfar--545.org.readthedocs.build/en/545/
