### PR TITLE
add verbose to read_sofa

### DIFF
--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -34,7 +34,7 @@ from . import _codec as codec
 import pyfar.classes.filter as fo
 
 
-def read_sofa(filename, verify=True):
+def read_sofa(filename, verify=True, verbose=True):
     """
     Import a SOFA file as pyfar object.
 
@@ -46,6 +46,9 @@ def read_sofa(filename, verify=True):
         Verify if the data contained in the SOFA file agrees with the AES69
         standard (see references). If the verification fails, the SOFA file
         can be loaded by setting ``verify=False``. The default is ``True``
+    verbose : bool, optional
+        Print the names of detected custom variables and attributes.
+        The default is True.
 
     Returns
     -------
@@ -85,7 +88,7 @@ def read_sofa(filename, verify=True):
 
     """
 
-    sofa = sf.read_sofa(filename, verify)
+    sofa = sf.read_sofa(filename, verify, verbose)
     return convert_sofa(sofa)
 
 

--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -72,7 +72,7 @@ def read_sofa(filename, verify=True, verbose=True):
         automatically matched.
     receiver_coordinates : Coordinates
         Coordinates object containing the data stored in
-        `SOFA_object.RecevierPosition`. The domain, convention and unit are
+        `SOFA_object.ReceiverPosition`. The domain, convention and unit are
         automatically matched.
 
     Notes


### PR DESCRIPTION
verbose was always True since it was not possible to change it when sf.read_sofa is called interanally.
Maybe we can make it in this releae ^^