### PR TITLE
Normaliztation: Force energetic properties to match the target after normalization

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2442,8 +2442,14 @@ def normalize(signal, reference_method='max', domain='auto',
             Compute the mean absolute values per channel.
         ``'energy'``
             Compute the energy per channel using :py:func:`~pyfar.dsp.energy`.
+            Note that the square root of the energy is used as `reference`,
+            which is required for the energy of the normalized signal to match
+            the `target`.
         ``'power'``
             Compute the power per channel using :py:func:`~pyfar.dsp.power`.
+            Note that the square root of the power is used as `reference`,
+            which is required for the power of the normalized signal to match
+            the `target`.
         ``'rms'``
             Compute the RMS per channel using :py:func:`~pyfar.dsp.rms`.
 
@@ -2661,6 +2667,12 @@ def normalize(signal, reference_method='max', domain='auto',
     else:
         raise ValueError(("channel_handling must be 'individual', 'max', "
                           "'min' or 'mean'."))
+
+    # scale normalization to achieve target energy and power. This must be
+    # done because they are energetic properties
+    if reference_method in ['energy', 'power']:
+        reference_norm = np.sqrt(reference_norm)
+
     # apply normalization
     normalized_signal = signal.copy() * target / reference_norm
     if return_reference:

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2443,13 +2443,15 @@ def normalize(signal, reference_method='max', domain='auto',
         ``'energy'``
             Compute the energy per channel using :py:func:`~pyfar.dsp.energy`.
             Note that the square root of the energy is used as `reference`,
-            which is required for the energy of the normalized signal to match
-            the `target`.
+            after handling multi-channel signals (see *channel_handling*
+            below). This is required for the energy of the normalized signal to
+            match the `target`.
         ``'power'``
             Compute the power per channel using :py:func:`~pyfar.dsp.power`.
             Note that the square root of the power is used as `reference`,
-            which is required for the power of the normalized signal to match
-            the `target`.
+            after handling multi-channel signals (see *channel_handling*
+            below). This is required for the power of the normalized signal to
+            match the `target`.
         ``'rms'``
             Compute the RMS per channel using :py:func:`~pyfar.dsp.rms`.
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2670,10 +2670,11 @@ def normalize(signal, reference_method='max', domain='auto',
         raise ValueError(("channel_handling must be 'individual', 'max', "
                           "'min' or 'mean'."))
 
-    # scale normalization to achieve target energy and power. This must be
-    # done because they are energetic properties
+    # scale normalization and target to achieve target energy and power. This
+    # must be done because they are energetic properties
     if reference_method in ['energy', 'power']:
         reference_norm = np.sqrt(reference_norm)
+        target = np.sqrt(target)
 
     # apply normalization
     normalized_signal = signal.copy() * target / reference_norm

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -27,13 +27,15 @@ def test_normalization_max_mean(reference_method, channel_handling, truth):
 
 @pytest.mark.parametrize(('reference_method', 'reference_function'), [
     ('energy', pf.dsp.energy), ('power', pf.dsp.power), ('rms', pf.dsp.rms)])
+@pytest.mark.parametrize('target', [.5, 1, 2])
 @pytest.mark.parametrize(('channel_handling', 'assert_function'), [
     ('max', np.max),
     ('individual', np.array),
     ('min', np.min),
     ('mean', np.mean)])
 def test_normalization_energy_power_rms(
-    reference_method, reference_function, channel_handling, assert_function):
+    reference_method, reference_function, target, channel_handling,
+    assert_function):
     """
     Parametrized test for all combinations of 'energy', 'power' and 'rms'
     reference_method and channel_handling parameters using impulse signals.
@@ -41,9 +43,10 @@ def test_normalization_energy_power_rms(
     signal = pf.signals.impulse(3, amplitude=[1, 5])
     normalized = pf.dsp.normalize(signal, domain='time',
                               reference_method=reference_method,
-                              channel_handling=channel_handling)
+                              channel_handling=channel_handling,
+                              target=target)
     value = assert_function(reference_function(normalized))
-    npt.assert_almost_equal(value, np.ones(value.shape), 10)
+    npt.assert_almost_equal(value, target * np.ones(value.shape), 10)
 
 
 @pytest.mark.parametrize('is_complex', [False, True])

--- a/tests/test_dsp_normalize.py
+++ b/tests/test_dsp_normalize.py
@@ -12,29 +12,38 @@ import numpy as np
     ('mean', 'max', [0.6, 3.0]),
     ('mean', 'individual', [3.0, 3.0]),
     ('mean', 'min', [3.0, 15.0]),
-    ('mean', 'mean', [1.0, 5.0]),
-    ('rms', 'max', [1*np.sqrt(3/5**2), 5*np.sqrt(3/5**2)]),
-    ('rms', 'individual', [1*np.sqrt(3/1**2), 5*np.sqrt(3/5**2)]),
-    ('rms', 'min', [1*np.sqrt(3/1**2), 5*np.sqrt(3/1**2)]),
-    ('rms', 'mean', [2/(np.sqrt(1/3)+np.sqrt(25/3)),
-                     2*5/(np.sqrt(1/3)+np.sqrt(25/3))]),
-    ('power', 'max', [1*3/5**2, 5*3/5**2]),
-    ('power', 'individual', [1*3/1**2, 5*3/5**2]),
-    ('power', 'min', [1*3/1**2, 5*3/1**2]),
-    ('power', 'mean', [1*3/((1**2+5**2)/2), 5*3/((1**2+5**2)/2)]),
-    ('energy', 'max', [1/5**2, 5/5**2]),
-    ('energy', 'individual', [1/1**2, 5/5**2]),
-    ('energy', 'min', [1/1**2, 5/1**2]),
-    ('energy', 'mean', [1/((1**2+5**2)/2), 5/((1**2+5**2)/2)])])
-def test_normalization(reference_method, channel_handling, truth):
-    """Parametrized test for all combinations of reference_method and
-    channel_handling parameters using an impulse.
+    ('mean', 'mean', [1.0, 5.0])])
+def test_normalization_max_mean(reference_method, channel_handling, truth):
+    """
+    Parametrized test for all combinations of 'max' and 'mean'
+    reference_method and channel_handling parameters using impulse signals.
     """
     signal = pf.signals.impulse(3, amplitude=[1, 5])
     answer = pf.dsp.normalize(signal, domain='time',
                               reference_method=reference_method,
                               channel_handling=channel_handling)
     npt.assert_allclose(answer.time[..., 0], truth, rtol=1e-14)
+
+
+@pytest.mark.parametrize(('reference_method', 'reference_function'), [
+    ('energy', pf.dsp.energy), ('power', pf.dsp.power), ('rms', pf.dsp.rms)])
+@pytest.mark.parametrize(('channel_handling', 'assert_function'), [
+    ('max', np.max),
+    ('individual', np.array),
+    ('min', np.min),
+    ('mean', np.mean)])
+def test_normalization_energy_power_rms(
+    reference_method, reference_function, channel_handling, assert_function):
+    """
+    Parametrized test for all combinations of 'energy', 'power' and 'rms'
+    reference_method and channel_handling parameters using impulse signals.
+    """
+    signal = pf.signals.impulse(3, amplitude=[1, 5])
+    normalized = pf.dsp.normalize(signal, domain='time',
+                              reference_method=reference_method,
+                              channel_handling=channel_handling)
+    value = assert_function(reference_function(normalized))
+    npt.assert_almost_equal(value, np.ones(value.shape), 10)
 
 
 @pytest.mark.parametrize('is_complex', [False, True])


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #721 

### Changes proposed in this pull request:

- use square root of a signals energy and power for normalization
- use square root of target as well.
- update docs and tests
