### PR TITLE
Add domain='auto' to pf.dsp.normalize

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2077,7 +2077,7 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False,
         return pyfar.FrequencyData(data, signal.frequencies, signal.comment)
 
 
-def normalize(signal, reference_method='max', domain='time',
+def normalize(signal, reference_method='max', domain='auto',
               channel_handling='individual', target=1, limits=(None, None),
               unit=None, return_reference=False, nan_policy='raise'):
     """
@@ -2126,8 +2126,15 @@ def normalize(signal, reference_method='max', domain='time',
           normalized magnitude spectrum is used
           pyfar examples gallery
           (cf. :ref:`FFT normalization<gallery:/gallery/interactive/fast_fourier_transform.ipynb#FFT-normalizations>`).
+        ``'auto'``
+           Uses ``'time'`` domain normalization for
+           :py:class:`Signal <pyfar.classes.audio.Signal>` and
+           :py:class:`TimeData <pyfar.classes.audio.TimeData>` objects and
+           ``'freq'`` domain normalization for
+           :py:class:`FrequencyData <pyfar.classes.audio.FrequencyData>`
+           objects.
 
-        The default is ``'time'``.
+        The default is ``'auto'``.
     channel_handling: string, optional
         Define how channel-wise `reference` values are handeled for multi-
         channel signals. This parameter does not affect single-channel signals.
@@ -2234,8 +2241,14 @@ def normalize(signal, reference_method='max', domain='time',
         raise TypeError(("Input data has to be of type 'Signal', 'TimeData' "
                          "or 'FrequencyData'."))
 
-    if domain not in ('time', 'freq'):
-        raise ValueError("domain must be 'time' or 'freq'.")
+    if domain not in ('time', 'freq', 'auto'):
+        raise ValueError("domain must be 'time', 'freq' or 'auto.")
+    # get signal domain if domain = 'auto'
+    if domain == 'auto' and type(signal) == pyfar.FrequencyData:
+        domain = 'freq'
+    elif domain == 'auto' and (type(signal) == pyfar.TimeData
+                               or type(signal) == pyfar.Signal):
+        domain = 'time'
     if (type(signal) is pyfar.FrequencyData) and domain == 'time':
         raise ValueError((
             f"domain is '{domain}' and signal is type '{signal.__class__}'"

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2242,7 +2242,8 @@ def normalize(signal, reference_method='max', domain='auto',
                          "or 'FrequencyData'."))
 
     if domain not in ('time', 'freq', 'auto'):
-        raise ValueError("domain must be 'time', 'freq' or 'auto.")
+        raise ValueError("domain must be 'time', 'freq' or 'auto' but is"
+                         f" '{domain}'.")
     # get signal domain if domain = 'auto'
     if domain == 'auto' and type(signal) == pyfar.FrequencyData:
         domain = 'freq'

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -51,6 +51,19 @@ def test_domains_normalization():
     npt.assert_allclose(np.max(np.abs(freq.freq)), 1)
 
 
+def test_auto_domain_normalization():
+    """Test for normalization with auto domain."""
+    signal = pf.Signal([1, 3, 0], 10)
+    time_data = pf.TimeData([1, 3, 0], [0, 1, 4])
+    freq_data = pf.FrequencyData([2, 0, 1.5], [10, 100, 1000])
+
+    assert pf.dsp.normalize(signal) == pf.dsp.normalize(signal, domain='time')
+    assert pf.dsp.normalize(time_data) == pf.dsp.normalize(time_data,
+                                                           domain='time')
+    assert pf.dsp.normalize(freq_data) == pf.dsp.normalize(freq_data,
+                                                           domain='freq')
+
+
 @pytest.mark.parametrize('unit, limit1, limit2', (
                          [None, (0, 1000), (1000, 2000)],
                          ['s', (0, 0.5), (0.5, 1)]))
@@ -132,7 +145,7 @@ def test_error_raises():
                                    "'pyfar.classes.audio.TimeData'>'")):
         pf.dsp.normalize(pf.TimeData([1, 1, 1], [1, 2, 3]), domain='freq')
 
-    with raises(ValueError, match=("domain must be 'time' or 'freq'.")):
+    with raises(ValueError, match=("domain must be 'time', 'freq' or 'auto.")):
         pf.dsp.normalize(pf.Signal([0, 1, 0], 44100), domain='invalid_domain')
 
     with raises(ValueError, match=("reference_method must be 'max', 'mean',")):

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -145,7 +145,8 @@ def test_error_raises():
                                    "'pyfar.classes.audio.TimeData'>'")):
         pf.dsp.normalize(pf.TimeData([1, 1, 1], [1, 2, 3]), domain='freq')
 
-    with raises(ValueError, match=("domain must be 'time', 'freq' or 'auto.")):
+    with raises(ValueError, match=("domain must be 'time', 'freq' or 'auto' "
+                                   "but is 'invalid_domain'.")):
         pf.dsp.normalize(pf.Signal([0, 1, 0], 44100), domain='invalid_domain')
 
     with raises(ValueError, match=("reference_method must be 'max', 'mean',")):


### PR DESCRIPTION
Added `domain='auto'` as default for normalization. 
Sets domain to ``'freq'`` for _FrequencyData_ and ``'time'`` for _TimeData_ and _Signal_

Closes #572
