### PR TITLE
return exact results for octave and third octave for limits out of range

### DIFF
--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -30,9 +30,9 @@ def fractional_octave_frequencies(
     Returns
     -------
     nominal : array, float
-        The nominal center frequencies in Hz specified in the standard.
-        Nominal frequencies are only returned for octave bands and third octave
-        bands.
+        The nominal center frequencies are only defined for octave bands and
+        third octave bands in the range between 25 Hz and 20 kHz.
+        For all other cases, ``None``is returned.
     exact : array, float
         The exact center frequencies in Hz, resulting in a uniform distribution
         of frequency bands over the frequency range.
@@ -50,7 +50,9 @@ def fractional_octave_frequencies(
         raise ValueError(
             "The second frequency needs to be higher than the first.")
 
-    if num_fractions in [1, 3] and (f_lims[0] > 15) and (f_lims[1] < 22e3):
+    within_iec_limits = (f_lims[0] > 25*2**(-1/3)) and (
+        f_lims[1] < 20e3*2**(1/6))
+    if num_fractions in [1, 3] and within_iec_limits:
         nominal, exact = _center_frequencies_fractional_octaves_iec(
             num_fractions)
 

--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -50,7 +50,7 @@ def fractional_octave_frequencies(
         raise ValueError(
             "The second frequency needs to be higher than the first.")
 
-    if num_fractions in [1, 3]:
+    if num_fractions in [1, 3] and (f_lims[0] > 15) and (f_lims[1] < 22e3):
         nominal, exact = _center_frequencies_fractional_octaves_iec(
             num_fractions)
 

--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -32,7 +32,7 @@ def fractional_octave_frequencies(
     nominal : array, float
         The nominal center frequencies are only defined for octave bands and
         third octave bands in the range between 25 Hz and 20 kHz.
-        For all other cases, ``None``is returned.
+        For all other cases, ``None`` is returned.
     exact : array, float
         The exact center frequencies in Hz, resulting in a uniform distribution
         of frequency bands over the frequency range.

--- a/tests/test_fractional_octaves.py
+++ b/tests/test_fractional_octaves.py
@@ -73,6 +73,13 @@ def test_fractional_coeff_oct_filter_iec():
     assert actual.shape == (1, order, 6)
 
 
+def test_fractional_frequencies_non_iec():
+    actual_nominal, actual_exact = filter.fractional_octave_frequencies(
+        num_fractions=1, frequency_range=(4e3, 64e3))
+    npt.assert_allclose(actual_exact, [4e3, 8e3, 16e3, 32e3, 64e3])
+    assert actual_nominal is None
+
+
 def test_fract_oct_filter_iec():
     # Test only Filter object related stuff here, testing of coefficients is
     # done in separate test.
@@ -137,3 +144,5 @@ def test_sum_bands_din():
 
     assert not np.any(diff[:, mask] > 10**(1/10))
     assert not np.any(diff[:, mask] < 10**(-1/10))
+
+

--- a/tests/test_fractional_octaves.py
+++ b/tests/test_fractional_octaves.py
@@ -144,5 +144,3 @@ def test_sum_bands_din():
 
     assert not np.any(diff[:, mask] > 10**(1/10))
     assert not np.any(diff[:, mask] < 10**(-1/10))
-
-


### PR DESCRIPTION
return exact results for octave and third octave for limits out of range.

bug:
```
pf.dsp.filter.fractional_octave_frequencies(
    num_fractions=3, frequency_range=[20000, 96000])
```
returns
```
(array([20000.]), array([19952.62314969]))
```
is now fixed. if frequency_range is not in the standard range, just the exact solution is returned.