### PR TITLE
modify `shape` of return value

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1430,7 +1430,7 @@ def find_impulse_response_start(
                     f'No values below threshold found found for channel {ch}',
                     'defaulting to 0')
 
-    return np.squeeze(start_sample)
+    return start_sample
 
 
 @rename_arg({"freq_range": "frequency_range"},


### PR DESCRIPTION
### Changes proposed in this pull request:
- remove `np.squeeze` in order to assure that the shape of the return type matches that of the signal

Working with pyfar, I've had my code fail at runtime because the shapes are inconsistent, especially in the `dsp` module. My code works for `n x m` channels, but when setting `n=1` or `m=1` sometimes dimensions are squeezed away which is a headache. Somewhat related: #627 