### PR TITLE
Remove phase for FFT normalizations 'power' and 'psd'

### DIFF
--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -229,11 +229,8 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
         else:
             # Equation 12 in Ahrens et al. 2020
             norm /= np.sum(window)**2
-        # the phase is kept for being able to switch between normalizations
-        # altoug the power spectrum does usually not have phase information,
-        # i.e., spec = np.abs(spec)**2
         if not inverse:
-            spec *= np.abs(spec)
+            spec = np.abs(spec)**2
     elif fft_norm == 'psd':
         if window is None:
             # Equation 6 in Ahrens et al. 2020
@@ -241,11 +238,8 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
         else:
             # Equation 13 in Ahrens et al. 2020
             norm /= (np.sum(np.asarray(window)**2) * sampling_rate)
-        # the phase is kept for being able to switch between normalizations
-        # altoug the power spectrum does usually not have phase information,
-        # i.e., spec = np.abs(spec)**2
         if not inverse:
-            spec *= np.abs(spec)
+            spec = np.abs(spec)**2
     elif fft_norm != 'unitary':
         raise ValueError(("norm type must be 'unitary', 'amplitude', 'rms', "
                           f"'power', or 'psd' but is '{fft_norm}'"))

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -139,7 +139,7 @@ def test_normalization_none(impulse_stub):
 def test_normalization_single_sided_single_channel_even_samples():
     # single sided test spectrum
     v = 1/3 + 1/3j
-    vsq = v * np.abs(v)
+    vsq = np.abs(v)**2
     spec_single = np.array([v, v, v])
     # valid number of samples of time signal corresponding to spec_single
     N = 4       # time signal with even number of samples
@@ -179,7 +179,7 @@ def test_normalization_single_sided_single_channel_even_samples():
 def test_normalization_single_sided_single_channel_odd_samples():
     # single sided test spectrum
     v = 1/3 + 1/3j
-    vsq = v * np.abs(v)
+    vsq = np.abs(v)**2
     spec_single = np.array([v, v, v])
     # valid number of samples of time signal corresponding to spec_single
     N = 5       # time signal with even number of samples
@@ -213,13 +213,17 @@ def test_normalization_single_sided_single_channel_odd_samples():
         print(f"Assesing normalization: '{normalization}' (inverse)")
         spec_out_inv = fft.normalization(spec_out, N, fs,
                                          normalization, inverse=True)
-        npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
+        if normalization in ['power', 'psd']:
+            # Inverse only resembles magnitude for power norms
+            npt.assert_allclose(spec_out_inv, np.abs(spec_single), atol=1e-15)
+        else:
+            npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
 
 
 def test_normalization_both_sided_single_channel():
     # single sided test spectrum
     v = 1/3 + 1/3j
-    vsq = v * np.abs(v)
+    vsq = np.abs(v)**2
     spec_single = np.array([v, v, v])
     # valid number of samples of time signal corresponding to spec_single
     N = 3       # time signal with even number of samples
@@ -251,13 +255,17 @@ def test_normalization_both_sided_single_channel():
         spec_out_inv = fft.normalization(spec_out, N, fs,
                                          normalization, inverse=True,
                                          single_sided=False)
-        npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
+        if normalization in ['power', 'psd']:
+            # Inverse only resembles magnitude for power norms
+            npt.assert_allclose(spec_out_inv, np.abs(spec_single), atol=1e-15)
+        else:
+            npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
 
 
 def test_normalization_single_sided_multi_channel_even_samples():
     # single sided test spectrum
     v = 1/3 + 1/3j
-    vsq = v * np.abs(v)
+    vsq = np.abs(v)**2
     tile = (4, 2, 1)
     spec_single = np.tile(np.array([v, v, v]), tile)
     # valid number of samples of time signal corresponding to spec_single
@@ -293,7 +301,11 @@ def test_normalization_single_sided_multi_channel_even_samples():
         print(f"Assesing normalization: '{normalization}' (inverse)")
         spec_out_inv = fft.normalization(spec_out, N, fs,
                                          normalization, inverse=True)
-        npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
+        if normalization in ['power', 'psd']:
+            # Inverse only resembles magnitude for power norms
+            npt.assert_allclose(spec_out_inv, np.abs(spec_single), atol=1e-15)
+        else:
+            npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
 
 
 def test_normalization_with_window():

--- a/tests/test_fft.py
+++ b/tests/test_fft.py
@@ -173,7 +173,11 @@ def test_normalization_single_sided_single_channel_even_samples():
         print(f"Assesing normalization: '{normalization}' (inverse)")
         spec_out_inv = fft.normalization(spec_out, N, fs,
                                          normalization, inverse=True)
-        npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
+        if normalization in ['power', 'psd']:
+            # Inverse only resembles magnitude for power norms
+            npt.assert_allclose(spec_out_inv, np.abs(spec_single), atol=1e-15)
+        else:
+            npt.assert_allclose(spec_out_inv, spec_single, atol=1e-15)
 
 
 def test_normalization_single_sided_single_channel_odd_samples():


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #553: Contrary to their definitions, FFT normalizations 'power' and 'psd' retained the phase of the signal. I think its a leftover from before the 'signal.freq_raw' property was introduced in 0.4.0 (PR https://github.com/pyfar/pyfar/pull/274), when retaining the phase was required to correctly calculate the inverse.

### Changes proposed in this pull request:

- Changed squaring operation from `spec*np.abs(spec) `to `np.abs(spec)**2`
- Updated tests

