### PR TITLE
Updated link to the SoundFile docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ Check out the `contributing guidelines`_ if you want to become part of pyfar.
 .. _pyfar example gallery: https://pyfar-gallery.readthedocs.io/en/latest/examples_gallery.html
 .. _pyfar documentation: https://pyfar.readthedocs.io
 .. _pyfar.org: https://pyfar.org
-.. _SoundFile: https://pysoundfile.readthedocs.io
+.. _SoundFile: https://python-soundfile.readthedocs.io
 .. _libsndfile: http://www.mega-nerd.com/libsndfile/
 .. _help section: https://pyfar-gallery.readthedocs.io/en/latest/help
 .. _contributing guidelines: https://pyfar.readthedocs.io/en/stable/contributing.html


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?
Link to SoundFile docs in README is deprecated.

### Changes proposed in this pull request:
[https://pysoundfile.readthedocs.io](https://pysoundfile.readthedocs.io) leads to a 404 page, as pysoundfile was renamed to soundfile. The docs are now located at [https://python-soundfile.readthedocs.io/](https://python-soundfile.readthedocs.io/). 