### PR TITLE
Add corrleation function to pyfar.dsp

### DIFF
--- a/pyfar/dsp/__init__.py
+++ b/pyfar/dsp/__init__.py
@@ -22,6 +22,7 @@ from .dsp import (
     rms,
     normalize,
     average,
+    correlate,
 )
 
 from .interpolation import (
@@ -65,4 +66,5 @@ __all__ = [
     'average',
     'normalize',
     'fractional_time_shift',
+    'correlate',
 ]

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2671,9 +2671,9 @@ def normalize(signal, reference_method='max', domain='auto',
         return normalized_signal
 
 
-def correlate(signal_1, signal_2, mode='full', normalize=None):
+def correlate(signal_1, signal_2, mode='full', normalize=False):
     r"""
-    Compute channel-wise correlation function between signals.
+    Compute the channel-wise correlation function between signals.
 
     The correlation function of the time signals :math:`x_1[n]` and
     :math:`x_2[n]` is given by
@@ -2766,8 +2766,10 @@ def correlate(signal_1, signal_2, mode='full', normalize=None):
         >>> argmax = cor.times[np.argmax(cor.time, axis=-1)]
         >>>
         >>> # plot correlation and indicate maximum
-        >>> ax = pf.plot.time(cor)
+        >>> ax = pf.plot.time(cor, unit='ms')
         >>> ax.set_title('Correlation and position of maxima (dots)')
+        >>> ax.set_xlabel('Time lags in ms')
+        >>> ax.set_ylabel('Auto correlation')
         >>> for amax, color in zip(argmax.flatten(), 'bryp'):
         >>>     ax.axvline(amax, color=pf.plot.color(color), linestyle=':')
 
@@ -2779,15 +2781,15 @@ def correlate(signal_1, signal_2, mode='full', normalize=None):
 
         >>> import pyfar as pf
         >>>
-        >>> signal = pf.signals.linear_perfect_sweep(2**8)
+        >>> signal = pf.signals.linear_perfect_sweep(2**7)
         >>>
         >>> for mode in ['full', 'cyclic']:
         >>>     line = '--' if mode == 'cyclic' else '-'
         >>>     cor = pf.dsp.correlate(signal, signal, mode, normalize=True)
         >>>     ax = pf.plot.time(cor, unit='ms', label=mode, ls=line)
         >>>
-        >>> ax.set_xlabel('time lags in seconds')
-        >>> ax.set_ylabel('auto correlation')
+        >>> ax.set_xlabel('Time lags in ms')
+        >>> ax.set_ylabel('Auto correlation')
         >>> ax.legend()
     """
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2783,10 +2783,6 @@ def correlate(signal_1, signal_2, mode='full'):
             type(signal_2) is not pyfar.Signal:
         raise TypeError("signal_1 and signal_2 must be pyfar.Signal objects")
 
-    if signal_1.complex != signal_2.complex:
-        raise ValueError(("Both signals must be complex or real valued. "
-                          "Mixtures are not allowed."))
-
     if signal_1.sampling_rate != signal_2.sampling_rate:
         raise ValueError("Both signals must have the same sampling rate.")
 
@@ -2796,6 +2792,12 @@ def correlate(signal_1, signal_2, mode='full'):
     # copy input to avoid changing mutual data
     signal_1 = signal_1.copy()
     signal_2 = signal_2.copy()
+
+    # check for complex signals
+    if signal_1.complex and not signal_2.complex:
+        signal_2.complex = True
+    if signal_2.complex and not signal_1.complex:
+        signal_1.complex = True
 
     # determine signal length for the FFT
     n_samples = np.array([signal_1.n_samples, signal_2.n_samples], dtype=int)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2703,7 +2703,7 @@ def correlate(signal_1, signal_2, mode='linear'):
         `signal_1`.
     mode : str, optional
 
-        ``'linear'```
+        ``'linear'``
             Computes the linear correlation by zero padding the input signals
             to a length of ``signal_1.n_samples + signal_2.n_samples - 1``
             before applying the Fourier transform (see equations above).
@@ -2712,10 +2712,12 @@ def correlate(signal_1, signal_2, mode='linear'):
             they are. In this case `signal_1` and `signal_2` must have the
             same number of samples (length).
 
+        The default is ``'linear'``.
+
     Returns
     -------
     correlation : numpy array
-        The correlation :math:`c[l]`. the shape of `correlation` matches the
+        The correlation :math:`c[l]`. The shape of `correlation` matches the
         shape to which `signal_1` and `signal_2` were broadcasted. The last
         dimension of the shape is given by the `lags` (see below).
     lags : numpy array
@@ -2728,11 +2730,11 @@ def correlate(signal_1, signal_2, mode='linear'):
         ``[-(signal_1.n_samples // 2), signal_1.n_samples // 2]`` if the
         signals have an odd number of samples.
     argmax : numpy array
-        The delays applied to `signal_2` which maximize the correlation between
-        the signals, i.e., :math:`\arg \max_{l} \, |c[l]|` where the absolute
-        :math:`|\cdot|` is required for complex-valued time signals. The shape
-        of `argmax` corresponds to the `cshape` to which the input signals were
-        broadcaseted.
+        The lag applied to `signal_2` which maximize the correlation between
+        the signals, i.e., :math:`\arg \max_{l} \, c[l]` for real-valued time
+        data, and :math:`\arg \max_{l} \, |c[l]|` for complex-valued time data.
+        The shape of `argmax` corresponds to the `cshape` to which the input
+        signals were broadcaseted.
 
     Examples
     --------
@@ -2830,7 +2832,10 @@ def correlate(signal_1, signal_2, mode='linear'):
     else:
         lags = np.arange(-n_samples[1] + 1, n_samples[0])
 
-    # get lag tha maximized the correlation
-    argmax = lags[np.argmax(np.abs(correlation), -1)]
+    # get the time lag that maximizes the correlation
+    if signal_1.complex:
+        argmax = lags[np.argmax(np.abs(correlation), -1)]
+    else:
+        argmax = lags[np.argmax(correlation, -1)]
 
     return correlation, lags, argmax

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2768,7 +2768,7 @@ def correlate(signal_1, signal_2, mode='full', normalize=False):
         >>> # plot correlation and indicate maximum
         >>> ax = pf.plot.time(cor, unit='ms')
         >>> ax.set_title('Correlation and position of maxima (dots)')
-        >>> ax.set_xlabel('Time lags in ms')
+        >>> ax.set_xlabel('Time lag in ms')
         >>> ax.set_ylabel('Auto correlation')
         >>> for amax, color in zip(argmax.flatten(), 'bryp'):
         >>>     ax.axvline(amax, color=pf.plot.color(color), linestyle=':')
@@ -2788,7 +2788,7 @@ def correlate(signal_1, signal_2, mode='full', normalize=False):
         >>>     cor = pf.dsp.correlate(signal, signal, mode, normalize=True)
         >>>     ax = pf.plot.time(cor, unit='ms', label=mode, ls=line)
         >>>
-        >>> ax.set_xlabel('Time lags in ms')
+        >>> ax.set_xlabel('Time lag in ms')
         >>> ax.set_ylabel('Auto correlation')
         >>> ax.legend()
     """

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2819,7 +2819,7 @@ def correlate(signal_1, signal_2, mode='full'):
 
     # compute correlation as frequency domain convolution
     # with time flipped and conjugate values for second signal
-    signal_2.time = signal_2.time.copy()[..., ::-1].conj()
+    signal_2.time = signal_2.time[..., ::-1].conj()
     correlation = signal_1 * signal_2
     correlation = correlation.time
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2718,14 +2718,16 @@ def correlate(signal_1, signal_2, mode='full'):
     -------
     correlation : TimeData
         The correlation :math:`c[l]` is contained in ``correlation.time`` and
-        the lags, i.e., the delays applied to `signal_2` (see equations above)
-        are contained in ``correlation.times``. The cshape of `correlation`
-        matches the cshape to which `signal_1` and `signal_2` were broadcasted.
-        The time lags are given in seconds and can be converted to samples by
-        multiplication with ``signal_1.sampling_rate``. In this case, they are
-        in the interval ``[-signal_2.n_samples + 1, signal_1.n_samples - 1]``
-        if the full correlation was computed. In case of the cyclic
-        correlation, they are in the interval
+        the lags in seconds, i.e., the delays applied to `signal_2`
+        (see equations above) are contained in ``correlation.times``.
+        ``correlation.time`` is complex if one of the input signals has
+        complex-valued time data. The cshape of `correlation` matches the
+        cshape to which `signal_1` and `signal_2` were broadcasted. The lags
+        can be converted to samples by multiplication with
+        ``signal_1.sampling_rate``. In this case, they are in the interval
+        ``[-signal_2.n_samples + 1, signal_1.n_samples - 1]`` if the full
+        correlation was computed. In case of the cyclic correlation, they are
+        in the interval
         ``[-(signal_1.n_samples // 2) + 1, signal_1.n_samples // 2]``
         if the signals have an even number of samples, and in the interval
         ``[-(signal_1.n_samples // 2), signal_1.n_samples // 2]``
@@ -2772,11 +2774,13 @@ def correlate(signal_1, signal_2, mode='full'):
         >>>
         >>> # compute the lags in samples
         >>> argmax = cor.times[np.argmax(cor.time, axis=-1)]
-        >>> argmax *= signal_1.sampling_rate
-
-    In this case the lags correspond to the negative delays:
-    ``argmax = [[0, -1], [-2, -3]]``.
-    """  # noqa: E501
+        >>>
+        >>> # plot correlation and indicate maximum
+        >>> ax = pf.plot.time(cor)
+        >>> ax.set_title('Correlation and position of maxima (dots)')
+        >>> for amax, color in zip(argmax.flatten(), 'bryp'):
+        >>>     ax.axvline(amax, color=pf.plot.color(color), linestyle=':')
+    """
 
     # check input
     if type(signal_1) is not pyfar.Signal or \

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2671,7 +2671,7 @@ def normalize(signal, reference_method='max', domain='auto',
         return normalized_signal
 
 
-def correlate(signal_1, signal_2, mode='linear'):
+def correlate(signal_1, signal_2, mode='full'):
     r"""
     Compute channel-wise correlation between signals.
 
@@ -2703,8 +2703,8 @@ def correlate(signal_1, signal_2, mode='linear'):
         `signal_1`.
     mode : str, optional
 
-        ``'linear'``
-            Computes the linear correlation by zero padding the input signals
+        ``'full'``
+            Computes the full correlation by zero padding the input signals
             to a length of ``signal_1.n_samples + signal_2.n_samples - 1``
             before applying the Fourier transform (see equations above).
         ``'cyclic'``
@@ -2712,7 +2712,7 @@ def correlate(signal_1, signal_2, mode='linear'):
             they are. In this case `signal_1` and `signal_2` must have the
             same number of samples (length).
 
-        The default is ``'linear'``.
+        The default is ``'full'``.
 
     Returns
     -------
@@ -2722,7 +2722,7 @@ def correlate(signal_1, signal_2, mode='linear'):
         dimension of the shape is given by the `lags` (see below).
     lags : numpy array
         The time lags, i.e., the delays applied to `signal_2` (see equations
-        above). In case of a linear correlation, the time lags are in the
+        above). In case of a full correlation, the time lags are in the
         interval ``[-signal_2.n_samples + 1, signal_1.n_samples - 1]``. In case
         of the cyclic correlation, they are in the interval
         ``[-(signal_1.n_samples // 2) + 1, signal_1.n_samples // 2]`` if the
@@ -2749,7 +2749,7 @@ def correlate(signal_1, signal_2, mode='linear'):
         >>>
         >>> signal = pf.signals.linear_perfect_sweep(2**8)
         >>>
-        >>> for mode in ['linear', 'cyclic']:
+        >>> for mode in ['full', 'cyclic']:
         >>>     cor, lags, _ = pf.dsp.correlate(signal, signal, mode)
         >>>     result = pf.TimeData(cor / pf.dsp.energy(signal), lags)
         >>>     ax = pf.plot.time(result, label=mode)
@@ -2774,7 +2774,7 @@ def correlate(signal_1, signal_2, mode='linear'):
         >>> delays = np.array([[0, 1], [2, 3]], dtype=int)
         >>> signal_2 = pf.signals.impulse(5, delays)
         >>>
-        >>> _, _, argmax = pf.dsp.correlate(signal_1, signal_2, 'linear')
+        >>> _, _, argmax = pf.dsp.correlate(signal_1, signal_2, 'full')
 
     In this case the lags correspond to the negative delays:
     ``argmax = [[0, -1], [-2, -3]]``.
@@ -2789,8 +2789,8 @@ def correlate(signal_1, signal_2, mode='linear'):
         raise ValueError(("Both signals must be complex or real valued. "
                           "Mixtures are not allowed."))
 
-    if mode not in ['linear', 'cyclic']:
-        raise ValueError(f"mode is '{mode}' but must be 'linear' or 'cyclic'")
+    if mode not in ['full', 'cyclic']:
+        raise ValueError(f"mode is '{mode}' but must be 'full' or 'cyclic'")
 
     # copy input to avoid changing mutual data
     signal_1 = signal_1.copy()

--- a/pyfar/signals/deterministic.py
+++ b/pyfar/signals/deterministic.py
@@ -650,20 +650,15 @@ def linear_perfect_sweep(
         >>> sweep = pf.signals.linear_perfect_sweep(2**8)
         >>>
         >>> # compute auto-correlation
-        >>> auto_correlation = np.empty(2**8)
-        >>> for idx, shift in enumerate(range(-2**7, 2**7)):
-        >>>     auto_correlation[idx] = np.dot(
-        ...         sweep.time.flatten(),
-        ...         np.roll(sweep.time.flatten(), shift))
+        >>> auto_correlation, lags, _ = pf.dsp.correlate(
+        ...     sweep, sweep, 'cyclic')
         >>>
-        >>> auto_correlation /= pf.dsp.energy(sweep)
+        >>> auto_correlation = pf.TimeData(
+        ...     auto_correlation / pf.dsp.energy(sweep), lags)
         >>>
-        >>> # plot auto-correlation
-        >>> with pf.plot.context():
-        >>>     plt.plot(np.arange(-2**7, 2**7), auto_correlation)
-        >>>     plt.gca().set_xlim(-2**7, 2**7)
-        >>>     plt.gca().set_xlabel('time lag in samples')
-        >>>     plt.gca().set_ylabel('auto correlation')
+        >>> ax = pf.plot.time(auto_correlation)
+        >>> ax.set_xlabel('time lag in samples')
+        >>> ax.set_ylabel('auto correlation')
     """
 
     return _frequency_domain_sweep(

--- a/pyfar/signals/deterministic.py
+++ b/pyfar/signals/deterministic.py
@@ -654,7 +654,7 @@ def linear_perfect_sweep(
         ...     sweep, sweep, 'cyclic', normalize=True)
         >>>
         >>> ax = pf.plot.time(auto_correlation, unit='ms')
-        >>> ax.set_xlabel('Time lags in ms')
+        >>> ax.set_xlabel('Time lag in ms')
         >>> ax.set_ylabel('Auto correlation')
     """
 

--- a/pyfar/signals/deterministic.py
+++ b/pyfar/signals/deterministic.py
@@ -650,11 +650,12 @@ def linear_perfect_sweep(
         >>> sweep = pf.signals.linear_perfect_sweep(2**8)
         >>>
         >>> # compute auto-correlation
-        >>> auto_correlation = pf.dsp.correlate(sweep, sweep, 'cyclic')
+        >>> auto_correlation = pf.dsp.correlate(
+        ...     sweep, sweep, 'cyclic', normalize=True)
         >>>
-        >>> ax = pf.plot.time(auto_correlation / pf.dsp.energy(sweep))
-        >>> ax.set_xlabel('time lags in seconds')
-        >>> ax.set_ylabel('auto correlation')
+        >>> ax = pf.plot.time(auto_correlation, unit='ms')
+        >>> ax.set_xlabel('Time lags in ms')
+        >>> ax.set_ylabel('Auto correlation')
     """
 
     return _frequency_domain_sweep(

--- a/pyfar/signals/deterministic.py
+++ b/pyfar/signals/deterministic.py
@@ -650,14 +650,10 @@ def linear_perfect_sweep(
         >>> sweep = pf.signals.linear_perfect_sweep(2**8)
         >>>
         >>> # compute auto-correlation
-        >>> auto_correlation, lags, _ = pf.dsp.correlate(
-        ...     sweep, sweep, 'cyclic')
+        >>> auto_correlation = pf.dsp.correlate(sweep, sweep, 'cyclic')
         >>>
-        >>> auto_correlation = pf.TimeData(
-        ...     auto_correlation / pf.dsp.energy(sweep), lags)
-        >>>
-        >>> ax = pf.plot.time(auto_correlation)
-        >>> ax.set_xlabel('time lag in samples')
+        >>> ax = pf.plot.time(auto_correlation / pf.dsp.energy(sweep))
+        >>> ax.set_xlabel('time lags in seconds')
         >>> ax.set_ylabel('auto correlation')
     """
 

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -1,0 +1,155 @@
+from pyfar.dsp import correlate
+import pyfar as pf
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+
+def test_error_signal_type():
+    """Test if a TypeError is raised for non Signal input."""
+
+    signal = pf.Signal(1, 1)
+
+    with pytest.raises(TypeError, match="signal_1 and signal_2 must be"):
+        correlate('not a signal', signal)
+
+    with pytest.raises(TypeError, match="signal_1 and signal_2 must be"):
+        correlate(signal, 'not a signal')
+
+    with pytest.raises(TypeError, match="signal_1 and signal_2 must be"):
+        correlate('not a signal', 'not a signal')
+
+
+def test_error_complex_and_real_signals():
+    """Test if a mixture of complex and real signals raises an error."""
+
+    signal_1 = pf.Signal(1, 1)
+    signal_2 = pf.Signal(1+1j, 1, is_complex=True)
+
+    with pytest.raises(ValueError, match="Both signals must be complex or"):
+        correlate(signal_1, signal_2)
+
+
+def test_error_mode_string():
+    """Test if a ValueError is raised for invalid mode values."""
+
+    signal = pf.Signal(1, 1)
+
+    with pytest.raises(ValueError, match="invalid_mode"):
+        correlate(signal, signal, 'invalid_mode')
+
+
+def test_error_cyclic_mode():
+    """
+    Test if ValueError for signals with differing length is raised in cyclic
+    mode.
+    """
+
+    signal_1 = pf.Signal(1, 1)
+    signal_2 = pf.Signal([1, 2], 1)
+
+    with pytest.raises(ValueError, match="must be of the same length"):
+        correlate(signal_1, signal_2, mode='cyclic')
+
+
+@pytest.mark.parametrize('length_1', [4, 5])
+@pytest.mark.parametrize('delay_1', [0, 1, 2])
+@pytest.mark.parametrize('length_2', [4, 5])
+@pytest.mark.parametrize('delay_2', [0, 1, 2])
+def test_linear_mode_1d(length_1, delay_1, length_2, delay_2):
+    """Test linear mode for different combinations of 1D signals."""
+
+    # compute correlation
+    signal_1 = pf.signals.impulse(length_1, delay_1)
+    signal_2 = pf.signals.impulse(length_2, delay_2)
+
+    correlation, lags, argmax = correlate(signal_1, signal_2)
+
+    # test output shapes
+    assert correlation.shape == (1, length_1 + length_2 - 1)
+    assert lags.shape == (length_1 + length_2 - 1, )
+    assert argmax.shape == (1, )
+
+    # test lag that maximizes the correlation
+    lag = delay_1 - delay_2
+    assert argmax == lag
+
+    # test correlation and lags
+    npt.assert_almost_equal(correlation[0, lags==lag], 1., 10)
+    npt.assert_almost_equal(correlation[0, lags!=lag], 0., 10)
+
+
+@pytest.mark.parametrize('length', [4, 5])
+@pytest.mark.parametrize('delay_1', [0, 1, 2])
+@pytest.mark.parametrize('delay_2', [0, 1, 2])
+def test_cyclic_mode_1d(length, delay_1, delay_2):
+    """Test cyclic mode for different combinations of 1D signals."""
+
+    # compute correlation
+    signal_1 = pf.signals.impulse(length, delay_1)
+    signal_2 = pf.signals.impulse(length, delay_2)
+
+    correlation, lags, argmax = correlate(signal_1, signal_2, mode='cyclic')
+
+    # test output shapes
+    assert correlation.shape == (1, length)
+    assert lags.shape == (length, )
+    assert argmax.shape == (1, )
+
+    # test lag that maximizes the correlation
+    # (lag must be adjusted to cyclic case)
+    lag = delay_1 - delay_2
+    if length % 2 and lag < -(length//2):
+        lag = length + lag
+    if not length % 2 and lag <= -(length//2):
+        lag = length + lag
+
+    assert argmax == lag
+
+    # test correlation and lags
+    npt.assert_almost_equal(correlation[0, lags==lag], 1., 10)
+    npt.assert_almost_equal(correlation[0, lags!=lag], 0., 10)
+
+
+def test_linear_mode_nd():
+    """Test broadcasting and n-dimensional signals in linear mode."""
+
+    # compute correlation
+    delays = np.array([[0, 1], [2, 3]], dtype=int)
+    signal_1 = pf.signals.impulse(5, 0)
+    signal_2 = pf.signals.impulse(5, delays)
+
+    correlation, lags, argmax = correlate(signal_1, signal_2)
+
+    # test output shapes
+    assert correlation.shape == (2, 2, 9)
+    assert lags.shape == (9, )
+    assert argmax.shape == (2, 2)
+
+    # test lag that maximizes the correlation
+    npt.assert_equal(argmax, -delays)
+
+    # test correlation and lags
+    for dim_1 in range(2):
+        for dim_2 in range(2):
+            npt.assert_almost_equal(
+                correlation[dim_1, dim_2, lags==-delays[dim_1, dim_2]], 1., 10)
+            npt.assert_almost_equal(
+                correlation[dim_1, dim_2, lags!=-delays[dim_1, dim_2]], 0., 10)
+
+
+def test_complex_signals():
+    """Test with complex signals"""
+
+    signal_1 = pf.Signal([0, 0, 1+0j], 1, is_complex=True)
+    signal_2 = pf.Signal([0+1j, 0, 0], 1, is_complex=True)
+
+    correlation, lags, argmax = correlate(signal_1, signal_2)
+
+    # test lag that maximizes the correlation
+    lag = 2
+    assert argmax == lag
+
+    # test correlation and lags
+    npt.assert_almost_equal(correlation[0, lags==lag], 0-1j, 10)
+    npt.assert_almost_equal(correlation[0, lags!=lag], 0+0j, 10)

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -57,7 +57,7 @@ def test_error_cyclic_mode():
 @pytest.mark.parametrize('length_2', [4, 5])
 @pytest.mark.parametrize('delay_2', [0, 1, 2])
 def test_linear_mode_1d(length_1, delay_1, length_2, delay_2):
-    """Test linear mode for different combinations of 1D signals."""
+    """Test full mode for different combinations of 1D signals."""
 
     # compute correlation
     signal_1 = pf.signals.impulse(length_1, delay_1)
@@ -112,7 +112,7 @@ def test_cyclic_mode_1d(length, delay_1, delay_2):
 
 
 def test_linear_mode_nd():
-    """Test broadcasting and n-dimensional signals in linear mode."""
+    """Test broadcasting and n-dimensional signals in full mode."""
 
     # compute correlation
     delays = np.array([[0, 1], [2, 3]], dtype=int)

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -152,6 +152,21 @@ def test_full_mode_nd():
                 0., 10)
 
 
+@pytest.mark.parametrize('normalize', [False, True])
+def test_normalize(normalize):
+    """Test the normalize parameter"""
+    # sine with 4 samples period -> auto-correlation is 4 samples period sine
+    signal = pf.signals.sine(5, 8, 1, 0, 20)
+    correlation = correlate(signal, signal, 'cyclic', normalize)
+    max_correlation = 1 if normalize else pf.dsp.energy(signal)
+
+    npt.assert_almost_equal(correlation.time[0, 0::2], np.zeros(4), 10)
+    npt.assert_almost_equal(correlation.time[0, 1::4],
+                            -max_correlation * np.ones(2), 10)
+    npt.assert_almost_equal(correlation.time[0, 3::4],
+                            max_correlation * np.ones(2), 10)
+
+
 def test_complex_signals():
     """Test with complex signals"""
 

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -52,7 +52,16 @@ def test_error_cyclic_mode():
         correlate(signal_1, signal_2, mode='cyclic')
 
 
+def test_mutable_objects():
+    """Test if input does not change."""
 
+    signal_1 = pf.Signal([1, 0, 0], 1)
+    signal_2 = pf.Signal([2, 0, 0], 1)
+
+    correlate(signal_1, signal_2)
+
+    assert signal_1 == pf.Signal([1, 0, 0], 1)
+    assert signal_2 == pf.Signal([2, 0, 0], 1)
 
 
 @pytest.mark.parametrize('length_1', [4, 5])

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -20,16 +20,6 @@ def test_error_signal_type():
         correlate('not a signal', 'not a signal')
 
 
-def test_error_complex_and_real_signals():
-    """Test if a mixture of complex and real signals raises an error."""
-
-    signal_1 = pf.Signal(1, 1)
-    signal_2 = pf.Signal(1+1j, 1, is_complex=True)
-
-    with pytest.raises(ValueError, match="Both signals must be complex or"):
-        correlate(signal_1, signal_2)
-
-
 def test_error_different_sampling_rates():
     """Test if signals with different sampling rates raise an error."""
 
@@ -60,6 +50,9 @@ def test_error_cyclic_mode():
 
     with pytest.raises(ValueError, match="must be of the same length"):
         correlate(signal_1, signal_2, mode='cyclic')
+
+
+
 
 
 @pytest.mark.parametrize('length_1', [4, 5])
@@ -162,5 +155,28 @@ def test_complex_signals():
     lag = 2
     npt.assert_almost_equal(
         correlation.time[0, correlation.times==lag], 0-1j, 10)
+    npt.assert_almost_equal(
+        correlation.time[0, correlation.times!=lag], 0+0j, 10)
+
+
+@pytest.mark.parametrize('complex_first', [True, False])
+def test_complex_and_real_signals(complex_first):
+    """Test with real and complex-valued signals"""
+
+    if complex_first:
+        signal_1 = pf.Signal([0, 0, 1j], 1, is_complex=True)
+        signal_2 = pf.Signal([1, 0, 0], 1, is_complex=True)
+        expected = 1j
+    else:
+        signal_1 = pf.Signal([0, 0, 1], 1, is_complex=True)
+        signal_2 = pf.Signal([1j, 0, 0], 1, is_complex=True)
+        expected = -1j
+
+    correlation = correlate(signal_1, signal_2)
+
+    # test correlation values
+    lag = 2
+    npt.assert_almost_equal(
+        correlation.time[0, correlation.times==lag], expected, 10)
     npt.assert_almost_equal(
         correlation.time[0, correlation.times!=lag], 0+0j, 10)


### PR DESCRIPTION
### Changes proposed in this pull request:

- [x] add `pyfar.dsp.correlate`
- [x] test `pyfar.dsp.correlate`
- [x] use `pyfar.dsp.correlate` in the docs were correlation was computed manually before

@sikersten maybe you remember our discusion from I while ago: I now figured that `scipy.signal.correlate` can perform only linear correlation. This function can perform cyclic correlation in addition, which was required in the case which we discussed a while ago.