### PR TITLE
Remove unwanted warning in Coordinates initialization

### DIFF
--- a/pyfar/classes/coordinates.py
+++ b/pyfar/classes/coordinates.py
@@ -260,12 +260,6 @@ class Coordinates():
         self.sh_order = sh_order
         self._comment = comment
 
-        if sh_order is not None:
-            warnings.warn((
-                "This function will be deprecated in pyfar 0.8.0 in favor "
-                "of spharpy.samplings.SamplingSphere."),
-                    PyfarDeprecationWarning)
-
     @classmethod
     def from_cartesian(
             cls, x, y, z, weights: np.array = None, comment: str = ""):
@@ -1047,10 +1041,12 @@ class Coordinates():
         """This function will be deprecated in pyfar 0.8.0 in favor
             of :py:class:`spharpy.samplings.SamplingSphere`.
             Set the maximum spherical harmonic order."""
-        warnings.warn((
-            "This function will be deprecated in pyfar 0.8.0 in favor "
-            "of spharpy.samplings.SamplingSphere."),
-                PyfarDeprecationWarning)
+
+        if value is not None:
+            warnings.warn((
+                "This function will be deprecated in pyfar 0.8.0 in favor "
+                "of spharpy.samplings.SamplingSphere."),
+                    PyfarDeprecationWarning)
 
         self._sh_order = int(value) if value is not None else None
 

--- a/pyfar/dsp/filter/_audiofilter.py
+++ b/pyfar/dsp/filter/_audiofilter.py
@@ -27,7 +27,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-"""  # noqa: E501
+"""   # noqa: E501
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
 import numpy as np

--- a/pyfar/dsp/filter/_audiofilter.py
+++ b/pyfar/dsp/filter/_audiofilter.py
@@ -27,7 +27,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
-"""
+"""  # noqa: E501
 import matplotlib.pyplot as plt
 from matplotlib.patches import Circle
 import numpy as np


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Creating a Coordinates object always raises a warning, even in featres scheduled for deprecation are *not* used.

### Changes proposed in this pull request:

Change the way the warning for the deprecated `sh` property of the class is raised.