### PR TITLE
pyfar: _utils broadcasting function

### DIFF
--- a/pyfar/_utils.py
+++ b/pyfar/_utils.py
@@ -1,4 +1,5 @@
 from pyfar.classes.warnings import PyfarDeprecationWarning
+import numpy as np
 import warnings
 import functools
 
@@ -52,3 +53,41 @@ def rename_arg(arg_map, warning_message):
             return func(*args, **new_kwargs)
         return wrapper
     return decorator
+
+
+def to_broadcastable_array(dtype, broadcast, *args):
+    """
+    Cast all *args to numpy arrays and check if shapes can be broadcasted.
+
+    Raises a value error if shapes can not be broadcasted
+
+    Parameters
+    ----------
+    dtype : string
+        The dtype for creating the numpy arrays, e.g., ``float``
+    broadcast : Bool
+        If ``True`` broadcasted arrays are returned. If ``False`` it is only
+        checked if arrays can be broadcasted.
+    *args : scalar, array like
+        Scalar and array likes that are converted to numpy arrays
+
+    Returns
+    -------
+    *args : list of numpy arrays
+        The input *args as numpy arrays
+    """
+    arrays = [np.array(arg, dtype=dtype) for arg in args]
+    shapes = [array.shape for array in arrays]
+
+    try:
+        if broadcast:
+            arrays = np.broadcast_arrays(*arrays)
+        else:
+            np.broadcast_shapes(*shapes)
+    except ValueError as e:
+        shapes = [str(shape) for shape in shapes]
+        raise ValueError(
+            f"Input parameters are of shape {', '.join(shapes)} and cannot be "
+            "be broadcasted to a common shape") from e
+
+    return arrays

--- a/tests/test__utils.py
+++ b/tests/test__utils.py
@@ -1,0 +1,35 @@
+from pyfar._utils import to_broadcastable_array
+import numpy as np
+import numpy.testing as npt
+import pytest
+import re
+
+@pytest.mark.parametrize('dtype', [(int), (float)])
+@pytest.mark.parametrize(('broadcast', 'a', 'b', 'a_target', 'b_target'), [
+    (False, [1], [1, 2], [1], [1, 2]),
+    (True,  [1], [1, 2], [1, 1], [1, 2])])
+def test_to_broadcastable_array(dtype, broadcast, a, b, a_target, b_target):
+    """Test function with different values for dtype and broadcast."""
+
+    a_target = np.array(a_target, dtype=dtype)
+    b_target = np.array(b_target, dtype=dtype)
+
+    a_actual, b_actual = to_broadcastable_array(dtype, broadcast, a, b)
+
+    npt.assert_equal(a_actual, a_target)
+    npt.assert_equal(b_actual, b_target)
+    assert isinstance(a_actual, type(a_target))
+    assert isinstance(b_actual, type(b_target))
+
+
+@pytest.mark.parametrize('broadcast', [(False), (True)])
+def test_to_broadcastable_array_error(broadcast):
+    """Test raising the ValueError in case input cannot be broadcasted."""
+
+    a = [1, 2, 3]
+    b = [1, 2]
+
+    match = re.escape('Input parameters are of shape (3,), (2,)')
+
+    with pytest.raises(ValueError, match=match):
+        to_broadcastable_array(int, broadcast, a, b)


### PR DESCRIPTION
### Changes proposed in this pull request:

In some cases, we have multipe input arguments that must be converted to numpy arrays and must be broadcastable to the same shape. This is a helper function to take care of this and raise a verbose error, of broadcasting does not work.