### PR TITLE
Feature/time weighted levels

### DIFF
--- a/pyfar/dsp/__init__.py
+++ b/pyfar/dsp/__init__.py
@@ -34,6 +34,10 @@ from .interpolation import (
     InterpolateSpectrum,
 )
 
+from .levels import (
+    time_weighted_levels,
+)
+
 from . import filter
 from . import fft
 
@@ -69,4 +73,5 @@ __all__ = [
     'normalize',
     'fractional_time_shift',
     'correlate',
+    'time_weighted_levels',
 ]

--- a/pyfar/dsp/levels.py
+++ b/pyfar/dsp/levels.py
@@ -1,0 +1,63 @@
+"""
+Functions used to calculate the levels of signals.
+"""
+
+import numpy as np
+import scipy.signal as sps
+
+
+def time_weighted_levels(signal, weighting: str,
+                         reference=1) -> np.ndarray:
+    """
+    Calculates sound pressure levels with exponential time weighting
+    according to IEC / DIN EN 61672-1.
+
+    Paramters:
+    ---------
+
+    signal: Signal
+        The signal object to calculate the levels for
+
+    type: str
+        The time weighting type. Options are "F" (="fast") and "S" (="slow"),
+        which correspond to level decays of -34.7 dB and -4.3 dB,
+        respectively.
+
+    reference: float
+        The reference sound pressure in Pascal to calculate the level
+        for. Defaults to 1, in which case the returned level is in dBFS
+        (decibels to full scale). If the input signal is in Pascal, use
+        `2e-5` to obtain a sound pressure level (SPL).
+
+    Returns
+    -------
+    A numpy array of the same shape as `signal.time` with the current time
+    weighted level for each point in time and channel.
+    """
+    weighting = weighting.upper()
+    if weighting in ["F", "FAST"]:
+        time_constant = 0.125
+    elif weighting in ["S", "SLOW"]:
+        time_constant = 1
+    else:
+        raise ValueError(f"Unknown 'type' parameter: {weighting}")
+
+    energies = signal.time**2
+
+    # the e-function defined in the norm, but while the norm defines it
+    # as an integral, we can implement it recursively as a scaling factor
+    # for performance.
+    sample_duration = 1 / signal.sampling_rate
+    exp_func_decay = np.exp(-sample_duration / time_constant)
+
+    # this is effectively the same as looping over all samples and doing
+    # > weighted[i] = exp_func_decay * weighted[i-1] + energies[i]
+    # but it's faster to use an lfilter call to make use of scipy's speed
+    weighted = sps.lfilter([1, 0], [1, -exp_func_decay], energies)
+
+    # normalize the integral
+    normalized = weighted / time_constant / signal.sampling_rate
+
+    with np.errstate(divide="ignore"):
+        levels = 10 * np.log10(normalized / reference**2)
+    return levels

--- a/tests/test_time_weighted_levels.py
+++ b/tests/test_time_weighted_levels.py
@@ -1,18 +1,17 @@
-import pytest
 import pyfar as pf
 import numpy as np
 
 def test_time_weighted_levels_decay():
     fs = 48000
     x = pf.signals.impulse(2 * fs, sampling_rate=fs)
-    
+
     levels_F = pf.dsp.time_weighted_levels(x, "F")
     diff1_F =  levels_F[0][fs] - levels_F[0][0]
     diff2_F = levels_F[0][fs + 100] - levels_F[0][100]
     F_DECAY = -34.7 # DIN EN 61672-1 §5.8.2
     assert abs(diff1_F - F_DECAY) < 0.1
     assert abs(diff2_F - F_DECAY) < 0.1
-    
+
     levels_S = pf.dsp.time_weighted_levels(x, "S")
     diff1_S =  levels_S[0][fs] - levels_S[0][0]
     diff2_S = levels_S[0][fs + 100] - levels_S[0][100]
@@ -22,16 +21,18 @@ def test_time_weighted_levels_decay():
 
 
 def test_time_weighting_levels_same_level():
