### PR TITLE
fix ruff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ jobs:
           pip-dependency-file: requirements_dev.txt
       - run:
           name: Ruff
-          command: ruff pyfar tests
+          command: ruff check
 
   test_documentation_build:
     parameters:

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -56,7 +56,7 @@ Ready to contribute? Here's how to set up `pyfar` for local development using th
 5. When you're done making changes, check that your changes pass ruff and the
    tests::
 
-    $ ruff pyfar tests
+    $ ruff check
     $ pytest
 
    ruff must pass without any warnings for `./pyfar` and `./tests` using the default or a stricter configuration. Ruff ignores a couple of PEP Errors (see `./pyproject.toml`). If necessary, adjust your linting configuration in your IDE accordingly.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,11 @@
 exclude = [
     ".git",
     "docs",
+    "setup.py",
 ]
-ignore = []
-select = [
+line-length = 79
+lint.ignore = []
+lint.select = [
     "E",
     "F",
     "W",


### PR DESCRIPTION
- add line length limit as we had before
- remove ruff warnings
    - replace ``ruff pyfar tests`` by ``ruff check`` as suggested by ruff. in ``pyproject.toml`` we define which files are checked by ``ruff check``. ``ruff pyfar tests`` was returning warnings.
    - use ``lint.ignore`` and ``lint.select`` as suggested by ruff warnings.
