### PR TITLE
fix inconstistant docstring format

### DIFF
--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -261,7 +261,7 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
         Note that the ``'unitary'`` normalization is also applied for
         ``'amplitude'``, ``'rms'``, ``'power'``, and ``'psd'``
         if the input spectrum is single sided (see
-        ``single_sided``).
+        `single_sided`).
     inverse : bool, optional
         apply the inverse normalization. The default is ``False``.
     single_sided : bool, optional

--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -224,7 +224,7 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
     Note that the phase is maintained in all cases, i.e., instead of taking
     the squared absolute values for ``'power'`` and ``'psd'``, the complex
     spectra are multiplied with their absolute values to ensure a correct
-    renormalization. Details on the FFT normalization given by ``fft_norm`` are
+    renormalization. Details on the FFT normalization given by `fft_norm` are
     given above.
 
     Parameters
@@ -265,7 +265,7 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
     inverse : bool, optional
         apply the inverse normalization. The default is ``False``.
     single_sided : bool, optional
-        denotes if ``spec`` is a single sided spectrum up to half the sampling
+        denotes if `spec` is a single sided spectrum up to half the sampling
         rate or a both sided (full) spectrum. If ``single_sided=True`` the
         ``'unitary'`` normalization according to [1]_ Eq. (8) is applied unless
         ``fft_norm='none'``.
@@ -273,7 +273,7 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
     window : None, array like
         window that was applied to the time signal before performing the FFT.
         Affects the normalization as in [1]_ Eqs. (11-13). The window must be
-        an array-like with ``n_samples`` length. The default is ``None``,
+        an array-like with `n_samples` length. The default is ``None``,
         which denotes that no window was applied.
 
     Returns

--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -224,7 +224,7 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
     Note that the phase is maintained in all cases, i.e., instead of taking
     the squared absolute values for ``'power'`` and ``'psd'``, the complex
     spectra are multiplied with their absolute values to ensure a correct
-    renormalization. Details on the FFT normalization given by `fft_norm` are
+    renormalization. Details on the FFT normalization given by ``fft_norm`` are
     given above.
 
     Parameters
@@ -265,15 +265,15 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
     inverse : bool, optional
         apply the inverse normalization. The default is ``False``.
     single_sided : bool, optional
-        denotes if `spec` is a single sided spectrum up to half the sampling
+        denotes if ``spec`` is a single sided spectrum up to half the sampling
         rate or a both sided (full) spectrum. If ``single_sided=True`` the
-        `unitary` normalization according to [1]_ Eq. (8) is applied unless
+        ``'unitary'`` normalization according to [1]_ Eq. (8) is applied unless
         ``fft_norm='none'``.
         The default is ``True``.
     window : None, array like
         window that was applied to the time signal before performing the FFT.
         Affects the normalization as in [1]_ Eqs. (11-13). The window must be
-        an array-like with `n_samples` length and. The default is ``None``,
+        an array-like with ``n_samples`` length. The default is ``None``,
         which denotes that no window was applied.
 
     Returns

--- a/pyfar/dsp/fft.py
+++ b/pyfar/dsp/fft.py
@@ -248,19 +248,20 @@ def normalization(spec, n_samples, sampling_rate, fft_norm='none',
         ``'amplitude'``
             Scale spectrum by ``1/n_samples`` as in [1]_ Eq. (4)
             to obtain the amplitude spectrum.
-        'rms'
+        ``'rms'``
             Scale spectrum by :math:`1/\sqrt{2}` as in [1]_
             Eq.(10) to obtain the RMS spectrum.
-        'power'
+        ``'power'``
             Power spectrum, which equals the squared RMS spectrum
             (except for the retained phase).
-        'psd'
+        ``'psd'``
             The power spectrum is scaled by ``n_samples/sampling_rate`` as in
             [1]_ Eq. (6)
 
-        Note that the `unitary` normalization is also applied for `amplitude`,
-        `rms`, `power`, and `psd` if the input spectrum is single sided (see
-        `single_sided`).
+        Note that the ``'unitary'`` normalization is also applied for
+        ``'amplitude'``, ``'rms'``, ``'power'``, and ``'psd'``
+        if the input spectrum is single sided (see
+        ``single_sided``).
     inverse : bool, optional
         apply the inverse normalization. The default is ``False``.
     single_sided : bool, optional


### PR DESCRIPTION
### Changes proposed in this pull request:

- make the style of the docstring constistant
- follows the Contribution guidelines now
