### PR TITLE
limit sphinx < 8

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,7 +4,7 @@ wheel
 watchdog
 flake8
 coverage
-Sphinx
+Sphinx<8
 twine
 pytest
 pytest-runner

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ test_requirements = [
     'watchdog',
     'flake8',
     'coverage',
-    'Sphinx',
+    'Sphinx<8',
     'twine'
 ]
 


### PR DESCRIPTION
Limit sphinx to version < 8 due to failing docs build.

related issue #661 

