### PR TITLE
Impulse response length estimation for Filter objects

### DIFF
--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -603,6 +603,8 @@ class FilterIIR(Filter):
             An integer array of shape (C, ) containing the length in samples
             where `C` denotes the number of channels of the filter.
         """
+        # This is a direct python port of the parts of Matlab's impzlength that
+        # refer to IIR filters
 
         channels = self.coefficients.shape[0]
         estimated_length = np.zeros(channels)
@@ -821,6 +823,8 @@ class FilterSOS(Filter):
             An integer array of shape (C, ) containing the length in samples
             where `C` denotes the number of channels of the filter.
         """
+        # This is a direct python port of the parts of Matlab's impzlength that
+        # refer to SOS filters
 
         channels = self.coefficients.shape[0]
         sections = self.coefficients.shape[1]

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -292,8 +292,10 @@ class Filter(object):
         Returns
         -------
         impulse_response : Signal
-            The impulse response of the filter with a ``cshape = (C, )`` where
-            `C` denotes the number of channels of the filter.
+            The impulse response of the filter of with a
+            ``cshape = (n_channels, )``, with the channel shape
+            :py:func:`~pyfar.Signal.cshape` and the number of filter channels
+            :py:func:`~n_channels`.
         """
         # set or check the impulse response length
         minimum_impulse_response_length = int(np.max(
@@ -461,8 +463,8 @@ class FilterFIR(Filter):
         Returns
         -------
         minimum_impulse_response_length : array
-            An integer array of shape (C, ) containing the length in samples
-            where `C` denotes the number of channels of the filter.
+            An integer array of shape(n_channels, ) containing the length in
+            samples with the number of filter channels :py:func:`~n_channels`.
         """
 
         # get filter coefficients
@@ -501,8 +503,10 @@ class FilterFIR(Filter):
         Returns
         -------
         impulse_response : Signal
-            The impulse response of the filter of with a ``cshape = (C, )``
-            where `C` denotes the number of channels of the filter.
+            The impulse response of the filter of with a
+            ``cshape = (n_channels, )``, with the channel shape
+            :py:func:`~pyfar.Signal.cshape` and the number of filter channels
+            :py:func:`~n_channels`.
         """
         return super().impulse_response(n_samples)
 
@@ -597,8 +601,10 @@ class FilterIIR(Filter):
         Returns
         -------
         impulse_response : Signal
-            The impulse response of the filter of with a ``cshape = (C, )``
-            where `C` denotes the number of channels of the filter.
+            The impulse response of the filter of with a
+            ``cshape = (n_channels, )``, with the channel shape
+            :py:func:`~pyfar.Signal.cshape` and the number of filter channels
+            :py:func:`~n_channels`.
         """
         return super().impulse_response(n_samples)
 
@@ -622,8 +628,8 @@ class FilterIIR(Filter):
         Returns
         -------
         minimum_impulse_response_length : array
-            An integer array of shape (C, ) containing the length in samples
-            where `C` denotes the number of channels of the filter.
+            An integer array of shape(n_channels, ) containing the length in
+            samples with the number of filter channels :py:func:`~n_channels`.
         """
         # This is a direct python port of the parts of Matlab's impzlength that
         # refer to IIR filters
@@ -835,8 +841,10 @@ class FilterSOS(Filter):
         Returns
         -------
         impulse_response : Signal
-            The impulse response of the filter with a ``cshape = (C, )`` where
-            `C` denotes the number of channels of the filter.
+            The impulse response of the filter of with a
+            ``cshape = (n_channels, )``, with the channel shape
+            :py:func:`~pyfar.Signal.cshape` and the number of filter channels
+            :py:func:`~n_channels`.
         """
         return super().impulse_response(n_samples)
 
@@ -860,8 +868,8 @@ class FilterSOS(Filter):
         Returns
         -------
         minimum_impulse_response_length : array
-            An integer array of shape (C, ) containing the length in samples
-            where `C` denotes the number of channels of the filter.
+            An integer array of shape(n_channels, ) containing the length in
+            samples with the number of filter channels :py:func:`~n_channels`.
         """
         # This is a direct python port of the parts of Matlab's impzlength that
         # refer to SOS filters

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -457,21 +457,14 @@ class FilterFIR(Filter):
         Parameters
         ----------
         tolerance : float, optional
-            A tolerance to estimate the length of noise FIR filters.
-
-            - ``None`` returns the full length by finding the last non-zero
-               coefficient per channel.
-            - ``float`` estimates the length by finding the last coefficient
-              with an absolute value greater or equal to the absolute maximum
-              of the coefficients per channel multiplied by `tolerance`. For
-              example if ``tolerance = 0.001`` trailing values below
-              :math:`20 \log_{10}(0.001)=-60` dB would be ignored in the length
-              estimation.
-
-            The returned lengths using ``tolerance=None`` will always be larger
-            or equal to the returned lengths if `tolerance` is a float value.
-            The default is ``None``.
-
+            Tolerance for estimating the minimum length of noisy FIR filters.
+            The length is estimated by finding the last coefficient with an
+            absolute value greater or equal to the absolute maximum of the
+            filter coefficients per channel multiplied by `tolerance`. For
+            example if ``tolerance = 0.001`` trailing values below
+            :math:`20 \log_{10}(0.001)=-60` dB would be ignored in the length
+            estimation. The default ``None`` uses the numerical precision
+            ``2 * numpy.finfo(float).resolution`` as a strict threshold.
         unit : string, optional
             The unit in which the length is returned. Can be ``'samples'`` or
             ``'s'`` (seconds). The default is ``'samples'``.
@@ -484,10 +477,10 @@ class FilterFIR(Filter):
         """
 
         # get filter coefficients
