### PR TITLE
Increase TOC depth for left sidebar to 2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,7 +133,7 @@ html_theme_options = {
     "secondary_sidebar_items": ["page-toc"],  # Omit 'show source' link that that shows notebook in json format
     "navigation_with_keys": True,
     # Configure navigation depth for section navigation
-    "navigation_depth": 1,
+    "navigation_depth": 2,
 }
 
 html_context = {


### PR DESCRIPTION
With the current level it's required to always go back to the main API docs page to change to a different sub-module or sub-page.
These can now be navigated using the left hand side-bar.