### PR TITLE
fix: just classname in error message

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2250,12 +2250,14 @@ def normalize(signal, reference_method='max', domain='auto',
                                or type(signal) is pyfar.Signal):
         domain = 'time'
     if (type(signal) is pyfar.FrequencyData) and domain == 'time':
+        class_name = signal.__class__.__name__
         raise ValueError((
-            f"domain is '{domain}' and signal is type '{signal.__class__}'"
+            f"domain is '{domain}' and signal is type '{class_name}'"
             " but must be of type 'Signal' or 'TimeData'."))
     if (type(signal) is pyfar.TimeData) and domain == 'freq':
+        class_name = signal.__class__.__name__
         raise ValueError((
-            f"domain is '{domain}' and signal is type '{signal.__class__}'"
+            f"domain is '{domain}' and signal is type '{class_name}'"
             " but must be of type 'Signal' or 'FrequencyData'."))
     if isinstance(limits, (int, float)) or len(limits) != 2:
         raise ValueError("limits must be an array like of length 2.")

--- a/pyfar/dsp/filter/audiofilter.py
+++ b/pyfar/dsp/filter/audiofilter.py
@@ -579,7 +579,8 @@ def high_shelf_cascade(
         signal, frequency, frequency_type="lower", gain=None, slope=None,
         bandwidth=None, N=None, sampling_rate=None):
     """
-    Create and apply constant slope filter from cascaded 2nd order high shelves.
+    Create and apply constant slope filter from cascaded 2nd order
+    high shelves.
 
     The filters - also known as High-Schultz filters (cf. [#]_) - are defined
     by their characteristic frequency, gain, slope, and bandwidth. Two out of

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -135,14 +135,12 @@ def test_error_raises():
         pf.dsp.normalize([0, 1, 0])
 
     with raises(ValueError, match=("domain is 'time' and signal is type "
-                                   "'<class "
-                                   "'pyfar.FrequencyData'>'")):
+                                   "'FrequencyData'")):
         pf.dsp.normalize(pf.FrequencyData([1, 1, 1], [100, 200, 300]),
                          domain='time')
 
     with raises(ValueError, match=("domain is 'freq' and signal is type "
-                                   "'<class "
-                                   "'pyfar.TimeData'>'")):
+                                   "'TimeData'")):
         pf.dsp.normalize(pf.TimeData([1, 1, 1], [1, 2, 3]), domain='freq')
 
     with raises(ValueError, match=("domain must be 'time', 'freq' or 'auto' "


### PR DESCRIPTION
there was a class description in the error message, not really human readable, so I changed it to the name of the class