### PR TITLE
deprecate Python 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.8"
                 - "3.9"
                 - "3.10"
                 - "3.11"
@@ -181,7 +180,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.8"
                 - "3.9"
                 - "3.10"
                 - "3.11"

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Use pip to install pyfar
 
     pip install pyfar
 
-(Requires Python 3.8 or higher)
+(Requires Python 3.9 or higher)
 
 Audio file reading/writing is supported through [SoundFile](https://python-soundfile.readthedocs.io), which is based on
 [libsndfile](http://www.mega-nerd.com/libsndfile/). On Windows and OS X, it will be installed automatically.

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
@@ -71,5 +70,5 @@ setup(
     },
     version='0.6.8',
     zip_safe=False,
-    python_requires='>=3.8'
+    python_requires='>=3.9'
 )


### PR DESCRIPTION
### Changes proposed in this pull request:

End support for Python 3.8 as discussed during the weekly and required by #682