### PR TITLE
add header to index

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,1 +1,4 @@
+pyfar
+=====
+
 .. include:: header.rst


### PR DESCRIPTION
replaces the no_title in previous 
add header to index so that the previous page on pyfar.html 
points to be discussed.
- rename readme header from pyfar to readme

old version see at the end of the page: https://pyfar.readthedocs.io/en/latest/pyfar.html
fixed version: https://pyfar--637.org.readthedocs.build/en/637/pyfar.html