### PR TITLE
improve error message for read_sofa

### DIFF
--- a/pyfar/io/io.py
+++ b/pyfar/io/io.py
@@ -195,7 +195,10 @@ def _sofa_pos(pos_type, coordinates):
             coordinates[:, 2],
         )
     else:
-        raise ValueError("Position:Type {pos_type} is not supported.")
+        raise ValueError(
+            f"Position: Type '{pos_type}' is not supported."
+            "Allowed types are 'cartesian' and 'spherical'.",
+            )
 
 
 def read(filename):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -728,3 +728,11 @@ def test_default_audio_subtype(default_audio_subtype_mock):
     subtype_return = pyfar.io.default_audio_subtype(format=audio_format)
     assert subtype_return == 'bla'
     default_audio_subtype_mock.assert_called_with(audio_format)
+
+
+def test__sofa_pos_error():
+    """Test error message for wrong position type."""
+    error_message = re.escape(
+        "Position: Type 'bla' is not supported")
+    with pytest.raises(ValueError, match=error_message):
+        io.io._sofa_pos('bla', np.array([1, 2, 3]))


### PR DESCRIPTION
previous error message was:
``Position:Type {pos_type} is not supported.`` without naming the type
