### PR TITLE
Fix secondary sidebar display of class attributes

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,5 +1,17 @@
-document.addEventListener("DOMContentLoaded", () => {
-    // Only target spans inside the page ToC
+/**
+ * Cleans up the third-level TOC entries in the secondary sidebar.
+ *
+ * This function is used to simplify the attribute names in secondary sidebar
+ * entries by removing the class name prefix.
+ *
+ * Example:
+ *   "Class.attribute" → "attribute"
+ *
+ * @function cleanTocAttributeEntries
+ * @returns {void}
+ */
+function cleanTocAttributeEntries() {
+    // Only target spans inside the secondary sidebar
     const sidebarToc = document.querySelector(".bd-sidebar-secondary");
     if (!sidebarToc) return;
 
@@ -11,4 +23,9 @@ document.addEventListener("DOMContentLoaded", () => {
         const firstDotIndex = original.indexOf(".");
         span.textContent = original.slice(firstDotIndex + 1); // Keep everything after the first dot
     });
+};
+
+// Run after html document has been parsed
+document.addEventListener("DOMContentLoaded", () => {
+    cleanTocAttributeEntries();
 });

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", () => {
+    // Only target spans inside the page ToC
+    const sidebarToc = document.querySelector(".bd-sidebar-secondary");
+    if (!sidebarToc) return;
+
+    // Select spans only inside <li class="toc-h3 nav-item toc-entry">
+    const tocSpans = sidebarToc.querySelectorAll("li.toc-h3.nav-item.toc-entry .pre");
+
+    tocSpans.forEach(span => {
+        const original = span.textContent;
+        if (original.includes(".")) {
+            span.textContent = original.split(".").pop(); // Keep only what comes after the last dot
+        }
+    });
+});

--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -8,8 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     tocSpans.forEach(span => {
         const original = span.textContent;
-        if (original.includes(".")) {
-            span.textContent = original.split(".").pop(); // Keep only what comes after the last dot
-        }
+        const firstDotIndex = original.indexOf(".");
+        span.textContent = original.slice(firstDotIndex + 1); // Keep everything after the first dot
     });
 });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,6 +105,7 @@ intersphinx_mapping = {
 html_theme = 'pydata_sphinx_theme'
 html_static_path = ['_static']
 html_css_files = ['css/custom.css']
+html_js_files = ["custom.js"]
 html_logo = 'resources/logos/pyfar_logos_fixed_size_pyfar.png'
 html_title = "pyfar"
 html_favicon = '_static/favicon.ico'


### PR DESCRIPTION
Closes #785 

Adjust display of secondary sidebar using custom js.
Show only class `attribute` in sidebar instead of `class.attribute`.