### PR TITLE
Fix math and description of coordinates

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1155,7 +1155,7 @@ class Coordinates():
     @property
     def rho(self):
         r"""
-        Distance perpendicular to the the z-axis of the right handed Cartesian
+        Radial distance to the the z-axis of the right handed Cartesian
         coordinate system (:math:`0` < rho < :math:`\infty`)."""
         return self.cylindrical[..., 2]
 

--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1120,7 +1120,7 @@ class Coordinates():
     def x(self):
         r"""
         X coordinate of a right handed Cartesian coordinate system in meters
-        (-\infty < x < \infty)."""
+        (:math:`-\infty` < x < :math:`\infty`)."""
         self._check_empty()
         return self._x
 
@@ -1132,7 +1132,7 @@ class Coordinates():
     def y(self):
         r"""
         Y coordinate of a right handed Cartesian coordinate system in meters
-        (-\infty < y < \infty)."""
+        (:math:`-\infty` < y < :math:`\infty`)."""
         self._check_empty()
         return self._y
 
@@ -1144,7 +1144,7 @@ class Coordinates():
     def z(self):
         r"""
         Z coordinate of a right handed Cartesian coordinate system in meters
-        (-\infty < z < \infty)."""
+        (:math:`-\infty` < z < :math:`\infty`)."""
         self._check_empty()
         return self._z
 
@@ -1155,8 +1155,8 @@ class Coordinates():
     @property
     def rho(self):
         r"""
-        Radial distance to the the z-axis of the right handed
-        Cartesian coordinate system in meters (0 \leq radius < \infty)."""
+        Distance perpendicular to the the z-axis of the right handed Cartesian
+        coordinate system (:math:`0` < rho < :math:`\infty`)."""
         return self.cylindrical[..., 2]
 
     @rho.setter
@@ -1168,8 +1168,8 @@ class Coordinates():
     @property
     def radius(self):
         r"""
-        Radial distance to the origin of the coordinate
-        system in meters (0 \leq radius < \infty)."""
+        Distance to the origin of the right handed Cartesian coordinate system
+        in meters (:math:`0` < radius < :math:`\infty`)."""
         return np.sqrt(self.x**2 + self.y**2 + self.z**2)
 
     @radius.setter
@@ -1181,10 +1181,10 @@ class Coordinates():
     @property
     def azimuth(self):
         r"""
-        Counter clock-wise angle in the x-y plane of the right handed
-        Cartesian coordinate system in radians. 0 radians are defined in
-        positive x-direction, pi/2 radians in positive y-direction and so on
-        (-\infty < azimuth < \infty, 2pi-cyclic)."""
+        Counter clock-wise angle in the x-y plane of the right handed Cartesian
+        coordinate system in radians. :math:`0` radians are defined in positive
+        x-direction, :math:`\pi/2` radians in positive y-direction and so on
+        (:math:`-\infty` < azimuth < :math:`\infty`, :math:`2\pi`-cyclic)."""
         return self.spherical_colatitude[..., 0]
 
     @azimuth.setter
@@ -1196,10 +1196,11 @@ class Coordinates():
     @property
     def elevation(self):
         r"""
-        Angle in the x-z plane of the right handed Cartesian coordinate
-        system in radians. 0 radians elevation are defined in positive
-        x-direction, pi/2 radians in positive z-direction, and -pi/2 in
-        negative z-direction (0 \leq azimuth \leq pi). The elevation is a
+        Angle in the x-z plane of the right handed Cartesian coordinate system
+        in radians. :math:`0` radians elevation are defined in positive
+        x-direction, :math:`\pi/2` radians in positive z-direction, and
+        :math:`-\pi/2` in negative z-direction
+        (:math:`-\pi/2\leq` elevation :math:`\leq\pi/2`). The elevation is a
         variation of the colatitude."""
         return self.spherical_elevation[..., 1]
 
