### PR TITLE
Feature: frequency weighting constants and filter

### DIFF
--- a/pyfar/constants/__init__.py
+++ b/pyfar/constants/__init__.py
@@ -17,6 +17,11 @@ from .constants import (
     air_attenuation,
 )
 
+from .frequency_weighting import (
+    frequency_weighting_curve,
+    frequency_weighting_band_corrections,
+)
+
 __all__ = [
     'saturation_vapor_pressure_magnus',
     'density_of_air',
@@ -24,6 +29,8 @@ __all__ = [
     'speed_of_sound_cramer',
     'speed_of_sound_ideal_gas',
     'air_attenuation',
+    'frequency_weighting_curve',
+    'frequency_weighting_band_corrections',
 ]
 
 

--- a/pyfar/constants/frequency_weighting.py
+++ b/pyfar/constants/frequency_weighting.py
@@ -1,0 +1,137 @@
+"""File containing all frequency weighting functions."""
+from typing import Literal
+import numpy as np
+
+# constants for the weighting curve formulas
+_F_1 = 20.598997057618316
+_F_2 = 107.65264864304629
+_F_3 = 737.8622307362901
+_F_4 = 12194.217147998012
+_A_1000 = -2
+_C_1000 = -0.062
+
+
+def _calculate_A_weighted_level(f: float | np.ndarray) -> float | np.ndarray:
+    """
+    Calculates the level correction in dB of a frequency component
+    when using the A weighting.
+    """
+    bracket_term = (_F_4**2 * f**4) / ((f**2 + _F_1**2) * (f**2 + _F_2**2)
+                                      ** 0.5 * (f**2 + _F_3**2)**0.5
+                                      * (f**2 + _F_4**2))
+    return 10 * np.log10(bracket_term**2) - _A_1000
+
+
+def _calculate_C_weighted_level(f: float | np.ndarray) -> float | np.ndarray:
+    """
+    Calculates the level correction in dB of a frequency component
+    when using the C weighting.
+    """
+    bracket_term = (_F_4**2 * f**2) / ((f**2 + _F_1**2) * (f**2 + _F_4**2))
+    return 10 * np.log10(bracket_term**2) - _C_1000
+
+
+def frequency_weighting_curve(weighting: Literal["A", "C"],
+            frequency: float | np.ndarray) -> float | np.ndarray:
+    """
+    Calculates the level correction in dB of a frequency component when using
+    the A or C weighting defined in IEC 61672-1.
+
+    Parameters
+    ----------
+    weighting: str ('A' or 'C')
+        Which frequency weighting to use.
+
+    frequency: float or array-like
+        The frequency or frequencies at which to evaluate the weighting curve.
+        The return value matches the shape of this argument.
+
+    Returns
+    -------
+    weights: float or array-like
+        The weights in dB in the same shape as the frequency arguments.
+    """
+    if weighting == "A":
+        return _calculate_A_weighted_level(frequency)
+    elif weighting == "C":
+        return _calculate_C_weighted_level(frequency)
+    else:
+        raise ValueError("Allowed literals for weighting are 'A' and 'C'")
+
+
+# constants for nominal band corrections.
+# This is somewhat redundant with dsp.filter.fractional_octaves -> move helper
+# functions to a new place where it can be accessed from everyhwere?
+_NOMINAL_THIRDBAND_FREQUENCIES = np.array([
+    10, 12.5, 16, 20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315,
+    400, 500, 630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300,
+    8000, 10000, 12500, 16000, 20000,
+])
+_THIRDBAND_WEIGHTINGS_A = np.array([
+    -70.4, -63.4, -56.7, -50.5, -44.7, -39.4, -34.6, -30.2, -26.2, -22.5,
+    -19.1, -16.1, -13.4, -10.9, -8.6, -6.6, -4.8, -3.2, -1.9, -0.8,
+    0.0, 0.6, 1.0, 1.2, 1.3, 1.2, 1.0, 0.5, -0.1, -1.1,
+    -2.5, -4.3, -6.6, -9.3,
+])
+_THIRDBAND_WEIGHTINGS_C = np.array([
+    -14.3, -11.2, -8.5, -6.2, -4.4, -3.0, -2.0, -1.3, -0.8, -0.5,
+    -0.3, -0.2, -0.1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0,
+    0.0, 0.0, -0.1, -0.2, -0.3, -0.5, -0.8, -1.3, -2.0, -3.0, -4.4,
+    -6.2, -8.5, -11.2,
+])
+
+
+def frequency_weighting_band_corrections(
+    weighting: Literal["A", "C"],
+    bands: Literal["third", "octave"],
+    frequency_range: tuple[float, float],
+) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Returns the A or C frequency weighting band corrections as specified in
+    IEC 62672-1 for the given frequency range. The lowest defined center
+    frequency is 10 Hz and the highest is 20 kHz.
+
+    Parameters
+    ----------
+    weighting: str ('A' or 'C')
+        Which frequency weighting type to use.
+
+    bands: str ('octave' or 'third')
+        Whether to use octave bands or third bands.
+
+    frequency_range: (float, float)
+        A range of what nominal center frequencies to include.
+
+    Returns
+    -------
+    nominal_frequencies: NDArray
+        The nominal center frequencies included in the given range.
+
+    weights: NDArray
+        The correction values in dB for the specific frequency weighting.
+    """
+    if weighting == "A":
+        all_weights = _THIRDBAND_WEIGHTINGS_A
+    elif weighting == "C":
+        all_weights = _THIRDBAND_WEIGHTINGS_C
+    else:
+        raise ValueError("Allowed literals for weighting are 'A' and 'C'")
+
+    if bands == "octave":
+        nominals = _NOMINAL_THIRDBAND_FREQUENCIES[2::3]
+        band_weights = all_weights[2::3]
+    elif bands == "third":
+        nominals =_NOMINAL_THIRDBAND_FREQUENCIES
+        band_weights = all_weights
+    else:
+        raise ValueError("Allowed literals for bands are 'octave' and 'third'")
+
+    mask = (nominals >= frequency_range[0]) & (nominals <= frequency_range[1])
+    nominals_in_range = nominals[mask]
+    weights_in_range = band_weights[mask]
+
+    if len(nominals_in_range) == 0:
+        raise ValueError("Frequency range must include at least one value"
+                         + "between 10 and 20000")
+
+    return (nominals_in_range, weights_in_range)

--- a/pyfar/constants/frequency_weighting.py
+++ b/pyfar/constants/frequency_weighting.py
@@ -1,5 +1,5 @@
 """File containing all frequency weighting functions."""
-from typing import Literal
+from typing import Literal, Union
 import numpy as np
 
 # constants for the weighting curve formulas
@@ -11,7 +11,8 @@ _A_1000 = -2
 _C_1000 = -0.062
 
 
-def _calculate_A_weighted_level(f: float | np.ndarray) -> float | np.ndarray:
+def _calculate_A_weighted_level(f: Union[float, np.ndarray],
+                                ) -> Union[float, np.ndarray]:
     """
     Calculates the level correction in dB of a frequency component
     when using the A weighting.
@@ -22,7 +23,8 @@ def _calculate_A_weighted_level(f: float | np.ndarray) -> float | np.ndarray:
     return 10 * np.log10(bracket_term**2) - _A_1000
 
 
-def _calculate_C_weighted_level(f: float | np.ndarray) -> float | np.ndarray:
+def _calculate_C_weighted_level(f: Union[float, np.ndarray],
+                                ) -> Union[float, np.ndarray]:
     """
     Calculates the level correction in dB of a frequency component
     when using the C weighting.
@@ -32,7 +34,7 @@ def _calculate_C_weighted_level(f: float | np.ndarray) -> float | np.ndarray:
 
 
 def frequency_weighting_curve(weighting: Literal["A", "C"],
-            frequency: float | np.ndarray) -> float | np.ndarray:
+            frequency: Union[float, np.ndarray]) -> Union[float, np.ndarray]:
     """
     Calculates the level correction in dB of a frequency component when using
     the A or C weighting defined in IEC 61672-1.

--- a/pyfar/dsp/filter/__init__.py
+++ b/pyfar/dsp/filter/__init__.py
@@ -40,6 +40,9 @@ from .gammatone import (
     erb_frequencies,
 )
 
+from .frequency_weighting import (
+    frequency_weighting_filter,
+)
 
 __all__ = [
     'allpass',
@@ -64,4 +67,5 @@ __all__ = [
     'fractional_octave_frequencies',
     'GammatoneBands',
     'erb_frequencies',
+    'frequency_weighting_filter',
 ]

--- a/pyfar/dsp/filter/frequency_weighting.py
+++ b/pyfar/dsp/filter/frequency_weighting.py
@@ -1,0 +1,336 @@
+"""
+Functions and helpers to create frequency weighting filters
+according to IEC 61672-1.
+"""
+from typing import Callable, Literal
+import numpy as np
+import pyfar as pf
+import pyfar.constants as pfc
+import scipy.signal as sps
+import scipy.optimize as spo
+from pyfar.constants.frequency_weighting import _F_1, _F_2, _F_3, _F_4
+
+
+_A_WEIGHTING_ZEROS = [0, 0, 0, 0]
+_A_WEIGHTING_POLES = [_F_1, _F_1, _F_4, _F_4, _F_2, _F_3]
+_C_WEIGHTING_ZEROS = [0, 0]
+_C_WEIGHTING_POLES = [_F_1, _F_1, _F_4, _F_4]
+
+
+def frequency_weighting_filter(
+        signal,
+        target_weighting: Literal["A", "C"]="A",
+        n_frequencies=100,
+        error_weighting: Callable[[
+            np.ndarray], np.ndarray] = None,
+        sampling_rate: float | None = None,
+        **kwargs,
+        ):
+    """
+    Creates an efficient SOS filter approximating the A or C weighting defined
+    in IEC/DIN-EN 61672-1.
+    When using default parameters, the returned filter is compliant with a
+    class 1 sound level meter as described in the norm for all tested
+    sampling rates (see Notes).
+    This function will run a least-squares algorithm to iteratively approach
+    the target weighting curve.
+    Therefore, it may be much faster to create the filter once and reuse that
+    filter when repeatedly weighting audio data of identical sampling rates.
+
+    Parameters
+    ----------
+    signal : Signal, None
+        The signal to be filtered. Pass ``None`` to create the filter without
+        applying it.
+
+    target_weighting: str, optional
+        Specifies which frequency weighting curve to approximate.
+        Must be either "A" or "C". The default is "A".
+
+    n_frequencies: int, optional
+        At how many frequencies to evaluate the filter coefficients during
+        optimization. Less frequencies means faster iterations, but
+        potentially worse results. The evaluation frequencies are
+        logarithmically spaced between 10 Hz and the Nyquist frequency.
+
+    error_weighting: callable
+        A function that can be used to emphasize the approximation errors in
+        specific frequency ranges. The function should take a float array as
+        argument, specifying the normalized frequencies between 0 and 1
+        (where 1 is the Nyquist frequency) to weight, and returns a float
+        array as output containing the weights.
+        The default value is None, in which case the errors of all
+        (logarithmically spaced) frequencies are equally weighted. This
+        usually leads to larger errors for higher frequencies. By passing
+        a function that emphasizes high frequencies, it is possible to reduce
+        this effect and get a filter potentially closer to the target curve.
+        Example: `error_weighting=lambda nf: 100**nf`. This example often
+        leads to better results for typical sampling rates, but much worse
+        for very high rates.
+
+    sampling_rate: float, conditionally optional
+        The sampling rate of the returned filter.
+
+    **kwargs: dict
+        Keyword args that are passed to the
+        :py:func:`scipy.optimize.least_squares` call.
+
+    Returns
+    -------
+    filter: FilterSOS
+        The frequency weighting filter in second order sections format.
+        If weighting is 'A' the filter order will be 6. 'C' weighting will
+        return a filter of order 4.
+
+    Notes
+    -----
+    Since this function performs an iterative approximation, results may not
+    be perfect depending on the input parameters. With the default parameters,
+    the filter will be at least class 1 compliant for the sampling rates
+    48 kHz, 44.1 kHz, 16 kHz as well as these sampling rates multiplied by
+    2, 4, 8, 0.5, 0.25 and 0.125 each.
+    With non-default parameters and/or other sampling rates, the returned
+    filter may not comply with class 1 requirements,
+    in which case a warning will be printed.
+    """
+    # check input
+    if (signal is None and sampling_rate is None) \
+            or (signal is not None and sampling_rate is not None):
+        raise ValueError('Either signal or sampling_rate must be none.')
+
+    # sampling frequency in Hz
+    fs = signal.sampling_rate if sampling_rate is None else sampling_rate
+
+    sos = _design_frequency_weighting_filter(fs, target_weighting,
+                                            n_frequencies, error_weighting,
+                                            **kwargs)
+    filt = pf.FilterSOS([sos], sampling_rate)
+    filt.comment = (f"Frequency weighting SOS filter of order {filt.order} "
+                    f"to approximate {target_weighting} weighting according "
+                    "to IEC 61672-1")
+
+    # apply or return the filter object
+    if signal is None:
+        return filt
+    else:
+        signal_filt = filt.process(signal)
+        return signal_filt
+
+
+def _design_frequency_weighting_filter(sampling_rate: float,
+                                      target_weighting: Literal["A", "C"]="A",
+                                      n_frequencies=100,
+                                      error_weighting: Callable[[
+                                          np.ndarray], np.ndarray] = None,
+                                      **kwargs,
+                                      ) -> np.ndarray:
+    """
+    Designs SOS filter coefficients approximating the A or C weighting defined
+    in IEC/DIN-EN 61672-1 for an arbitrary sampling rate.
+
+    Parameters
+    ----------
+    sampling_rate: float
+        The sampling rate of the returned filter.
+
+    target_weighting: str, optional
+        Specifies which frequency weighting curve to approximate.
+        Must be either "A" or "C". The default is "A".
+
+    n_frequencies: int, optional
+        At how many frequencies to evaluate the filter coefficients during
+        optimization. Less frequencies means faster iterations, but
+        potentially worse results. The evaluation frequencies are
+        logarithmically spaced between 10 Hz and the Nyquist frequency.
+
+    error_weighting: callable
+        A function that can be used to emphasize the approximation errors in
+        specific frequency ranges. The function should take a float array as
+        argument, specifying the normalized frequencies between 0 and 1
+        (where 1 is the Nyquist frequency) to weight, and returns a float
+        array as output containing the weights.
+        The default value is None, in which case the errors of all
+        (logarithmically spaced) frequencies are equally weighted. This
+        usually leads to larger errors for higher frequencies. By passing
+        a function that emphasizes high frequencies, it is possible to reduce
+        this effect and get a filter potentially closer to the target curve.
+        Example: `error_weighting=lambda nf: 100**nf`. This example often
+        leads to better results for typical sampling rates, but much worse
+        for very high rates.
+
+    **kwargs: dict
+        Keyword args that are passed to the
+        :py:func:`scipy.optimize.least_squares` call.
+
+    Returns
+    -------
+    sos_coefficients: NDarray
+        The coefficients of the designed filter in scipy's sos format.
+
+    Notes
+    -----
+    Since this function performs an iterative approximation, results may not
+    be perfect depending on the input parameters. With the default parameters,
+    the filter will be at least class 1 compliant for the sampling rates
+    48 kHz, 44.1 kHz, 16 kHz as well as these sampling rates multiplied by
+    2, 4, 8, 0.5, 0.25 and 0.125 each.
+    With non-default parameters and/or other sampling rates, the returned
+    filter may not comply with class 1 requirements,
+    in which case a warning will be printed.
+    """
+
+    if target_weighting not in ["A", "C"]:
+        raise ValueError(f"Unrecognized weighting: '{target_weighting}'.",
+                         " Only 'A' and 'C' are implemented")
+
+    # Build the initial guess x0 (the variables to optimize) from
+    # zeros, poles and gain. Use the poles from the bilinear filter,
+    # since they are not too far from the approximation.
+    _z, p0, _k = _zpk_from_analog(target_weighting, sampling_rate)
+    # The zeros at (1, 0) (=0 Hz) are fixed. The remaining two are wrong from
+    # the bilinear transform, so we optimize them starting from 0
+    # (the z-plane origin).
+    z0 = [0, 0]
+    k0 = 1
+    x0 = np.concat([z0, p0, [k0]])
+
+    # build the cost function (as a closure, so that passing it to
+    # least_squares() is easier and cleaner)
+    frequencies = np.logspace(1, np.log10(sampling_rate/2), n_frequencies)
+    target_levels = pfc.frequency_weighting_curve(target_weighting,
+                                                  frequencies)
+
+    def compute_residuals(x: np.ndarray) -> np.ndarray:
+        """
+        Lets least_squares() compute how close the current approximation is to
+        the target. Treats x (z, p and k) as real values, limiting them to
+        the real axis.
+        """
+        z, p, k = _x2zpk(x, target_weighting)
+        _, freq_response = sps.freqz_zpk(
+            z, p, k, frequencies, fs=sampling_rate)
+        approximated_levels = 20 * np.log10(abs(freq_response))
+
+        # use level differences (in dB) as cost
+        level_diffs = target_levels - approximated_levels
+        if error_weighting:
+            level_diffs *= error_weighting(frequencies / (sampling_rate/2))
+        return level_diffs
+
+    # Bounds are necessary to keep poles inside the unit circle,
+    # ensuring the resulting filter is stable.
+    kwargs.setdefault("bounds", (-1, 1))
+    # The actual optimization happens here. This iteratively moves
+    # zeros and poles along the real axis on the z-plane until
+    # a local optimum is reached.
+    optimization_result = spo.least_squares(compute_residuals, x0, **kwargs)
+
+    # turn the result into a filter object
+    z, p, k = _x2zpk(optimization_result.x, target_weighting)
+    sos = sps.zpk2sos(z, p, k)
+
+    # check if the filter is class 1 compliant
+    is_class_1, max_err, mean_err = _check_filter(
+        sampling_rate, sos, target_weighting)
+    if not is_class_1:
+        print(f"Warning: The generated {target_weighting} weighting filter is"
+              + "not class 1 compliant; "
+              + f"Max error: {max_err:.2} dB, mean error: {mean_err:.2} dB.")
+    return sos
+
+
+
+def _zpk_from_analog(weighting: str, fs: float,
+                     ) -> tuple[np.ndarray, np.ndarray, float]:
+    """
+    Transforms the analog (s-plane) A or C weighting filter as specified in
+    IEC/DIN-EN 61672-1 to a digital filter (z-plane) via bilinear transform
+    and returns it as zeros poles and gain.
+    The resulting filter is heavily warped near the Nyquist frequency.
+    """
+    if weighting == "A":
+        zeros, poles = (_A_WEIGHTING_ZEROS, _A_WEIGHTING_POLES)
+    elif weighting == "C":
+        zeros, poles = (_C_WEIGHTING_ZEROS, _C_WEIGHTING_POLES)
+    else:
+        raise ValueError("Unrecognized weighting:", weighting)
+
+    poles_angular = np.array(poles) * -2 * np.pi
+    return sps.bilinear_zpk(zeros, poles_angular, 1, fs)
+
+
+def _x2zpk(x: np.ndarray,
+           target_weighting: Literal["A", "C"],
+           ) -> tuple[np.ndarray, np.ndarray, float]:
+    """
+    Reobtain z, p and k from x (the 1-D array of optimizer inputs).
+    Adds back the fixed zeros at 0 Hz that are excluded from optimization.
+    """
+    fixed_zeros = [1, 1, 1, 1] if target_weighting == "A" else [1, 1]
+    zeros = np.concat([fixed_zeros, x[0:2]])
+    return (zeros, x[2:-1], x[-1])
+
+
+
+def _get_error_margins(f: np.ndarray):
+    """
+    Returns the upper and lower error margin in dB for every frequency in the
+    input array for the A and C weighting according to IEC/DIN-EN 61672-1.
+    """
+    upper = np.zeros_like(f)
+    upper[f <= 10] = 3.0
+    upper[(f > 10) & (f <= 12.5)] = 2.5
+    upper[(f > 12.5) & (f <= 25)] = 2.0
+    upper[(f > 25) & (f <= 31.5)] = 1.5
+    upper[(f > 31.5) & (f <= 800)] = 1.0
+    upper[(f > 800) & (f < 1250)] = 0.7
+    upper[(f >= 1250) & (f < 5000)] = 1.0
+    upper[(f >= 5000) & (f < 10e3)] = 1.5
+    upper[(f >= 10e3) & (f < 16e3)] = 2.0
+    upper[(f >= 16e3) & (f < 20e3)] = 2.5
+    upper[f >= 20e3] = 3.0
+
+    lower = np.zeros_like(f)
+    lower[f <= 12.5] = -np.inf
+    lower[(f > 12.5) & (f <= 16)] = -4.0
+    lower[(f > 16) & (f <= 20)] = -2.0
+    lower[(f > 20) & (f <= 31.5)] = -1.5
+    lower[(f > 31.5) & (f <= 800)] = -1.0
+    lower[(f > 800) & (f < 1250)] = -0.7
+    lower[(f >= 1250) & (f < 5000)] = -1.0
+    lower[(f >= 5000) & (f < 6300)] = -1.5
+    lower[(f >= 6300) & (f < 8000)] = -2.0
+    lower[(f >= 8000) & (f < 10e3)] = -2.5
+    lower[(f >= 10e3) & (f < 12500)] = -3.0
+    lower[(f >= 12500) & (f < 16e3)] = -5.0
+    lower[(f >= 16e3) & (f < 20e3)] = -16.0
+    lower[f >= 20e3] = -np.inf
+
+    return upper, lower
+
+
+def _check_filter(sampling_rate: float,
+                  sos: np.ndarray,
+                  weighting: Literal["A", "C"],
+                  ) -> tuple[bool, float, float]:
+    """
+    Checks whether the filter is class 1 compliant according to the norm and
+    provides simple error statistics.
+    """
+    test_freqs = np.logspace(1, np.log10(sampling_rate / 2), 100_000)
+
+    # calculate the magnitude differences between the filter response
+    # and the target weighting
+    z, p, k = sps.sos2zpk(sos)
+    _, freq_resp = sps.freqz_zpk(z, p, k, test_freqs, fs=sampling_rate)
+    mags = np.abs(freq_resp)
+    mags_dB = 10 * np.log10(mags**2)
+    mag_diffs = mags_dB - pfc.frequency_weighting_curve(weighting, test_freqs)
+
+    upper, lower = _get_error_margins(test_freqs)
+    is_class_1 = np.all(mag_diffs < upper) and np.all(mag_diffs >= lower)
+    max_diff = np.max(np.abs(mag_diffs))
+    mean_diff = np.mean(np.abs(mag_diffs))
+    return is_class_1, max_diff, mean_diff
+
+

--- a/pyfar/dsp/filter/frequency_weighting.py
+++ b/pyfar/dsp/filter/frequency_weighting.py
@@ -2,7 +2,7 @@
 Functions and helpers to create frequency weighting filters
 according to IEC 61672-1.
 """
-from typing import Callable, Literal
+from typing import Callable, Literal, Optional
 import numpy as np
 import pyfar as pf
 import pyfar.constants as pfc
@@ -21,9 +21,9 @@ def frequency_weighting_filter(
         signal,
         target_weighting: Literal["A", "C"]="A",
         n_frequencies=100,
-        error_weighting: Callable[[
-            np.ndarray], np.ndarray] = None,
-        sampling_rate: float | None = None,
+        error_weighting: Optional[Callable[[
+            np.ndarray], np.ndarray]] = None,
+        sampling_rate: Optional[float] = None,
         **kwargs,
         ):
     """
@@ -120,8 +120,8 @@ def frequency_weighting_filter(
 def _design_frequency_weighting_filter(sampling_rate: float,
                                       target_weighting: Literal["A", "C"]="A",
                                       n_frequencies=100,
-                                      error_weighting: Callable[[
-                                          np.ndarray], np.ndarray] = None,
+                                      error_weighting: Optional[Callable[[
+                                          np.ndarray], np.ndarray]] = None,
                                       **kwargs,
                                       ) -> np.ndarray:
     """

--- a/tests/test_frequency_weighting.py
+++ b/tests/test_frequency_weighting.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytest
+from numpy import testing as npt
+import pyfar
+import pyfar.dsp.filter as pffilt
+
+
+def test_frequency_weighting_constants():
+    weightings = ["A", "C"]
+    band_options = ["octave", "third"]
+    freq_ranges = [
+        (20, 20000),
+        (0, 100),
+        (4000, 100_000),
+    ]
+    for freq_range in freq_ranges:
+        for weighting in weightings:
+            for bands in band_options:
+                _test_frequency_weighting_constants_combination(
+                    weighting, bands, freq_range)
+
+
+def _test_frequency_weighting_constants_combination(
+        weighting, bands, freq_range):
+
+    (nominals, iec_weights) = pyfar.constants. \
+            frequency_weighting_band_corrections(weighting, bands, freq_range)
+    calculated_weights = pyfar.constants. \
+            frequency_weighting_curve(weighting, nominals)
+            
+    # maybe there is a better way of testing. tolerance is 0.2, because
+    # we need 0.1 for rounding the weight and then larger error
+    # due to the difference in nominal vs exact frequency being evaluated
+    npt.assert_allclose(calculated_weights, iec_weights, atol=0.3)
+
+
+def test_frequency_weighting_filter():
+    base_rates = np.array([48000, 44100, 16000])
+    test_rates = np.array([
+        base_rates,
+        base_rates / 2, base_rates * 2,
+        base_rates / 4, base_rates * 4,
+        base_rates / 8, base_rates * 8,
+    ]).flatten().tolist()
+
+    for weighting in ["A", "C"]:
+        for fs in test_rates:
+            filt = pffilt.frequency_weighting_filter(None,
+                                                     weighting,
+                                                     sampling_rate=fs)
+            is_class_1, _, _ = pffilt.frequency_weighting. \
+                _check_filter(filt.sampling_rate,
+                              filt.coefficients[0],
+                              weighting)
+            assert is_class_1

--- a/tests/test_frequency_weighting.py
+++ b/tests/test_frequency_weighting.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 from numpy import testing as npt
 import pyfar
 import pyfar.dsp.filter as pffilt
@@ -27,7 +26,7 @@ def _test_frequency_weighting_constants_combination(
             frequency_weighting_band_corrections(weighting, bands, freq_range)
     calculated_weights = pyfar.constants. \
             frequency_weighting_curve(weighting, nominals)
-            
+
     # maybe there is a better way of testing. tolerance is 0.2, because
     # we need 0.1 for rounding the weight and then larger error
     # due to the difference in nominal vs exact frequency being evaluated


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #761 and #758

### Changes proposed in this pull request:

Implementing octave/third-band correction values, A/C-weighting curves and a frequency weighting filter based on these curves, as described in #675.
This merge request is essentially a revamped version of #759. I decided to do this in a new branch as the previous is somewhat old by now and there were a lot of changes requested since then.

In summary, the frequency weighting filter works by running a least-squares optimization on the zeros and poles on the z-plane, which are then turned into an SOS filter. 

Points of interest for discussion:

**Redundant third-band definition:** 
The definition and selection of nominal frequency bands in a range in `constants.frequency_weighting_band_corrections` is largely redundant with `dsp.filter.fractional_octave` functions. However, since the two functions are based on different standards (61260 vs 61672), there are some differences: 61260 allows other octave fractions than 1 and 3, whereas 61672 only defines octave and third bands. On the other hand, 61672 defines bands down to 10 Hz instead of 25 Hz. 
Should we merge these helper functions anyway?

**Performance/Caching:**
While `dsp.filter.frequency_weighting_filter` adapts the usual style of other filter functions, it is different in that it runs an approximation internally, thus taking more computation time (a fraction of a second each call). If used in a loop, or by several different level functions later on, this might add up and make scripts slower. 
I thought about caching, but the current implementation is not cachable to my knowledge, since it allows users to specify an error_weighting function and kwargs for the optimizer as arguments, which are not hashable (https://docs.python.org/3/library/functools.html#functools.lru_cache). 
If we remove these options, the design function would still produce good results (class 1 compliant at all usual sampling rates) and become cachable, but we would prevent users from finding more optimal solutions, or ones that work even for unusual/extreme sampling rates.
So we could:
1. Leave it as is and accept that it might be slow for repeated calls (A hint is provided in the docstring comment)
2. Remove the unhashable parameters, limiting what the function can do (while also hiding potentially unwanted complexity)
3. Add a cachable wrapper function around the design function that is used in case only the mandatory parameters are specified. So we get caching in most cases, except when the optional parameters are used. This should be the best of both worlds, at the cost of slightly more complex code.

I prefer option 3 but want to hear your opinions first.