### PR TITLE
fix deprecation warnings from matplotlib and numpy

### DIFF
--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -50,13 +50,11 @@ class LogLocatorITAToolbox(LogLocator):
         self,
         base=10.0,
         subs=(0.2, 0.4, 0.6, 1),
-        numdecs=4,
         numticks=None
     ):
         super().__init__(
             base=base,
             subs=subs,
-            numdecs=numdecs,
             numticks=numticks)
 
 

--- a/pyfar/samplings/spatial.py
+++ b/pyfar/samplings/spatial.py
@@ -52,7 +52,7 @@ class SphericalVoronoi(spat.SphericalVoronoi):
         if len(radius_round) > 1:
             raise ValueError("All sampling points need to be on the \
                     same radius.")
-        super().__init__(points, radius_round, center)
+        super().__init__(points, radius_round[0], center)
 
     def copy(self):
         """Return a copy of the Voronoi object."""


### PR DESCRIPTION
fix deprecation warnings on main to avoid sth like #638 in future
requires #638

we could think about a test on circle ci which breaks if we get deprecation warnings:
```
pytest tests -W error::DeprecationWarning
```