### PR TITLE
Bug/deprecation_fix

### DIFF
--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -106,17 +106,6 @@ def test_deprecations_0_8_0(statement):
             eval(statement)
 
 
-def test_deprecations_0_8_0_set_sh_order():
-    coords = pf.Coordinates(np.arange(6), 0, 0)
-
-    # remove statement from pyfar 0.8.0!
-    if version.parse(pf.__version__) >= version.parse('0.8.0'):
-        with pytest.raises(AttributeError):
-            coords.sh_order = 1
-        with pytest.raises(AttributeError):
-            assert coords.sh_order
-
-
 def test_signal_len():
     if version.parse(pf.__version__) >= version.parse('0.8.0'):
         match = "object of type 'Signal' has no len"


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #747

### Changes proposed in this pull request:

fixes errors which came up py run tests/test_deprecations.py after manually setting pf.__version__ = '0.8.0'
- we forgot to remove this test
- pytest will fail on develop for 0.8.0