-        b = self.coefficients
+        b = self.coefficients.astype(float)
 
         if tolerance is None:
-            thresholds = np.zeros(b.shape[0])
+            thresholds = np.ones(b.shape[0]) * 2 * np.finfo(b.dtype).eps
         else:
             thresholds = np.max(np.abs(b), -1) * tolerance
 

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -664,10 +664,16 @@ class FilterIIR(Filter):
                     poles_damped = poles[idx_damped[0]]
                     idx = np.argmax(np.abs(poles_damped))
                     multiplicity = self._pole_multiplicity(poles_damped, idx)
+                    # catch runtime warning for poles in the origin
+                    if np.abs(poles_damped[idx]) > 0:
+                        multiplicity_factor = np.log10(tolerance) / \
+                            np.log10(np.abs(poles_damped[idx]))
+                    else:
+                        multiplicity_factor = 0
+
                     estimated_length[channel] += np.maximum(
                         periods,
-                        multiplicity * np.log10(tolerance) / \
-                            np.log10(np.abs(poles_damped[idx])))
+                        multiplicity * multiplicity_factor)
 
             estimated_length[channel] = np.maximum(
                 len(a) + len(b) - 1, estimated_length[channel])

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -284,8 +284,10 @@ class Filter(object):
 
         Parameters
         ----------
-        n_samples : int
-            Length in samples for which the impulse response is computed.
+        n_samples : int, None
+            Length in samples for which the impulse response is computed. If
+            this is ``None``the length is estimated using
+            `impulse_response_length`.
 
         Returns
         -------

--- a/pyfar/classes/filter.py
+++ b/pyfar/classes/filter.py
@@ -287,12 +287,13 @@ class Filter(object):
         n_samples : int, None
             Length in samples for which the impulse response is computed. If
             this is ``None``the length is estimated using
-            `minimum_impulse_response_length((`.
+            `minimum_impulse_response_length`.
 
         Returns
         -------
         impulse_response : Signal
-            The impulse response of the filter.
+            The impulse response of the filter with a ``cshape = (C, )`` where
+            `C` denotes the number of channels of the filter.
         """
         # set or check the impulse response length
         minimum_impulse_response_length = int(np.max(
@@ -447,7 +448,7 @@ class FilterFIR(Filter):
 
     def minimum_impulse_response_length(self, unit='samples'):
         """
-        Get the minimum length of filter impulse response.
+        Get the minimum length of the filter impulse response.
 
         The length is computed from the last non-zero coefficient per channel.
 
