### PR TITLE
Wrapper function for private 1st and 2nd order allpass implementations

### DIFF
--- a/pyfar/dsp/filter/__init__.py
+++ b/pyfar/dsp/filter/__init__.py
@@ -9,6 +9,7 @@ from .band_filter import (
 )
 
 from .audiofilter import (
+    allpass,
     bell,
     high_shelve,
     low_shelve,
@@ -29,6 +30,7 @@ from .gammatone import (
 
 
 __all__ = [
+    'allpass',
     'butterworth',
     'chebyshev1',
     'chebyshev2',

--- a/pyfar/dsp/filter/_audiofilter.py
+++ b/pyfar/dsp/filter/_audiofilter.py
@@ -285,7 +285,7 @@ def biquad_bs2nd(fm, q, fs, q_warp_method="cos"):
     return B, A, b, a
 
 
-def biquad_ap1st(fc, fs, ai):
+def biquad_ap1st(fc, fs, ai=1.):
     """Calc coeff for allpass 1st order.
 
     input:
@@ -310,7 +310,7 @@ def biquad_ap1st(fc, fs, ai):
     return B, A, b, a
 
 
-def biquad_ap2nd(fc, fs, bi, ai):
+def biquad_ap2nd(fc, fs, bi=1., ai=np.sqrt(2)):
     """Calc coeff for allpass 2nd order.
 
     input:

--- a/pyfar/dsp/filter/_audiofilter.py
+++ b/pyfar/dsp/filter/_audiofilter.py
@@ -285,7 +285,7 @@ def biquad_bs2nd(fm, q, fs, q_warp_method="cos"):
     return B, A, b, a
 
 
-def biquad_ap1st(fc, fs, ai=1.):
+def biquad_ap1st(fc, fs, ai):
     """Calc coeff for allpass 1st order.
 
     input:
@@ -310,7 +310,7 @@ def biquad_ap1st(fc, fs, ai=1.):
     return B, A, b, a
 
 
-def biquad_ap2nd(fc, fs, bi=1., ai=np.sqrt(2)):
+def biquad_ap2nd(fc, fs, bi, ai):
     """Calc coeff for allpass 2nd order.
 
     input:

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -110,13 +110,13 @@ blob/master/filter_design/audiofilter.py
         if coefficients is None:
             coefficients = 0.6436
         # get filter coefficients for first order allpass
-        _, _, b, a = iir.biquad_ap1st(frequency, fs, ai=coefficients)
+        b, a = iir.biquad_ap1st(frequency, fs, ai=coefficients)[2:]
     elif order == 2:
         if coefficients is None:
             coefficients = [0.8832, 1.6278]
         # get filter coefficients for second order allpass
-        _, _, b, a = iir.biquad_ap2nd(
-            frequency, fs, bi=coefficients[0], ai=coefficients[1])
+        b, a = iir.biquad_ap2nd(
+            frequency, fs, bi=coefficients[0], ai=coefficients[1])[2:]
     else:
         raise ValueError('Order must be 1 or 2')
 

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -110,7 +110,7 @@ blob/master/filter_design/audiofilter.py
         if coefficients is None:
             coefficients = 0.6436
         # get filter coefficients for first order allpass
-        _, _, b, a = iir.biquad_ap1st(frequency, fs, ai=coefficients)
+        b, a = iir.biquad_ap1st(frequency, fs, ai=coefficients)[2, 3]
     elif order == 2:
         if coefficients is None:
             coefficients = [0.8832, 1.6278]

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -18,7 +18,7 @@ def allpass(signal, frequency, order, coefficients=None, sampling_rate=None):
 
 
     where :math:`\\omega_c = 2 \\pi f_c` with the cut-off frequency :math:`f_c`
-    and :math:`s=\\sigma + \\mathrm{i} \\omega`.
+    and :math:`s=\\mathrm{i} \\omega`.
 
     By definition the ``bi`` coefficient of a first order allpass is ``0``.
 

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -110,13 +110,13 @@ blob/master/filter_design/audiofilter.py
         if coefficients is None:
             coefficients = 0.6436
         # get filter coefficients for first order allpass
-        b, a = iir.biquad_ap1st(frequency, fs, ai=coefficients)[2, 3]
+        _, _, b, a = iir.biquad_ap1st(frequency, fs, ai=coefficients)
     elif order == 2:
         if coefficients is None:
             coefficients = [0.8832, 1.6278]
         # get filter coefficients for second order allpass
-        b, a = iir.biquad_ap2nd(
-            frequency, fs, bi=coefficients[0], ai=coefficients[1])[2, 3]
+        _, _, b, a = iir.biquad_ap2nd(
+            frequency, fs, bi=coefficients[0], ai=coefficients[1])
     else:
         raise ValueError('Order must be 1 or 2')
 

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -4,6 +4,138 @@ import pyfar as pf
 from . import _audiofilter as iir
 
 
+def allpass(signal, frequency, order, coefficients=None, sampling_rate=None):
+    """
+    Create and apply first or second order allpass filter.
+    Transfer function based on Tietze et al. [#]_:
+
+    .. math:: A(s_n) = \\frac{1-\\frac{a_i}{\\omega_c} s_n+\\frac{b_i}
+                {\\omega_c^2} s_n^2}{1+\\frac{a_i}{\\omega_c} s_n
+                +\\frac{b_i}{\\omega_c^2} s_n^2}
+
+    By definition the ``bi`` coefficient of a first order allpass is ``0``.
+
+    Uses the implementation of [#]_.
+
+    Parameters
+    ----------
+    signal : Signal, None
+        The signal to be filtered. Pass ``None`` to create the filter without
+        applying it.
+    frequency : number
+        Cutoff frequency of the allpass in Hz.
+    order : number
+        Order of the allpass filter. Must be ``1`` or ``2``.
+    coefficients:  number, list, optional
+        Filter characteristic coefficients ``bi`` and ``ai``.
+
+        - For 1st order allpass provide ai-coefficient as single value.
+        - For 2nd order allpass provide coefficients as list ``[bi, ai]``.
+
+        Defaults are chosen according to Tietze et al. (Fig. 12.66)
+        for maximum flat group delay.
+    sampling_rate : None, number
+        The sampling rate in Hz. Only required if signal is ``None``. The
+        default is ``None``.
+    Returns
+    -------
+    signal : Signal
+        The filtered signal. Only returned if ``sampling_rate = None``.
+    filter : FilterIIR
+        Filter object. Only returned if ``signal = None``.
+    References
+    ----------
+    .. [#] Tietze, U., Schenk, C. & Gamm, E. (2019). Halbleiter-
+        Schaltungstechnik (16th ed.). Springer Vieweg
+    .. [#] https://github.com/spatialaudio/digital-signal-processing-lecture/\
+blob/master/filter_design/audiofilter.py
+
+    Examples
+    -----
+    First and second order allpass filter with ``fc = 1000`` Hz.
+
+    .. plot::
+
+        import pyfar as pf
+        import matplotlib.pyplot as plt
+        import numpy as np
+
+        # impulse to be filtered
+        impulse = pf.signals.impulse(256)
+
+        orders = [1, 2]
+        labels = ['First order', 'Second order']
+
+        fig, (ax1, ax2) = plt.subplots(2,1, layout='constrained')
+
+        for (order, label) in zip(orders, labels):
+            # create and apply allpass filter
+            sig_filt = pf.dsp.filter.allpass(impulse, 1000, order)
+            pf.plot.group_delay(sig_filt, label=label, ax=ax1)
+            pf.plot.phase(sig_filt, label=label, ax=ax2, unwrap = True)
+
+        ax2.legend()
+    """
+
+    # check input
+    if (signal is None and sampling_rate is None) \
+            or (signal is not None and sampling_rate is not None):
+        raise ValueError('Either signal or sampling_rate must be none.')
+
+    # check if coefficients match filter order
+    if coefficients is not None and (
+            (order == 1 and np.isscalar(coefficients) is False)
+            or (order == 2 and (
+                type(coefficients) is not list or len(coefficients) != 2))):
+        print(type(coefficients), order)
+        raise ValueError('Coefficients must match order')
+
+    # sampling frequency in Hz
+    fs = signal.sampling_rate if sampling_rate is None else sampling_rate
+
+    if coefficients is None:
+        # Set default coefficients, see Tietze/ Schenk fig. 12.66
+        coeffs_ap1 = 0.6436
+        coeffs_ap2 = [0.8832, 1.6278]
+    elif np.isscalar(coefficients) is True:
+        # custom coefficients for first order allpass
+        coeffs_ap1 = coefficients
+    elif len(coefficients) == 2:
+        # custom coefficients for second order allpass
+        coeffs_ap2 = coefficients
+
+    if order == 1:
+        # get filter coefficients for first order allpass
+        _, _, b, a = iir.biquad_ap1st(frequency, fs, ai=coeffs_ap1)
+        filter_coeffs = np.stack((b, a), axis=0)
+
+        # filter object
+        filt = pf.FilterIIR(filter_coeffs, fs)
+        filt.comment = ("First order allpass-filter with cutoff frequency"
+                        f" {frequency} Hz.")
+
+    elif order == 2:
+        # get filter coefficients for second order allpass
+        _, _, b, a = iir.biquad_ap2nd(frequency, fs, bi=coeffs_ap2[0],
+                                      ai=coeffs_ap2[1])
+        filter_coeffs = np.stack((b, a), axis=0)
+
+        # filter object
+        filt = pf.FilterIIR(filter_coeffs, fs)
+        filt.comment = ("Second order allpass-filter with cutoff frequency"
+                        f" {frequency} Hz.")
+    else:
+        raise ValueError('Order must be 1 or 2')
+
+    if signal is None:
+        # return filter-object
+        return filt
+    else:
+        # return filtered signal
+        signal_filt = filt.process(signal)
+        return signal_filt
+
+
 def bell(signal, center_frequency, gain, quality, bell_type='II',
          quality_warp='cos', sampling_rate=None):
     """

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -115,8 +115,8 @@ blob/master/filter_design/audiofilter.py
         if coefficients is None:
             coefficients = [0.8832, 1.6278]
         # get filter coefficients for second order allpass
-        _, _, b, a = iir.biquad_ap2nd(frequency, fs, bi=coefficients[0],
-                                      ai=coefficients[1])
+        b, a = iir.biquad_ap2nd(
+            frequency, fs, bi=coefficients[0], ai=coefficients[1])[2, 3]
     else:
         raise ValueError('Order must be 1 or 2')
 

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -40,19 +40,21 @@ def allpass(signal, frequency, order, coefficients=None, sampling_rate=None):
             The default is ``ai = 0.6436``.
 
         -   For 2nd order allpass provide coefficients as list ``[bi, ai]``.\n
-            The default is ``bi = 1.6278``, ``ai = 0.8832``.
+            The default is ``bi = 0.8832``, ``ai = 1.6278``.
 
         Defaults are chosen according to Tietze et al. (Fig. 12.66)
         for maximum flat group delay.
     sampling_rate : None, number
         The sampling rate in Hz. Only required if signal is ``None``. The
         default is ``None``.
+
     Returns
     -------
     signal : Signal
         The filtered signal. Only returned if ``sampling_rate = None``.
     filter : FilterIIR
         Filter object. Only returned if ``signal = None``.
+
     References
     ----------
     .. [#] Tietze, U., Schenk, C. & Gamm, E. (2019). Halbleiter-
@@ -68,7 +70,6 @@ blob/master/filter_design/audiofilter.py
 
         import pyfar as pf
         import matplotlib.pyplot as plt
-        import numpy as np
 
         # impulse to be filtered
         impulse = pf.signals.impulse(256)

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -96,9 +96,10 @@ blob/master/filter_design/audiofilter.py
 
     # check if coefficients match filter order
     if coefficients is not None and (
-            (order == 1 and np.isscalar(coefficients) is False)
-            or (order == 2 and (isinstance(coefficients, (list, np.ndarray))
-                                is False or len(coefficients) != 2))):
+            (order == 1 and np.isscalar(coefficients) is False) or
+            (order == 2 and (
+                not isinstance(coefficients, (list, np.ndarray)) or
+                len(coefficients) != 2))):
         print(type(coefficients), order)
         raise ValueError('Coefficients must match the allpass order')
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -127,6 +127,44 @@ def test_bessel(impulse):
         x = pfilt.bessel(None, 2, 1000, 'lowpass', 'phase')
 
 
+def test_allpass(impulse):
+    # Uses third party code.
+    # We thus only test the functionality not the results
+
+    fc = 1000
+    orders = [1, 2]
+    kinds = ['First', 'Second']
+
+    for (order, kind) in zip(orders, kinds):
+        f_obj = pfilt.allpass(None, fc, order, sampling_rate=44100)
+        assert isinstance(f_obj, pclass.FilterIIR)
+        assert f_obj.comment == (
+            f"{kind} order allpass-filter with cutoff frequency {fc} Hz.")
+
+        # Filter
+        x = pfilt.allpass(impulse, fc, order)
+        y = f_obj.process(impulse)
+        assert isinstance(x, Signal)
+        npt.assert_allclose(x.time, y.time)
+
+    # test ValueError
+    with pytest.raises(ValueError):
+        # pass signal and sampling rate
+        x = pfilt.allpass(impulse, fc, 1, sampling_rate=44100)
+    with pytest.raises(ValueError):
+        # pass no signal and no sampling rate
+        x = pfilt.allpass(None, fc, 1)
+    with pytest.raises(ValueError):
+        # pass wrong order
+        x = pfilt.allpass(impulse, fc, 3)
+    with pytest.raises(ValueError):
+        # pass wrong combination of coefficients and order
+        x = pfilt.allpass(impulse, fc, 1, [1, 2])
+    with pytest.raises(ValueError):
+        # pass wrong combination of coefficients and order
+        x = pfilt.allpass(impulse, fc, 2, 1)
+
+
 def test_bell(impulse):
     # Uses third party code.
     # We thus only test the functionality not the results

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -127,42 +127,64 @@ def test_bessel(impulse):
         x = pfilt.bessel(None, 2, 1000, 'lowpass', 'phase')
 
 
-def test_allpass(impulse):
+@pytest.mark.parametrize('order', [1, 2])
+def test_allpass(impulse, order):
     # Uses third party code.
     # We thus only test the functionality not the results
+    fc = 1033
 
-    fc = 1000
-    orders = [1, 2]
-    kinds = ['First', 'Second']
+    sig_filt = pfilt.allpass(impulse, fc, order)
+    gd = pf.dsp.group_delay(sig_filt)
 
-    for (order, kind) in zip(orders, kinds):
-        f_obj = pfilt.allpass(None, fc, order, sampling_rate=44100)
-        assert isinstance(f_obj, pclass.FilterIIR)
-        assert f_obj.comment == (
-            f"{kind} order allpass-filter with cutoff frequency {fc} Hz.")
+    # Group delay at w = 0
+    T_gr_0 = gd[0]
+    # definition of group delay at fc (Tietze et al.)
+    T_fc_desired = T_gr_0 * (1 / np.sqrt(2))
+    # id of frequency bin closest to fc
+    freqs = sig_filt.frequencies
+    idx = np.argmin(abs(freqs - fc))
+    # group delay below fc and at fc
+    T_below = gd[:idx]
+    T_fc = gd[idx]
 
-        # Filter
-        x = pfilt.allpass(impulse, fc, order)
-        y = f_obj.process(impulse)
-        assert isinstance(x, Signal)
-        npt.assert_allclose(x.time, y.time)
+    # tolerance for group delay below fc
+    tol = 1 - (T_fc / T_gr_0)
 
+    # Test if group delay at fc is correct
+    np.testing.assert_allclose(T_fc_desired, T_fc, rtol=0.01)
+    # Test group delay below fc
+    np.testing.assert_allclose(T_below, T_gr_0, rtol=tol)
+
+    f_obj = pfilt.allpass(None, fc, order, sampling_rate=44100)
+    assert isinstance(f_obj, pclass.FilterIIR)
+    assert f_obj.comment == (
+        f"Allpass of order {order} with cutoff frequency "
+        f"{fc} Hz.")
+
+    # Filter
+    x = pfilt.allpass(impulse, fc, order)
+    y = f_obj.process(impulse)
+    assert isinstance(x, Signal)
+    npt.assert_allclose(x.time, y.time)
+
+
+def test_allpass_warnings(impulse, fc=1000):
     # test ValueError
     with pytest.raises(ValueError):
         # pass signal and sampling rate
-        x = pfilt.allpass(impulse, fc, 1, sampling_rate=44100)
+        _ = pfilt.allpass(impulse, fc, 1, sampling_rate=44100)
     with pytest.raises(ValueError):
         # pass no signal and no sampling rate
-        x = pfilt.allpass(None, fc, 1)
+        _ = pfilt.allpass(None, fc, 1)
     with pytest.raises(ValueError):
         # pass wrong order
-        x = pfilt.allpass(impulse, fc, 3)
+        _ = pfilt.allpass(impulse, fc, 3)
     with pytest.raises(ValueError):
         # pass wrong combination of coefficients and order
-        x = pfilt.allpass(impulse, fc, 1, [1, 2])
+        _ = pfilt.allpass(impulse, fc, 1, [1, 2])
     with pytest.raises(ValueError):
         # pass wrong combination of coefficients and order
-        x = pfilt.allpass(impulse, fc, 2, 1)
+        _ = pfilt.allpass(impulse, fc, 2, 1)
 
 
 def test_bell(impulse):

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -141,8 +141,7 @@ def test_allpass(impulse, order):
     # definition of group delay at fc (Tietze et al.)
     T_fc_desired = T_gr_0 * (1 / np.sqrt(2))
     # id of frequency bin closest to fc
-    freqs = sig_filt.frequencies
-    idx = np.argmin(abs(freqs - fc))
+    idx = sig_filt.find_nearest_frequency(fc)
     # group delay below fc and at fc
     T_below = gd[:idx]
     T_fc = gd[idx]
@@ -170,21 +169,26 @@ def test_allpass(impulse, order):
 
 def test_allpass_warnings(impulse, fc=1000):
     # test ValueError
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError,
+                       match='Either signal or sampling_rate must be none.'):
         # pass signal and sampling rate
-        _ = pfilt.allpass(impulse, fc, 1, sampling_rate=44100)
-    with pytest.raises(ValueError):
+        pfilt.allpass(impulse, fc, 1, sampling_rate=44100)
+    with pytest.raises(ValueError,
+                       match='Either signal or sampling_rate must be none.'):
         # pass no signal and no sampling rate
-        _ = pfilt.allpass(None, fc, 1)
-    with pytest.raises(ValueError):
+        pfilt.allpass(None, fc, 1)
+    with pytest.raises(ValueError,
+                       match='Order must be 1 or 2'):
         # pass wrong order
-        _ = pfilt.allpass(impulse, fc, 3)
-    with pytest.raises(ValueError):
+        pfilt.allpass(impulse, fc, 3)
+    with pytest.raises(ValueError,
+                       match='Coefficients must match the allpass order'):
         # pass wrong combination of coefficients and order
-        _ = pfilt.allpass(impulse, fc, 1, [1, 2])
-    with pytest.raises(ValueError):
+        pfilt.allpass(impulse, fc, 1, [1, 2])
+    with pytest.raises(ValueError,
+                       match='Coefficients must match the allpass order'):
         # pass wrong combination of coefficients and order
-        _ = pfilt.allpass(impulse, fc, 2, 1)
+        pfilt.allpass(impulse, fc, 2, 1)
 
 
 def test_bell(impulse):


### PR DESCRIPTION
Wrapper function for allpass implementation #527 

I probably should add a test for the filter properties to ``test_filter.py``. Any ideas for a smart way of checking if the filter is doing what it's supposed to do?

Link to docs:
https://pyfar--571.org.readthedocs.build/en/571/modules/pyfar.dsp.filter.html#pyfar.dsp.filter.allpass

