### PR TITLE
Introduce radius_tol to Coordiantes.find_nearest()

### DIFF
--- a/tests/test_coordinates_find.py
+++ b/tests/test_coordinates_find.py
@@ -111,6 +111,26 @@ def test_find_nearest_error():
     with pytest.raises(ValueError):
         coords.find_nearest(find, 1, 5)
 
+    # test negative radius_tol
+    with pytest.raises(ValueError,
+                       match="radius_tol must be a non negative number."):
+        coords.find_nearest(find, 1, "spherical_radians", -1)
+
+
+def test_find_nearest_radius_tol():
+    coords = pf.Coordinates.from_spherical_elevation(
+        np.arange(0, 360, 10)*np.pi/180, 0, 1)
+    radius = coords.radius
+    radius[0] = 1.09
+    coords.radius = radius
+    coords2find = pf.Coordinates.from_spherical_elevation(0, 0, 1)
+    idx, _ = coords.find_nearest(
+        coords2find,
+        1,
+        "spherical_radians",
+        radius_tol=0.1)
+    assert coords[idx] == coords[0]
+
 
 def test_find_within_simple():
     x = np.arange(6)


### PR DESCRIPTION
Closes #616 

Added a radius tolerance ``radius_tol`` parameter to ``Coordinates.find_nearest`` in case the differences between the radii are larger than zero when using spherical distance measures.
