### PR TITLE
Harmonize class documentation

### DIFF
--- a/docs/classes/pyfar.audio.rst
+++ b/docs/classes/pyfar.audio.rst
@@ -4,5 +4,4 @@ Audio (Signal, TimeData, FrequencyData)
 .. automodule:: pyfar.classes.audio
    :members:
    :undoc-members:
-   :special-members: [, __init__, __getitem__, __setitem__, __iter__, ]
    :inherited-members:

--- a/docs/classes/pyfar.orientations.rst
+++ b/docs/classes/pyfar.orientations.rst
@@ -4,5 +4,4 @@ Orientations
 .. automodule:: pyfar.classes.orientations
    :members:
    :undoc-members:
-   :special-members: __init__
    :show-inheritance:

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -17,10 +17,11 @@ warnings.filterwarnings("error", category=VisibleDeprecationWarning)
 class Orientations(Rotation):
     """
     This class for Orientations in the three-dimensional space,
-    is a subclass of scipy.spatial.transform.Rotation and equally based on
-    quaternions of shape (N, 4). It inherits all methods of the Rotation class
-    and adds the creation from perpendicular view and up vectors and a
-    convenient plot function.
+    is a subclass of :py:class:`scipy:scipy.spatial.transform.Rotation` and
+    equally based on quaternions of shape (N, 4). It inherits all methods of
+    the Rotation class and adds the creation from perpendicular view and up
+    vectors through :py:func:`~from_view_up` and a convenient plot function
+    :py:func:`~show`.
 
     An orientation can be visualized with the triple of view, up and right
     vectors and it is tied to the object's local coordinate system.


### PR DESCRIPTION
Some classes still used an explicit documentation of their magic methods, which I think is not good practive.

closes #506 

### Changes proposed in this pull request:

- Move documentation of `Orientation.__init__` to the class docstring and make interactive links
- Move documentation from Audio objects (Signal/TimeData/FrequencyData) `__init__` to the class docstring.
- Move Information from Audio objects `__getitem__`, `__setitem__`, and `__iter__` to the module dosctring.

In the latter case, we might consider adding an example notebook to the gallery instead. The information in the docs on this is rather sparse. But I did not want to add stuff in this pull.
