### PR TITLE
Fix bug in `Coordinates.find within`

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -1703,12 +1703,12 @@ class Coordinates():
                     f"radius. Differences are larger than {radius_tol}")
             radius = np.max(radius)
 
-            if distance_measure == 'spherical_meter':
+            if distance_measure == 'spherical_radians':
                 # convert angle in radiant to distance on the sphere
                 # d = 2r*pi*d/(2*pi) = r*d
                 distance = radius * distance
 
-            # convert length on the great circle to in cartesian coordinates
+            # convert length on the great circle to euclidean distance
             distance = 2 * radius * np.sin(distance / (2 * radius))
 
             index = kdtree.query_ball_point(

--- a/tests/test_coordinates_find.py
+++ b/tests/test_coordinates_find.py
@@ -179,14 +179,23 @@ def test_find_within_error():
 @pytest.mark.parametrize('distance_measure', [
      'spherical_radians', 'spherical_meter'
 ])
-def test_find_within_spherical(distance_measure):
+@pytest.mark.parametrize('radius', [.5, 1, 2])
+def test_find_within_spherical(distance_measure, radius):
+    '''Test spherical distance measures for different radii'''
+    # Sampling grid in the median plane
     coords = pf.Coordinates.from_spherical_front(
-        np.arange(0, 360, 10)*np.pi/180, 1, 1)
-    find = pf.Coordinates(0, 0, 1)
+        np.arange(0, 360, 10)*np.pi/180, np.pi/2, radius)
+    # query point at north pole
+    find = pf.Coordinates(0, 0, radius)
+    # search within 90 degrees
+    distance = np.pi / 2
+    if distance_measure == 'spherical_meter':
+        distance *= radius
     spatial_mask = coords.find_within(
         find,
-        distance=np.pi/2,
+        distance=distance,
         distance_measure=distance_measure)
+    # all points with positive z-coordinates must be found
     npt.assert_array_equal(coords[spatial_mask], coords[coords.z >= 0])
 
 
@@ -210,15 +219,20 @@ def test_find_within_atol():
 
 
 def test_find_within_tol_radius():
+    '''Test spherical distance measure with tolerance for radius'''
+    # Sampling grid in the median plane with varying radii
     coords = pf.Coordinates.from_spherical_front(
-        np.arange(0, 360, 10)*np.pi/180, 1, 1)
+        np.arange(0, 360, 10)*np.pi/180, np.pi/2, 1)
     radius = coords.radius
     radius[0] = 1.01
     coords.radius = radius
+    # query point at north pole
     find = pf.Coordinates(0, 0, 1)
+    # search within 90 degrees
     spatial_mask = coords.find_within(
         find,
         distance=np.pi/2,
-        distance_measure='spherical_meter',
+        distance_measure='spherical_radians',
         radius_tol=0.011)
+    # all points with positive z-coordinates must be found
     npt.assert_array_equal(coords[spatial_mask], coords[coords.z >= 0])


### PR DESCRIPTION
There was a bug when converting the spherical distance measures to eucledian distance.

### Changes proposed in this pull request:

- Fixed the bug
- Updated and improved the tests to be correct and tests spherical distance measures for multiple radii
