### PR TITLE
Add missing default in `pyfar.FilterIIR.init_state`

### DIFF
--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -164,6 +164,15 @@ class Filter(object):
         self._state = state
         self._initialized = True
 
+    @staticmethod
+    def _check_state_keyword(state):
+        """
+        Check the value of the state keyword for 'ini_state' class methods.
+        """
+        if state not in ['zeros', 'step']:
+            raise ValueError(
+                f"state is '{state}' but must be 'zeros' or 'step'")
+
     @property
     def coefficients(self):
         """
@@ -377,6 +386,8 @@ class FilterFIR(Filter):
             an empty filter, or ``'step'`` which constructs the initial
             conditions for step response steady-state. The default is 'zeros'.
         """
+        self._check_state_keyword(state)
+
         new_state = np.zeros((self.n_channels, *cshape, self.order))
         if state == 'step':
             for idx, coeff in enumerate(self._coefficients):
@@ -449,6 +460,8 @@ class FilterIIR(Filter):
             an empty filter, or ``'step'`` which constructs the initial
             conditions for step response steady-state. The default is 'zeros'.
         """
+        self._check_state_keyword(state)
+
         new_state = np.zeros((self.n_channels, *cshape, self.order))
         if state == 'step':
             for idx, coeff in enumerate(self._coefficients):
@@ -543,6 +556,8 @@ class FilterSOS(Filter):
             an empty filter, or ``'step'`` which constructs the initial
             conditions for step response steady-state. The default is 'zeros'.
         """
+        self._check_state_keyword(state)
+
         new_state = np.zeros((self.n_channels, *cshape, self.n_sections, 2))
         if state == 'step':
             for idx, coeff in enumerate(self._coefficients):

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -159,8 +159,13 @@ class Filter(object):
         self._sampling_rate = sampling_rate
         self.comment = comment
 
-    def init_state(self, state='zeros'):
-        """Initialize the buffer elements to pre-defined initial conditions."""
+    def init_state(self, state):
+        """
+        Initialize the buffer elements to pre-defined initial conditions.
+
+        This method is overwritten in the child classes and called after
+        setting the state there.
+        """
         self._state = state
         self._initialized = True
 

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -436,7 +436,7 @@ class FilterIIR(Filter):
         """The order of the filter."""
         return np.max(self._coefficients.shape[-2:]) - 1
 
-    def init_state(self, cshape, state):
+    def init_state(self, cshape, state='zeros'):
         """Initialize the buffer elements to pre-defined initial conditions.
 
         Parameters

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -43,6 +43,32 @@ def test_filter_comment():
         pf.Signal([1, 2, 3], 44100, comment=[1, 2, 3])
 
 
+@pytest.mark.parametrize('filter_object', [
+    (fo.FilterFIR([[1, -1]], 48000)),
+    (fo.FilterIIR([[1, -1], [1, -1]], 48000)),
+    (fo.FilterSOS([[[1, -1, 1, 1, -1, 1]]], 48000)),
+])
+def test_filter_init_state_default_and_error(filter_object):
+    """
+    Test the default for the state keyword and if an error is raised if passing
+    an invalid value.
+    """
+
+    # set state explicitly
+    filter_object.init_state((1, ), 'zeros')
+    state_explicit = filter_object.state.copy()
+    # set state implicitly using the default
+    filter_object.init_state((1, ))
+    state_implicit = filter_object.state.copy()
+    # assert states
+    npt.assert_equal(state_implicit, state_explicit)
+
+    # test raising the error for an invalid value
+    with pytest.raises(ValueError, match="state is 'random' but must be"):
+        filter_object.init_state((1, ), 'random')
+
+
+
 def test_filter_iir_init():
     coeff = np.array([[1, 1/2, 0], [1, 0, 0]])
     filt = fo.FilterIIR(coeff, sampling_rate=2*np.pi)


### PR DESCRIPTION
### Changes proposed in this pull request:

Technically a bug, but I assume this function is rarely used. Make it a bug or release with the next features?

- Add missing default in `pyfar.FilterIIR.init_state`
- Test default value
- Implement and test raising an error for invalud values