-    """The energy of a long 1kHz signal must be identical
-    across F, S and eq levels"""
+    """
+    The energy of a long 1kHz signal must be identical
+    across F, S and eq levels.
+    """
     fs = 48000
     duration = 60
     x = pf.signals.sine(1000, fs * duration, sampling_rate=48000)
-    
-    L_eq = 10 * np.log10(np.sum(x.time[0]**2) / x.n_samples) 
+
+    L_eq = 10 * np.log10(np.sum(x.time[0]**2) / x.n_samples)
     levels_F = pf.dsp.time_weighted_levels(x, "F")
     levels_S = pf.dsp.time_weighted_levels(x, "S")
-    # compare last sample to the equivalent average, 
+    # compare last sample to the equivalent average,
     # so the exp-filter has enough time to integrate energy
     assert abs(L_eq - levels_F[0][-1]) < 0.1
     assert abs(L_eq - levels_S[0][-1]) < 0.1

--- a/tests/test_time_weighted_levels.py
+++ b/tests/test_time_weighted_levels.py
@@ -1,0 +1,37 @@
+import pytest
+import pyfar as pf
+import numpy as np
+
+def test_time_weighted_levels_decay():
+    fs = 48000
+    x = pf.signals.impulse(2 * fs, sampling_rate=fs)
+    
+    levels_F = pf.dsp.time_weighted_levels(x, "F")
+    diff1_F =  levels_F[0][fs] - levels_F[0][0]
+    diff2_F = levels_F[0][fs + 100] - levels_F[0][100]
+    F_DECAY = -34.7 # DIN EN 61672-1 §5.8.2
+    assert abs(diff1_F - F_DECAY) < 0.1
+    assert abs(diff2_F - F_DECAY) < 0.1
+    
+    levels_S = pf.dsp.time_weighted_levels(x, "S")
+    diff1_S =  levels_S[0][fs] - levels_S[0][0]
+    diff2_S = levels_S[0][fs + 100] - levels_S[0][100]
+    S_DECAY = -4.3 # DIN EN 61672-1 §5.8.2
+    assert abs(diff1_S - S_DECAY) < 0.1
+    assert abs(diff2_S - S_DECAY) < 0.1
+
+
+def test_time_weighting_levels_same_level():
+    """The energy of a long 1kHz signal must be identical
+    across F, S and eq levels"""
+    fs = 48000
+    duration = 60
+    x = pf.signals.sine(1000, fs * duration, sampling_rate=48000)
+    
+    L_eq = 10 * np.log10(np.sum(x.time[0]**2) / x.n_samples) 
+    levels_F = pf.dsp.time_weighted_levels(x, "F")
+    levels_S = pf.dsp.time_weighted_levels(x, "S")
+    # compare last sample to the equivalent average, 
+    # so the exp-filter has enough time to integrate energy
+    assert abs(L_eq - levels_F[0][-1]) < 0.1
+    assert abs(L_eq - levels_S[0][-1]) < 0.1


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #760 

### Changes proposed in this pull request:

- adding a new function to calculate time weighted sound pressure levels in accordance with IEC / DIN EN 61672-1

Here is how plots look for the pf.signals.files.guitar example: 
![image](https://github.com/user-attachments/assets/5b15ea5b-51e0-4f46-ab6a-996b0b703ad0)

### ToDo and to discuss:

- [ ] So far the function handles each channel separately. Should this function have options to merge channels?
- [ ] What to do about the sections with 0 energy in the numpy.log10 step? Right now it simply suppresses numpy warnings and returns these values as negative infinity, but we could add a parameter so the user can provide a default value.
- [ ] How to handle reference values: Right now it defaults to use 1 as reference, meaning the result is in dBFS. There are also reasons to use 2e-5 as default to get dB SPL, but then we still to know the sensitivity unless we just expect the input to be in Pascals, which i find unlikely in most use cases.