@@ -603,7 +604,7 @@ class FilterIIR(Filter):
 
     def minimum_impulse_response_length(self, unit='samples', tolerance=5e-5):
         """
-        Estimated the minimum length of filter impulse response.
+        Estimate the minimum length of the filter impulse response.
 
         The length is estimated from the positions of the poles of the filter.
         The closer the poles are to the unit circle, the longer the estimated
@@ -657,7 +658,7 @@ class FilterIIR(Filter):
                 idx = np.abs(poles - 1) < 1e-5
                 poles[idx] = -poles[idx]
 
-                # poles on and close to unit circls
+                # poles on and close to unit circle
                 idx_oscillation = np.argwhere(np.abs(np.abs(poles)-1) < 1e-5)
                 # poles further away from unit circle
                 idx_damped = np.argwhere(np.abs(np.abs(poles)-1) >= 1e-5)
@@ -834,13 +835,14 @@ class FilterSOS(Filter):
         Returns
         -------
         impulse_response : Signal
-            The impulse response of the filter.
+            The impulse response of the filter with a ``cshape = (C, )`` where
+            `C` denotes the number of channels of the filter.
         """
         return super().impulse_response(n_samples)
 
     def minimum_impulse_response_length(self, unit='samples', tolerance=5e-5):
         """
-        Estimated the minimum length of filter impulse response.
+        Estimate the minimum length of the filter impulse response.
 
         The length is estimated separately per second order section using
         :py:func:`~FilterIIR.minimum_impulse_response_length`. The final length

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -43,7 +43,7 @@ def test_filter_comment():
     with pytest.raises(TypeError, match="comment has to be of type string."):
         pf.Signal([1, 2, 3], 44100, comment=[1, 2, 3])
 
-
+@pytest.mark.parametrize('unit', [('samples'), ('s')])
 @pytest.mark.parametrize(('filter_object', 'actual_length'), [
     # FIR filter ---------------------------------------------
     # single-channel filter
@@ -85,14 +85,16 @@ def test_filter_comment():
     (pf.FilterSOS([[[1, 0, 0, 1, 0, .5]],
                    [[1, 0, 0, 1, 0, .9]]], 44100), np.array([28, 187])),
 ])
-def test_filter_impulse_response_length(filter_object, actual_length):
+def test_filter_impulse_response_length(filter_object, actual_length, unit):
     """
     Test minimum_impulse_response_length class method for all classes and
     cases.
     """
 
+    length_divisor = 1 if unit == 'samples' else 44100
     estimated_length = filter_object.minimum_impulse_response_length()
-    npt.assert_equal(estimated_length, actual_length)
+    npt.assert_equal(estimated_length / length_divisor,
+                     actual_length / length_divisor)
     assert estimated_length.shape == actual_length.shape
     assert estimated_length.dtype == int
 

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -177,11 +177,21 @@ def test_filter_impulse_response_n_samples_default(filter_object, actual):
     (pf.FilterIIR([[[1, 0, 0], [1, 0, .9]]], 44100)),
     (pf.FilterSOS([[[1, 0, 0, 1, 0, .9]]], 44100)),
 ])
-def test_filter_impulse_response_length_tolerance(filter_object):
+def test_filter_recursive_impulse_response_length_tolerance(filter_object):
     """Test tolerance parameter for estimating the impulse response length."""
     low = filter_object.minimum_impulse_response_length(tolerance=5e-5)
     high = filter_object.minimum_impulse_response_length(tolerance=5e-6)
     assert low[0] < high[0]
+
+
+def test_filter_non_recursive_impulse_response_length_tolerance():
+    coefficients = np.array([[1, 0, .5, .0001, 0, 0],
+                             [2, 0, 0, .5, .0001, 0]])
+    filter_object = pf.FilterFIR(coefficients, 44100)
+
+    n_samples = filter_object.minimum_impulse_response_length(tolerance=.001)
+    assert n_samples.shape == (2, )
+    npt.assert_equal(n_samples, np.array([3, 4]))
 
 
 @pytest.mark.parametrize('filter_object', [

--- a/tests/test_filter_classes.py
+++ b/tests/test_filter_classes.py
@@ -86,9 +86,12 @@ def test_filter_comment():
                    [[1, 0, 0, 1, 0, .9]]], 44100), np.array([28, 187])),
 ])
 def test_filter_impulse_response_length(filter_object, actual_length):
-    """Test impulse_response_length class method for all classes and cases."""
+    """
+    Test minimum_impulse_response_length class method for all classes and
+    cases.
+    """
 
-    estimated_length = filter_object.impulse_response_length()
+    estimated_length = filter_object.minimum_impulse_response_length()
     npt.assert_equal(estimated_length, actual_length)
     assert estimated_length.shape == actual_length.shape
     assert estimated_length.dtype == int
@@ -163,7 +166,7 @@ def test_filter_impulse_response_warning(filter_object, actual):
                     [1, 0, 0, 1, 0, .9]]], 44100), 187),
 ])
 def test_filter_impulse_response_n_samples_default(filter_object, actual):
-    """Test default value for impulse_response_length class methods."""
+    """Test default value for minimum_impulse_response_length class methods."""
     impulse_response = filter_object.impulse_response()
     assert impulse_response.n_samples == actual
 
@@ -174,8 +177,8 @@ def test_filter_impulse_response_n_samples_default(filter_object, actual):
 ])
 def test_filter_impulse_response_length_tolerance(filter_object):
     """Test tolerance parameter for estimating the impulse response length."""
-    low = filter_object.impulse_response_length(tolerance=5e-5)
-    high = filter_object.impulse_response_length(tolerance=5e-6)
+    low = filter_object.minimum_impulse_response_length(tolerance=5e-5)
+    high = filter_object.minimum_impulse_response_length(tolerance=5e-6)
     assert low[0] < high[0]
 
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #766 

### Changes proposed in this pull request:

- Add `impulse_response_length` method to all class functions. This is a port of [impzlength](https://de.mathworks.com/help/signal/ref/impzlength.html). These methods are tested against values computed with `impzlength`.
- Use new method to set default impulse response length for all filter classes
- Raise a warning if user values for impulse response length are smaller than the estimated length
