### PR TITLE
remove obsolete information from print Coordinates

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -2651,17 +2651,8 @@ class Coordinates():
         else:
             obj = "Empty Coordinates object"
 
-        # coordinate convention
-        conv = "domain: {}, convention: {}, unit: {}".format(
-            self._system['domain'], self._system['convention'],
-            self._system['unit'])
-
-        # coordinates and units
-        coords = ["{} in {}".format(c, u) for c, u in
-                  zip(self._system['coordinates'], self._system['units'])]
-
         # join information
-        _repr = obj + "\n" + conv + "\n" + "coordinates: " + ", ".join(coords)
+        _repr = obj + "\n"
 
         # check for sampling weights
         if self._weights is None:


### PR DESCRIPTION
### Changes proposed in this pull request:

change output from:
```
1D Coordinates object with 40 points of cshape (40,)
domain: cart, convention: right, unit: met
coordinates: x in meters, y in meters, z in meters
Does not contain sampling weights
```
to:
```
1D Coordinates object with 40 points of cshape (40,)
Does not contain sampling weights
```

