### PR TITLE
Use oaconvolve for FIR process

### DIFF
--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -388,9 +388,26 @@ class FilterFIR(Filter):
         """Process a single filter channel.
         This is a hidden static method required for a shared processing
         function in the parent class.
+
+        Parameters
+        ----------
+        coefficients : array
+            Coefficients of the filter channel.
+        data : array
+            The data to be filtered of shape ``(cshape, n_samples)``.
+        zi : array, optional
+            The initial filter state of shape ``(cshape, order)`` where
+            ``cshape`` is the channel shape of the signal to be filtered.
+            The default is ``None``.
+
+        Returns
+        -------
+        out : array
+            The filtered data.
+        zf : array
+            The final filter state. Only returned if ``zi is not None``.
         """
         b = coefficients[0]
-
         # broadcast b to match ndim of data for convolution
         b = np.broadcast_to(b, (1, ) * (data.ndim - b.ndim) + b.shape)
 

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -389,19 +389,19 @@ class FilterFIR(Filter):
         This is a hidden static method required for a shared processing
         function in the parent class.
         """
+        print(data.shape)
+
         if zi is None:
             # dynamically add new dimensions to b to match ndims of data
             # for convolution
             b = coefficients[0]
-            new_dims = data.ndim - b.ndim
 
-            for _i in range(new_dims):
-                b = b[np.newaxis, ...]
+            b = np.broadcast_to(b, (data.ndim - 1, *b.shape))
 
             out_full = spsignal.oaconvolve(data, b, mode='full')
+
             # Ensure that the output has the same shape as the input
-            idx = out_full.shape[-1] - len(coefficients[0]) + 1
-            out = out_full[..., 0:idx]
+            out = out_full[..., 0:data.shape[-1]]
             return out
         else:
             return spsignal.lfilter(coefficients[0], 1, data, zi=zi)

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -389,8 +389,6 @@ class FilterFIR(Filter):
         This is a hidden static method required for a shared processing
         function in the parent class.
         """
-        print(data.shape)
-
         if zi is None:
             # dynamically add new dimensions to b to match ndims of data
             # for convolution

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -392,7 +392,7 @@ class FilterFIR(Filter):
         b = coefficients[0]
 
         # broadcast b to match ndim of data for convolution
-        b = np.broadcast_to(b, (data.ndim - 1, *b.shape))
+        b = np.broadcast_to(b, (*np.ones(data.ndim-1, int), *b.shape))
 
         out_full = spsignal.oaconvolve(data, b, mode='full')
 

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -392,7 +392,7 @@ class FilterFIR(Filter):
         b = coefficients[0]
 
         # broadcast b to match ndim of data for convolution
-        b = np.broadcast_to(b, (*np.ones(data.ndim-1, int), *b.shape))
+        b = np.broadcast_to(b, (1, ) * (data.ndim - b.ndim) + b.shape)
 
         out_full = spsignal.oaconvolve(data, b, mode='full')
 

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -178,7 +178,7 @@ def test_filter_fir_process_state(impulse):
     state = filt.state
 
     npt.assert_allclose([[[0, 0, 0, 0, 0]]], state)
-    npt.assert_allclose(res.time[:, :6], np.atleast_2d(coeff))
+    npt.assert_allclose(res.time[:, :6], np.atleast_2d(coeff), atol=1e-16)
 
 
 def test_filter_fir_init_state(impulse):

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -163,6 +163,17 @@ def test_filter_fir_process(impulse):
     npt.assert_allclose(res.time[0, :3], coeff)
 
 
+@pytest.mark.parametrize('shape', [(2,), (4, 1), (1, 2, 3)])
+def test_filter_fir_process_multichannel_signal(shape):
+    impulse = pf.signals.impulse(44100, amplitude=np.ones(shape))
+    coeff = np.array([1, 1/2, 0])
+    filt = fo.FilterFIR(coeff, impulse.sampling_rate)
+    res = filt.process(impulse)
+    desired = np.tile(coeff, (*shape, 1))
+
+    npt.assert_allclose(res.time[..., :3], desired)
+
+
 def test_filter_fir_process_complex(impulse_complex):
     coeff = np.array([1, 1/2, 0])
     filt = fo.FilterFIR(coeff, impulse_complex.sampling_rate)

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -396,8 +396,10 @@ def test_blockwise_processing(Filter):
     block_a = Filter.process(pf.Signal(signal.time[0, :3], 44100), reset=False)
     block_b = Filter.process(pf.Signal(signal.time[0, 3:], 44100), reset=False)
     # outputs have to be identical in this case
-    npt.assert_array_equal(np.atleast_2d(complete.time[0, :3]), block_a.time)
-    npt.assert_array_equal(np.atleast_2d(complete.time[0, 3:]), block_b.time)
+    npt.assert_allclose(np.atleast_2d(complete.time[0, :3]), block_a.time,
+                        atol=1e-15)
+    npt.assert_allclose(np.atleast_2d(complete.time[0, 3:]), block_b.time,
+                        atol=1e-15)
 
 
 def test_blockwise_processing_with_coefficients_exchange():


### PR DESCRIPTION
Closes #730

Applying a FIR filter takes very long for larger signals, because  scipy's `lfilter` uses `np.convolve` (direct convolution) which in most cases is much slower than overlapp-add or fft convolution.

Changes proposed:

Have `FIRFilter.process` use scipy's `oaconvole`