### PR TITLE
Remove restriction for matplotlib version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ pytest-runner
 pytest-cov
 numpy>=1.23.0
 scipy>=1.5.0
-matplotlib<=3.7
+matplotlib
 urllib3
 deepdiff
 autodocsumm

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.rst') as history_file:
 requirements = [
     'numpy>=1.23.0',
     'scipy>=1.5.0',
-    'matplotlib<=3.7',
+    'matplotlib',
     'sofar>=0.1.2',
     'urllib3',
     'deepdiff',


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #501 

### Changes proposed in this pull request:

- Remove version restriction for Matplotlib