@@ -1212,10 +1213,11 @@ class Coordinates():
     @property
     def colatitude(self):
         r"""
-        Angle in the x-z plane of the right handed Cartesian coordinate
-        system in radians. 0 radians elevation are defined in positive
-        z-direction, pi/2 radians in positive x-direction, and pi in negative
-        z-direction (pi/2 \leq azimuth \leq pi/2). The colatitude is a
+        Angle in the x-z plane of the right handed Cartesian coordinate system
+        in radians. :math:`0` radians colatitude are defined in positive
+        z-direction, :math:`\pi/2` radians in positive x-direction, and
+        :math:`\pi` in negative z-direction
+        (:math:`0\leq` colatitude :math:`\leq\pi`). The colatitude is a
         variation of the elevation angle."""
         return self.spherical_colatitude[..., 1]
 
@@ -1228,10 +1230,11 @@ class Coordinates():
     @property
     def frontal(self):
         r"""
-        Angle in the y-z plane of the right handed Cartesian coordinate
-        system in radians. 0 radians elevation are defined in positive
-        y-direction, pi/2 radians in positive z-direction, pi in negative
-        y-direction and so on (-\infty < azimuth < \infty, 2pi-cyclic)."""
+        Angle in the y-z plane of the right handed Cartesian coordinate system
+        in radians. :math:`0` radians frontal angle are defined in positive
+        y-direction, :math:`\pi/2` radians in positive z-direction,
+        :math:`\pi` in negative y-direction and so on
+        (:math:`-\infty` < frontal < :math:`\infty`, :math:`2\pi`-cyclic)."""
         return self.spherical_front[..., 0]
 
     @frontal.setter
@@ -1243,10 +1246,11 @@ class Coordinates():
     @property
     def upper(self):
         r"""
-        Angle in the x-z plane of the right handed Cartesian coordinate
-        system in radians. 0 radians elevation are defined in positive
-        x-direction, pi/2 radians in positive z-direction, and pi in negative
-        x-direction (0 \leq azimuth \leq pi)."""
+        Angle in the x-z plane of the right handed Cartesian coordinate system
+        in radians. :math:`0` radians upper angle are defined in positive
+        x-direction, :math:`\pi/2` radians in positive z-direction, and
+        :math:`\pi` in negative x-direction
+        (:math:`0\leq` upper :math:`\leq\pi`)."""
         return self.spherical_front[..., 1]
 
     @upper.setter
@@ -1258,10 +1262,11 @@ class Coordinates():
     @property
     def lateral(self):
         r"""
-        Counter clock-wise angle in the x-y plane of the right handed
-        Cartesian coordinate system in radians. 0 radians are defined in
-        positive x-direction, pi/2 radians in positive y-direction and -pi/2
-        in negative y-direction (-pi/2 \leq lateral \leq pi/2)."""
+        Counter clock-wise angle in the x-y plane of the right handed Cartesian
+        coordinate system in radians. :math:`0` radians are defined in positive
+        x-direction, :math:`\pi/2` radians in positive y-direction and
+        :math:`-\pi/2` in negative y-direction
+        (:math:`-\pi/2\leq` lateral :math:`\leq\pi/2`)."""
         return self.spherical_side[..., 0]
 
     @lateral.setter
@@ -1273,10 +1278,11 @@ class Coordinates():
     @property
     def polar(self):
         r"""
-        Angle in the x-z plane of the right handed Cartesian coordinate
-        system in radians. 0 radians elevation are defined in positive
-        x-direction, pi/2 radians in positive z-direction, pi in negative
-        x-direction and so on (-\infty < azimuth < \infty, 2pi-cyclic)."""
+        Angle in the x-z plane of the right handed Cartesian coordinate system
+        in radians. :math:`0` radians polar angle are defined in positive
+        x-direction, :math:`\pi/2` radians in positive z-direction,
+        :math:`\pi` in negative x-direction and so on
+        (:math:`-\infty` < polar < :math:`\infty`, :math:`2\pi`-cyclic)."""
         return self.spherical_side[..., 1]
 
     @polar.setter


### PR DESCRIPTION
### Changes proposed in this pull request:

Docstring for coordinates properties are now identical with the table introduced in #591. Note that this includes a couple of small fixes where coordinate names were confused after copy/past mistakes and correcting the coordinate ranges from < to \leq if required.