### PR TITLE
Make Coordiantes.show() use equal axes scaling and return Axis object.

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1399,12 +1399,20 @@ class Coordinates():
 
         """
         if mask is None:
-            pf.plot.scatter(self, **kwargs)
+            ax = pf.plot.scatter(self, **kwargs)
         else:
             mask = np.asarray(mask)
             colors = np.full(self.cshape, pf.plot.color('b'))
             colors[mask] = pf.plot.color('r')
-            pf.plot.scatter(self, c=colors.flatten(), **kwargs)
+            ax = pf.plot.scatter(self, c=colors.flatten(), **kwargs)
+
+        ax.set_box_aspect([
+            np.ptp(self.x),
+            np.ptp(self.y),
+            np.ptp(self.z)])
+        ax.set_aspect('equal')
+
+        return ax
 
     def find_nearest(self, find, k=1, distance_measure='euclidean'):
         """


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

This has been broken for a while now. 
The code in the scatter and quiver plots looks like it should be re-done, so I've implemented this as a hot-fix inside the show method. Eventually I'd suggest merging with the scatter function in spharpy.

- Fixes the equal axes scaling issue mentioned in PR #364 
- Returns the Axis object as mentioned in the docstring

``` python 
import pyfar as pf
s = pf.samplings.sph_gaussian(10)
s.show()
```

![image](https://github.com/pyfar/pyfar/assets/15856767/75227994-b457-409c-9498-ea8973f39cd5)
