### PR TITLE
hot: fix compress flag in pyfar.io.write

### DIFF
--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -316,7 +316,7 @@ def write(filename, compress=False, **objs):
     """
     # Check for .far file extension
     filename = pathlib.Path(filename).with_suffix('.far')
-    compression = zipfile.ZIP_STORED if compress else zipfile.ZIP_DEFLATED
+    compression = zipfile.ZIP_DEFLATED if compress else zipfile.ZIP_STORED
     zip_buffer = io.BytesIO()
     builtin_wrapper = codec.BuiltinsWrapper()
     with zipfile.ZipFile(zip_buffer, "a", compression) as zip_file:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -451,6 +451,15 @@ def test_write_read_multiplePyfarObjects(
     assert dict_of_builtins.items() <= actual.items()
 
 
+def test_write_read_compression(sine, tmpdir):
+    filename_compressed = os.path.join(tmpdir, 'sine_compressed.far')
+    io.write(filename_compressed, signal=sine, compress=True)
+    filename_uncompressed = os.path.join(tmpdir, 'sine_uncompressed.far')
+    io.write(filename_uncompressed, signal=sine, compress=False)
+    assert os.path.getsize(filename_uncompressed) > os.path.getsize(
+        filename_compressed)
+
+
 def test_write_read_multiplePyfarObjectsWithCompression(
         filter,
         filterFIR,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -452,6 +452,7 @@ def test_write_read_multiplePyfarObjects(
 
 
 def test_write_read_compression(sine, tmpdir):
+    """Test whether compressed files are larger than uncompressed files."""
     filename_compressed = os.path.join(tmpdir, 'sine_compressed.far')
     io.write(filename_compressed, signal=sine, compress=True)
     filename_uncompressed = os.path.join(tmpdir, 'sine_uncompressed.far')


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #706

### Changes proposed in this pull request:

- fix usage of compress parameter in ``pyfar.io.write``
- add test whether the compressed file is smaller then the uncompressed one.
