### PR TITLE
deprecate 'frequencies' reconstructing_fractional_octave_bands()

### DIFF
--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -417,10 +417,10 @@ def reconstructing_fractional_octave_bands(
         >>> import matplotlib.pyplot as plt
         >>> # generate data
         >>> x = pf.signals.impulse(2**12)
-        >>> y, _ = pf.dsp.filter.reconstructing_fractional_octave_bands(x)
+        >>> y = pf.dsp.filter.reconstructing_fractional_octave_bands(x)[0]
         >>> # get center frequencies
-        >>> _, f = pf.dsp.filter.fractional_octave_frequencies(
-        ...    frequency_range=(60, 16000))
+        >>> f = pf.dsp.filter.fractional_octave_frequencies(
+        ...    frequency_range=(60, 16000))[1]
         >>> y_sum = pf.Signal(np.sum(y.time, 0), y.sampling_rate)
         >>> # time domain plot
         >>> ax = pf.plot.time_freq(y_sum, color='k', unit='ms')

--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -397,8 +397,9 @@ def reconstructing_fractional_octave_bands(
     filter : FilterFIR
         FIR Filter object. Only returned if ``signal = None``.
     frequencies : np.ndarray
-        Center frequencies of the filters. ``'frequencies'`` return will be
-        deprecated in pyfar 0.9.0.
+        Center frequencies of the filters. Return variable will be removed
+        in pyfar 0.9.0. To get the fractional octave center frequencies, use
+        :py:func:`~pyfar.dsp.filter.fractional_octave_frequencies` instead.
 
     References
     ----------
@@ -416,7 +417,10 @@ def reconstructing_fractional_octave_bands(
         >>> import matplotlib.pyplot as plt
         >>> # generate data
         >>> x = pf.signals.impulse(2**12)
-        >>> y, f = pf.dsp.filter.reconstructing_fractional_octave_bands(x)
+        >>> y, _ = pf.dsp.filter.reconstructing_fractional_octave_bands(x)
+        >>> # get center frequencies
+        >>> _, f = pf.dsp.filter.fractional_octave_frequencies(
+        ...    frequency_range=(60, 16000))
         >>> y_sum = pf.Signal(np.sum(y.time, 0), y.sampling_rate)
         >>> # time domain plot
         >>> ax = pf.plot.time_freq(y_sum, color='k', unit='ms')
@@ -520,8 +524,10 @@ def reconstructing_fractional_octave_bands(
         f"(num_fractions={num_fractions}, frequency_range={frequency_range}, "
         f"overlap={overlap}, slope={slope})")
 
-    warnings.warn(("Return parameter 'frequencies' will be deprecated in pyfar"
-                   " 0.9.0"), PyfarDeprecationWarning, stacklevel=2)
+    warnings.warn(("Return parameter 'frequencies' will be removed in pyfar"
+                   " 0.9.0. To get the fractional octave center frequencies,"
+                   " use `pyfar.dsp.filter.fractional_octave_frequencies` "
+                   "instead."), PyfarDeprecationWarning, stacklevel=2)
 
     if signal is None:
         # return the filter object

--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -4,6 +4,7 @@ import numpy as np
 import scipy.signal as spsignal
 import pyfar as pf
 from pyfar._utils import rename_arg
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 
 def fractional_octave_frequencies(
@@ -396,7 +397,8 @@ def reconstructing_fractional_octave_bands(
     filter : FilterFIR
         FIR Filter object. Only returned if ``signal = None``.
     frequencies : np.ndarray
-        Center frequencies of the filters.
+        Center frequencies of the filters. ``'frequencies'`` return will be
+        deprecated in pyfar 0.9.0.
 
     References
     ----------
@@ -517,6 +519,9 @@ def reconstructing_fractional_octave_bands(
         "Reconstructing linear phase fractional octave filter bank."
         f"(num_fractions={num_fractions}, frequency_range={frequency_range}, "
         f"overlap={overlap}, slope={slope})")
+
+    warnings.warn(("Return parameter 'frequencies' will be deprecated in pyfar"
+                   " 0.9.0"), PyfarDeprecationWarning, stacklevel=2)
 
     if signal is None:
         # return the filter object

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -399,6 +399,8 @@ def test_deprecations_audio_io():
 def test_deprecations_reconstructing_fractional_octave_bands_frequencies():
     with pytest.warns(
         PyfarDeprecationWarning, match="Return parameter 'frequencies' will be"
-        " deprecated in pyfar 0.9.0"):
+        " removed in pyfar 0.9.0. To get the fractional octave center "
+        "frequencies, use `pyfar.dsp.filter.fractional_octave_frequencies` "
+        "instead."):
         pfilt.reconstructing_fractional_octave_bands(None,
                                                      sampling_rate=44.1e3)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -394,3 +394,11 @@ def test_deprecations_audio_io():
     if version.parse(pf.__version__) >= version.parse('0.9.0'):
         with pytest.raises(TypeError):
             pf.io.audio_subtypes(format='wav')
+
+
+def test_deprecations_reconstructing_fractional_octave_bands_frequencies():
+    with pytest.warns(
+        PyfarDeprecationWarning, match="Return parameter 'frequencies' will be"
+        " deprecated in pyfar 0.9.0"):
+        pfilt.reconstructing_fractional_octave_bands(None,
+                                                     sampling_rate=44.1e3)


### PR DESCRIPTION
deprecate `frequencies` return in `reconstructing_fractional_octave_bands()`

Closes #657 
