### PR TITLE
Replace latest with stable when linking to the docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -187,7 +187,7 @@ Mocks are similar to stubs but used for **behavioral verification**. For example
 Writing the Documentation
 -------------------------
 
-Pyfar follows the `numpy style guide <https://numpydoc.readthedocs.io/en/latest/format.html>`_ for the docstring. A docstring has to consist at least of
+Pyfar follows the `numpy style guide <https://numpydoc.readthedocs.io/en/stable/format.html>`_ for the docstring. A docstring has to consist at least of
 
 - A short and/or extended summary,
 - the Parameters section, and

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ pyfar
 
 .. image:: https://badge.fury.io/py/pyfar.svg
     :target: https://badge.fury.io/py/pyfar
-.. image:: https://readthedocs.org/projects/pyfar/badge/?version=latest
-    :target: https://pyfar.readthedocs.io/en/latest/?badge=latest
+.. image:: https://readthedocs.org/projects/pyfar/badge/?version=stable
+    :target: https://pyfar.readthedocs.io/en/stable/?badge=stable
     :alt: Documentation Status
 .. image:: https://circleci.com/gh/pyfar/pyfar.svg?style=shield
     :target: https://circleci.com/gh/pyfar/pyfar
@@ -46,6 +46,6 @@ Refer to the `contribution guidelines`_ for more information.
 .. _contribution guidelines: https://github.com/pyfar/pyfar/blob/develop/CONTRIBUTING.rst
 .. _examples notebook: https://mybinder.org/v2/gh/pyfar/pyfar/main?filepath=examples%2Fpyfar_demo.ipynb
 .. _pyfar.org: https://pyfar.org
-.. _read the docs: https://pyfar.readthedocs.io/en/latest
-.. _SoundFile: https://pysoundfile.readthedocs.io/en/latest/
+.. _read the docs: https://pyfar.readthedocs.io/en/stable
+.. _SoundFile: https://pysoundfile.readthedocs.io/en/stable/
 .. _libsndfile: http://www.mega-nerd.com/libsndfile/

--- a/docs/_templates/navbar-nav.html
+++ b/docs/_templates/navbar-nav.html
@@ -3,13 +3,13 @@
       <ul class="bd-navbar-elements navbar-nav">
 
                         <li class="nav-item">
-                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/latest/">
+                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/stable/">
                             Home
                             </a>
                         </li>
 
                         <li class="nav-item">
-                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/latest/examples_gallery.html">
+                            <a class="nav-link" href="https://pyfar-gallery.readthedocs.io/en/stable/examples_gallery.html">
                                 Examples
                             </a>
                         </li>
@@ -27,13 +27,13 @@
                         </li>
 
                         <li class="nav-item">
-                          <a class="nav-link" href="https://spharpy.readthedocs.io/en/latest/">
+                          <a class="nav-link" href="https://spharpy.readthedocs.io/en/stable/">
                             spharpy
                           </a>
                         </li>
 
                         <li class="nav-item">
-                          <a class="nav-link" href="https://pyrato.readthedocs.io/en/latest/">
+                          <a class="nav-link" href="https://pyrato.readthedocs.io/en/stable/">
                             pyrato
                           </a>
                         </li>


### PR DESCRIPTION
We're often linking to the latest version of the docs, which points to the latest commit on the main branch.
This is replaced with the stable version, which is the latest tagged commit.