### PR TITLE
include kwargs to parse to scipy in to support the new parameter.

### DIFF
--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -53,8 +53,8 @@ class Orientations(Rotation):
     ----------
         quat : array_like, shape (N, 4) or (4,)
             Each row is a (possibly non-unit norm) quaternion in scalar-last
-            (x, y, z, w) format. The normalization is defined by
-            ``'normalize'``.
+            (x, y, z, w) format. Each quaternion will be normalized to unit
+            norm.
 
     """
 

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -55,12 +55,6 @@ class Orientations(Rotation):
             Each row is a (possibly non-unit norm) quaternion in scalar-last
             (x, y, z, w) format. The normalization is defined by
             ``'normalize'``.
-        normalize : bool, optional
-            Whether each quaternion will be normalized to unit
-            norm. Default is True.
-        copy : bool, optional
-            Whether the quaternion array will be copied or not.
-            Default is True.
 
     """
 

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -53,15 +53,21 @@ class Orientations(Rotation):
     ----------
         quat : array_like, shape (N, 4) or (4,)
             Each row is a (possibly non-unit norm) quaternion in scalar-last
-            (x, y, z, w) format. Each quaternion will be normalized to unit
-            norm.
+            (x, y, z, w) format. The normalization is defined by
+            ``'normalize'``.
+        normalize : bool, optional
+            Whether each quaternion will be normalized to unit
+            norm. Default is True.
+        copy : bool, optional
+            Whether the quaternion array will be copied or not.
+            Default is True.
 
     """
 
-    def __init__(self, quat=None, normalize=True, copy=True):
+    def __init__(self, quat=None, normalize=True, copy=True, **kwargs):
         if quat is None:
             quat = np.array([0., 0., 0., 1.])
-        super().__init__(quat, copy=copy)
+        super().__init__(quat, copy=copy, **kwargs)
 
     @classmethod
     def from_view_up(cls, views, ups):

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -49,19 +49,6 @@ class Orientations(Rotation):
     To create `Orientations` objects use ``from_...`` methods.
     ``Orientations(...)`` is not supposed to be instantiated directly.
 
-    Attributes
-    ----------
-        quat : array_like, shape (N, 4) or (4,)
-            Each row is a (possibly non-unit norm) quaternion in scalar-last
-            (x, y, z, w) format. The normalization is defined by
-            ``'normalize'``.
-        normalize : bool, optional
-            Whether each quaternion will be normalized to unit
-            norm. Default is True.
-        copy : bool, optional
-            Whether the quaternion array will be copied or not.
-            Default is True.
-
     """
 
     def __init__(self, quat=None, normalize=True, copy=True, **kwargs):

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -49,6 +49,19 @@ class Orientations(Rotation):
     To create `Orientations` objects use ``from_...`` methods.
     ``Orientations(...)`` is not supposed to be instantiated directly.
 
+    Attributes
+    ----------
+        quat : array_like, shape (N, 4) or (4,)
+            Each row is a (possibly non-unit norm) quaternion in scalar-last
+            (x, y, z, w) format. The normalization is defined by
+            ``'normalize'``.
+        normalize : bool, optional
+            Whether each quaternion will be normalized to unit
+            norm. Default is True.
+        copy : bool, optional
+            Whether the quaternion array will be copied or not.
+            Default is True.
+
     """
 
     def __init__(self, quat=None, normalize=True, copy=True, **kwargs):

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -928,7 +928,7 @@ def minimum_phase(signal, n_fft=None, truncate=True):
         >>> from scipy.signal import remez
         >>> import matplotlib.pyplot as plt
         >>> freq = [0, 0.2, 0.3, 1.0]
-        >>> h_linear = pf.Signal(remez(151, freq, [1, 0], Hz=2.), 44100)
+        >>> h_linear = pf.Signal(remez(151, freq, [1, 0], fs=2.), 44100)
         >>> # create minimum phase impulse responses
         >>> h_min = pf.dsp.minimum_phase(h_linear, truncate=False)
         >>> # plot the result


### PR DESCRIPTION
- tests are failing atm
- remove attributes for init, since init is not supposed the get called directly.
- add **kwargs to make it wok with [scipy's](https://github.com/scipy/scipy/releases/tag/v1.14.0) new parameter scalar-first (it is also backwardcompatible)
- change from ``'Hz'`` parameter in [scipy](https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.signal.remez.html)

also general remark: we can discuss if its a good idea to overwrite the init function, just to allow to run 'pf.Orientations()' even if the orientation is not empty, beacuse scipy does not allow it.