### PR TITLE
Change squeeze in filter class to keep cshape of input signal

### DIFF
--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -247,7 +247,12 @@ class Filter(object):
 
         # prepare output signal
         filtered_signal = deepcopy(signal)
-        filtered_signal.time = np.squeeze(filtered_signal_data)
+
+        # squeeze first dimension if there is only one filter channel
+        if self.n_channels == 1:
+            filtered_signal.time = np.squeeze(filtered_signal_data, axis=0)
+        else:
+            filtered_signal.time = filtered_signal_data
 
         return filtered_signal
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -223,7 +223,7 @@ def test_crossover(impulse):
     for order in [2, 4, 6, 8]:
         for frequency in [4000, (1e2, 10e3)]:
             x = pfilt.crossover(impulse, order, frequency)
-            x_sum = np.sum(x.freq, axis=-2).flatten()
+            x_sum = np.sum(x.freq, axis=-3).flatten()
             x_ref = np.ones(x.n_bins)
             npt.assert_allclose(x_ref, np.abs(x_sum), atol=.0005)
 
@@ -254,7 +254,7 @@ def test_reconstructing_fractional_octave_bands():
     x = pf.signals.impulse(2**12)
     y, f = pfilt.reconstructing_fractional_octave_bands(x)
     assert isinstance(y, Signal)
-    assert y.cshape == (9, )
+    assert y.cshape == (9, 1)
     assert y.fft_norm == 'none'
 
     # test reconstruction (sum has a group delay of half the filter length)
@@ -279,7 +279,7 @@ def test_reconstructing_fractional_octave_bands_filter_slopes():
         # restricting rtol was not needed locally. It was added for tests to
         # pass on the testing platform
         npt.assert_allclose(
-            y.time, np.atleast_2d(reference), rtol=.01, atol=1e-10)
+            y.time[:,0,:], np.atleast_2d(reference), rtol=.01, atol=1e-10)
 
 
 def test_reconstructing_fractional_octave_bands_warning():

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -279,7 +279,7 @@ def test_reconstructing_fractional_octave_bands_filter_slopes():
         # restricting rtol was not needed locally. It was added for tests to
         # pass on the testing platform
         npt.assert_allclose(
-            y.time[:,0,:], np.atleast_2d(reference), rtol=.01, atol=1e-10)
+            y.time[:, 0, :], np.atleast_2d(reference), rtol=.01, atol=1e-10)
 
 
 def test_reconstructing_fractional_octave_bands_warning():

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -198,7 +198,7 @@ def test_filter_iir_process_multi_dim_filt(impulse):
 
     res = filt.process(impulse)
 
-    npt.assert_allclose(res.time[:, :3], coeff[:, 0])
+    npt.assert_allclose(res.time[:, 0, :3], coeff[:, 0])
 
     impulse.time = np.vstack((impulse.time, impulse.time))
     filt = fo.FilterIIR(coeff, impulse.sampling_rate)
@@ -218,7 +218,7 @@ def test_filter_fir_process_multi_dim_filt(impulse):
 
     filt = fo.FilterFIR(coeff, impulse.sampling_rate)
     res = filt.process(impulse)
-    npt.assert_allclose(res.time[:, :3], coeff)
+    npt.assert_allclose(res.time[:, 0, :3], coeff)
 
     impulse.time = np.vstack((impulse.time, impulse.time))
     filt = fo.FilterFIR(coeff, impulse.sampling_rate)
@@ -325,7 +325,7 @@ def test_filter_sos_process_multi_dim_filt(impulse):
     filt = fo.FilterSOS(sos, impulse.sampling_rate)
     res = filt.process(impulse)
 
-    npt.assert_allclose(res.time[:, :3], coeff[:, 0])
+    npt.assert_allclose(res.time[:, 0, :3], coeff[:, 0])
 
     impulse.time = np.vstack((impulse.time, impulse.time))
     filt = fo.FilterSOS(sos, impulse.sampling_rate)

--- a/tests/test_fractional_octaves.py
+++ b/tests/test_fractional_octaves.py
@@ -135,5 +135,5 @@ def test_sum_bands_din():
 
     mask = (impulse.frequencies > 30) & (impulse.frequencies < 20e3)
 
-    assert not np.any(diff[mask] > 10**(1/10))
-    assert not np.any(diff[mask] < 10**(-1/10))
+    assert not np.any(diff[:, mask] > 10**(1/10))
+    assert not np.any(diff[:, mask] < 10**(-1/10))


### PR DESCRIPTION
I changed the squeeze in ``Filter.process`` so it doesn't squeeze any of the input signal's channel dimensions.

Closes #627 

I would do separate PRs for gammatone class and the dsp-functions if changes are necessary.