### PR TITLE
Complex signals: fix ``side`` docstring

### DIFF
--- a/pyfar/plot/line.py
+++ b/pyfar/plot/line.py
@@ -129,7 +129,7 @@ def freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -199,7 +199,7 @@ def phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -276,7 +276,7 @@ def group_delay(signal, unit="s", freq_scale='log', ax=None, style='light',
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -376,7 +376,7 @@ def time_freq(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         The default is ``'real'``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -461,7 +461,7 @@ def freq_phase(signal, dB=True, log_prefix=None, log_reference=1,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -552,7 +552,7 @@ def freq_group_delay(signal, dB=True, log_prefix=None, log_reference=1,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs

--- a/pyfar/plot/two_d.py
+++ b/pyfar/plot/two_d.py
@@ -239,7 +239,7 @@ def freq_2d(signal, dB=True, log_prefix=None, log_reference=1,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -375,7 +375,7 @@ def phase_2d(signal, deg=False, unwrap=False, freq_scale='log', indices=None,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -519,7 +519,7 @@ def group_delay_2d(signal, unit="s", freq_scale='log', indices=None,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -681,7 +681,7 @@ def time_freq_2d(signal, dB_time=False, dB_freq=True, log_prefix_time=20,
         plotted. The default is ``real``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -828,7 +828,7 @@ def freq_phase_2d(signal, dB=True, log_prefix=None, log_reference=1,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -983,7 +983,7 @@ def freq_group_delay_2d(signal, dB=True, log_prefix=None, log_reference=1,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs
@@ -1124,7 +1124,7 @@ def spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         ``light``.
     side : str, optional
         ``'right'`` to plot the right-sided spectrum containing the positive
-        frequencies, or ``'left'``to plot the left-sided spectrum containing
+        frequencies, or ``'left'`` to plot the left-sided spectrum containing
         the negative frequencies (only possible for complex Signals). The
         default is ``'right'``.
     **kwargs


### PR DESCRIPTION
Missing whitespace between ``'left'`` and "to"in docstring of new ``side`` parameter caused a rendering issue.