### PR TITLE
Relax arithmetic rules in case only one audio object is involved

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -906,6 +906,8 @@ def add(data: tuple, domain='freq'):
 
     The `fft_norm` of the result is as follows
 
+    * If only one signal is involved in the operation, the result gets the same
+      normalization.
     * If one signal has the FFT normalization ``'none'``, the results gets
       the normalization of the other signal.
     * If both signals have the same FFT normalization, the results gets the
@@ -951,6 +953,8 @@ def subtract(data: tuple, domain='freq'):
 
     The `fft_norm` of the result is as follows
 
+    * If only one signal is involved in the operation, the result gets the same
+      normalization.
     * If one signal has the FFT normalization ``'none'``, the results gets
       the normalization of the other signal.
     * If both signals have the same FFT normalization, the results gets the
@@ -996,6 +1000,8 @@ def multiply(data: tuple, domain='freq'):
 
     The `fft_norm` of the result is as follows
 
+    * If only one signal is involved in the operation, the result gets the same
+      normalization.
     * If one signal has the FFT normalization ``'none'``, the results gets
       the normalization of the other signal.
     * If both signals have the same FFT normalization, the results gets the
@@ -1040,6 +1046,8 @@ def divide(data: tuple, domain='freq'):
 
     The `fft_norm` of the result is as follows
 
+    * If only one signal is involved in the operation, the result gets the same
+      normalization.
     * If the denominator signal has the FFT normalization ``'none'``, the
       result gets the normalization of the numerator signal.
     * If both signals have the same FFT normalization, the results gets the
@@ -1084,6 +1092,8 @@ def power(data: tuple, domain='freq'):
 
     The `fft_norm` of the result is as follows
 
+    * If only one signal is involved in the operation, the result gets the same
+      normalization.
     * If one signal has the FFT normalization ``'none'``, the results gets
       the normalization of the other signal.
     * If both signals have the same FFT normalization, the results gets the
@@ -1169,6 +1179,8 @@ def matrix_multiplication(
 
     The `fft_norm` of the result is as follows
 
+    * If only one signal is involved in the operation, the result gets the same
+      normalization.
     * If one signal has the FFT normalization ``'none'``, the results gets
       the normalization of the other signal.
     * If both signals have the same FFT normalization, the results gets the

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1389,8 +1389,7 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool,
                     if n_samples != d.n_samples:
                         raise ValueError(
                             "The number of samples does not match.")
-                    fft_norm = _match_fft_norm(
-                        fft_norm, d.fft_norm, division)
+                    fft_norm = _match_fft_norm(fft_norm, d.fft_norm, division)
                 elif isinstance(d, TimeData):
                     if not np.allclose(times, d.times, atol=1e-15):
                         raise ValueError(
@@ -1538,8 +1537,7 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
     """
 
     # check if fft_norms are valid
-    valid_fft_norms = [
-        'none', 'unitary', 'amplitude', 'rms', 'power', 'psd']
+    valid_fft_norms = ['none', 'unitary', 'amplitude', 'rms', 'power', 'psd']
     if fft_norm_1 not in valid_fft_norms:
         raise ValueError((f"fft_norm_1 is {fft_norm_1} but must be in "
                           f"{', '.join(valid_fft_norms)}"))

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1358,7 +1358,7 @@ def _assert_match_for_arithmetic(data: tuple, domain: str, division: bool,
 
     # check input types and meta data
     n_audio_objects = 0
-    for d in enumerate(data):
+    for d in data:
         if isinstance(d, (Signal, TimeData, FrequencyData)):
             n_audio_objects += 1
             # store meta data upon first appearance

--- a/tests/test_audio_signal_arithmetic.py
+++ b/tests/test_audio_signal_arithmetic.py
@@ -214,19 +214,14 @@ def test_add_arrays():
         z, x + y, atol=1e-15)
 
 
-def test_signal_inversion():
+@pytest.mark.parametrize('fft_norm', ['none', 'rms'])
+def test_signal_inversion(fft_norm):
     """Test signal inversion with different FFT norms"""
 
-    # 'none' norm
-    signal = pf.Signal([2, 0, 0], 44100, fft_norm='none')
+    signal = pf.Signal([2, 0, 0], 44100, fft_norm=fft_norm)
     signal_inv = 1 / signal
     npt.assert_allclose(signal.time.flatten(), [2, 0, 0])
     npt.assert_allclose(signal_inv.time.flatten(), [.5, 0, 0])
-
-    # 'rms' norm
-    signal.fft_norm = 'rms'
-    with raises(ValueError, match="Either fft_norm_2"):
-        1 / signal
 
 
 def test_subtraction():
@@ -756,3 +751,25 @@ def test_matrix_multiplication_undocumented():
     y = np.ones((3, 2, 10)) * np.array([[1, 2], [3, 4], [5, 6]])[..., None]
     pf.matrix_multiplication(
         (x, y), domain='time', axes=[(-2, -1), (-3, -2), (-2, -1)])
+
+
+@pytest.mark.parametrize('audio_object', [
+    pf.Signal([1, -1, 1], 1, fft_norm='none'),
+    pf.Signal([1, -1, 1], 1, fft_norm='rms'),
+    pf.FrequencyData([1, -1, 1], [0, 1, 3]),
+    pf.TimeData([1, -1, 1], [1, 2, 3])])
+@pytest.mark.parametrize('operation', [
+    pf.add, pf.subtract, pf.multiply, pf.divide, pf.power])
+def test_audio_object_and_number(audio_object, operation):
+    """
+    Test if arithmetic operations work regardless of the fft norm and
+    audio object type if only one audio object is involved.
+    """
+
+    domain = 'time' if type(audio_object) is pf.TimeData else 'freq'
+
+    result = operation((1, audio_object), domain=domain)
+    assert type(result) is type(audio_object)
+
+    result = operation((audio_object, 1), domain=domain)
+    assert type(result) is type(audio_object)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #587 

### Changes proposed in this pull request:

- Bypass rules for fft norm if only one audio object is involved in the opeeration
- Add and update tests
- Update docstrings

### For discussion

I discovered that we had a test that explicitly does not allow `1/signal` if the FFT norm is not `'none'`. I did not remove this test yet. Do we want to stay hard?
