### PR TITLE
Feature/horn transmission matrices

### DIFF
--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -876,15 +876,14 @@ class TransmissionMatrix(FrequencyData):
             >>> import numpy as np
             >>> # Horn parameters
             >>> a = 0.1
-            >>> b = 0.2
-            >>> Omega = 0.4
+            >>> b = 1.7
+            >>> Omega = 2.4
             >>> frequencies = np.linspace(20, 20e3, 1000)
             >>> omega = 2 * np.pi * frequencies
             >>> k = pf.FrequencyData(omega / pf.constants.reference_speed_of_sound, frequencies)
             >>> Z0 = pf.constants.reference_air_impedance
-            >>> direction = 'forwards'
             >>> # Create the transmission matrix
-            >>> T = pf.TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z0, direction)
+            >>> T = pf.TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z0)
             >>> # Plot the transmission matrix
             >>> pf.plot.freq(T.input_impedance(np.inf))
             

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -870,6 +870,8 @@ class TransmissionMatrix(FrequencyData):
 
         Example
         -------
+        Arbitrarily sized lossless conical horn section.
+        
         .. plot::
 
             >>> import pyfar as pf
@@ -884,9 +886,10 @@ class TransmissionMatrix(FrequencyData):
             >>> Z0 = pf.constants.reference_air_impedance
             >>> direction = 'forwards'
             >>> # Create the transmission matrix
-            >>> T = conical_horn_section(a, b, Omega, k, Z0, direction)
+            >>> T = pf.TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z0, direction)
             >>> # Plot the transmission matrix
             >>> pf.plot.freq(T.input_impedance(np.inf))
+            
         """
         if not isinstance(a, Number):
             raise TypeError("The input a must be a number.")

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -847,11 +847,11 @@ class TransmissionMatrix(FrequencyData):
         Parameters
         ----------
         a : float
-            Distance from the horn's start to the virtual apex of the underlying cone.
+            Distance from the horn's narrow end to the virtual apex of the underlying cone.
             This is not the physical length of the horn but the extrapolated length to the point
             where the conical walls would converge.
         b : float
-            Distance from the horn's end to the same virtual apex of the cone.
+            Distance from the horn's wide end to the same virtual apex of the cone.
             The difference (b - a) gives the actual physical length of the horn segment.
         Omega : float
             Area constant, such that the horn's cross-sectional area at any length
@@ -889,8 +889,8 @@ class TransmissionMatrix(FrequencyData):
             
         Note
         ----
-        The returned transmission matrix relates the sound pressure and volume velocity at the horn's narrow end (a)
-        to the sound pressure and volume velocity at the horn's wide end (b).
+        By default, the calculated transmission matrix relates the sound pressure and volume velocity at the horn's narrow end (a)
+        to the sound pressure and volume velocity at the horn's wide end (b):
         
         .. math::
             \begin{bmatrix} p_a \\ q_a \end{bmatrix} = \begin{bmatrix}
@@ -898,7 +898,9 @@ class TransmissionMatrix(FrequencyData):
                 \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab) \sin{kl} - kl \cos{kl} \right) & \frac{a}{b}cos(kl)-\frac{1}{kb}sin(kl)
                 \end{bmatrix}\begin{bmatrix} p_b \\ q_b \end{bmatrix}
 
-        If one instead wants to express :math:`p_b` and :math:`q_b` in terms of :math:`p_a` and :math:`q_a`, then the position of `a` and `b` in the function signature must be swapped.
+        If one instead wants to express :math:`p_b` and :math:`q_b` in terms of :math:`p_a` and :math:`q_a`,
+        i.e. model wave propagation from the narrow towards the wide end,
+        then the position of `a` and `b` in the function signature must be swapped.
         """
         if not isinstance(a, Number):
             raise TypeError("The input a must be a number.")

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -826,11 +826,13 @@ class TransmissionMatrix(FrequencyData):
             A, B, C, D, kl.frequencies)
 
     @staticmethod
-    def create_conical_horn_section(a: Number, b: Number, Omega: Number,
-                         k: FrequencyData,
-                         medium_impedance: Number | FrequencyData,
-                         direction: str = 'backwards'
-                         ) -> TransmissionMatrix:
+    def create_conical_horn_section(a: Number,
+            b: Number,
+            Omega: Number,
+            k: FrequencyData,
+            medium_impedance: Number | FrequencyData,
+            direction: str = 'backwards'
+            ) -> TransmissionMatrix:
         r"""Create a transmission matrix representing a conical horn.
 
         The transmission matrix is calculated based on the starting point :math:`a`, 

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -826,7 +826,7 @@ class TransmissionMatrix(FrequencyData):
             A, B, C, D, kl.frequencies)
 
     @staticmethod
-    def create_conical_horn_section(a: Number,
+    def create_conical_horn(a: Number,
             b: Number,
             Omega: Number,
             k: FrequencyData,

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -826,7 +826,7 @@ class TransmissionMatrix(FrequencyData):
             A, B, C, D, kl.frequencies)
 
     @staticmethod
-    def conical_horn_section(a: Number, b: Number, Omega: Number,
+    def create_conical_horn_section(a: Number, b: Number, Omega: Number,
                          k: FrequencyData,
                          medium_impedance: Number | FrequencyData,
                          direction: str = 'backwards'
@@ -835,7 +835,7 @@ class TransmissionMatrix(FrequencyData):
 
         The transmission matrix is calculated based on the starting point :math:`a`, 
         end point :math:`b`, area constant :math:`\Omega`,  wave number :math:`k`, and
-        characteristic impedance :math:`Z_0` following Equation (5-18) of Reference [1]_:
+        medium impedance :math:`Z_0` following Equation (5-18) of Reference [1]_:
 
         .. math::
             T = \begin{bmatrix}
@@ -889,33 +889,33 @@ class TransmissionMatrix(FrequencyData):
             >>> pf.plot.freq(T.input_impedance(np.inf))
         """
         if not isinstance(a, Number):
-            raise TypeError("Parameter 'a' must be a number.")
-        elif a <= 0:
-            raise ValueError("Parameter 'a' must be strictly greater than 0.")
+            raise TypeError("The input a must be a number.")
+        elif isinstance(a, complex) or a <= 0:
+            raise ValueError("The input a must be real and strictly greater than 0.")
         if not isinstance(b, Number):
-            raise TypeError("Parameter 'b' must be a number.")
-        elif b <= 0:
-            raise ValueError("Parameter 'b' must be strictly greater than 0.")
+            raise TypeError("The input b must be a number.")
+        elif isinstance(b, complex) or b <= 0:
+            raise ValueError("The input b must be real and strictly greater than 0.")
         if not isinstance(Omega, Number):
-            raise TypeError("Parameter 'Omega' must be a number.")
-        elif Omega <= 0:
-            raise ValueError("Parameter 'Omega' must be strictly greater than 0.")
+            raise TypeError("The input Omega must be a number.")
+        elif isinstance(Omega, complex) or Omega <= 0:
+            raise ValueError("The input Omega must be real and strictly greater than 0.")
         if not isinstance(k, FrequencyData):
-            raise TypeError("The wavenumber 'k' must be a FrequencyData object.")
+            raise TypeError("The wave number k must be a FrequencyData object.")
         else:
             frequencies = k.frequencies
             k = k.freq
         if isinstance(medium_impedance, FrequencyData):
-            if not np.allclose(medium_impedance.frequencies, k.frequencies, atol=1e-15):
-                raise ValueError("The frequencies of 'characteristic_impedance' must match those of 'k'.")
+            if not np.allclose(medium_impedance.frequencies, frequencies, atol=1e-15):
+                raise ValueError("The frequencies of characteristic_impedance must match those of k.")
             else:
                 medium_impedance = medium_impedance.freq
         elif not isinstance(medium_impedance, Number):
-            raise TypeError("Parameter 'characteristic_impedance' must be a number or a FrequencyData object.")
+            raise TypeError("The input medium_impedance must be a number or a FrequencyData object.")
         if not isinstance(direction, str):
-            raise TypeError("Parameter 'direction' must be a string.")
+            raise TypeError("The input direction must be a string.")
         if direction not in ['backwards', 'forwards']:
-            raise ValueError("Parameter 'direction' must be either 'backwards' or 'forwards'.")
+            raise ValueError("The input direction must be either 'backwards' or 'forwards'.")
 
         L = b - a
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -139,10 +139,10 @@ def _compare_tmat_vs_abcd(tmat, A, B, C, D):
         assert tmat.C == C
         assert tmat.D == D
     else:
-        assert np.all(tmat.A.freq == A)
-        assert np.all(tmat.B.freq == B)
-        assert np.all(tmat.C.freq == C)
-        assert np.all(tmat.D.freq == D)
+        assert np.allclose(tmat.A.freq, A, atol=1e-15)
+        assert np.allclose(tmat.B.freq, B, atol=1e-15)
+        assert np.allclose(tmat.C.freq, C, atol=1e-15)
+        assert np.allclose(tmat.D.freq, D, atol=1e-15)
 
 def test_tmatrix_abcd_entries(abcd_data_3x2, abcd_data_3x3x1):
     """Test whether ABCD entries of T-Matrix match ABCD data used for
@@ -337,8 +337,8 @@ def test_create_conical_horn_number():
     b = 0.5
     Omega = 0.4
     
-    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
-    tmat_forwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'forwards')
+    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
+    tmat_forwards = TransmissionMatrix.create_conical_horn(b, a, Omega, k, Z)
 
     A = b/a * np.cos(k.freq*(b-a)) - 1/(k.freq*a) * np.sin(k.freq*(b-a))
     B = 1j * Z / (a*b*Omega) * np.sin(k.freq*(b-a))
@@ -366,8 +366,8 @@ def test_create_conical_horn_frequency_data():
     b = 0.5
     Omega = 0.4
     
-    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
-    tmat_forwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'forwards')
+    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
+    tmat_forwards = TransmissionMatrix.create_conical_horn(b, a, Omega, k, Z)
 
     A = b/a * np.cos(k.freq*(b-a)) - 1/(k.freq*a) * np.sin(k.freq*(b-a))
     B = 1j * Z.freq / (a*b*Omega) * np.sin(k.freq*(b-a))
@@ -394,9 +394,9 @@ def test_create_conical_horn_broadcasting():
     a = 0.3
     b = 0.5
     Omega = 0.4
-    
-    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
-    tmat_forwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'forwards')
+
+    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
+    tmat_forwards = TransmissionMatrix.create_conical_horn(b, a, Omega, k, Z)
 
     A = b/a * np.cos(k.freq*(b-a)) - 1/(k.freq*a) * np.sin(k.freq*(b-a))
     B = 1j * Z.freq / (a*b*Omega) * np.sin(k.freq*(b-a))
@@ -425,7 +425,7 @@ def test_create_conical_horn_a_type_error(a):
     
     with pytest.raises(
         TypeError, match="The input a"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
         
 @pytest.mark.parametrize("a", [0, -5, 2j])
 def test_create_conical_horn_a_value_error(a):
@@ -437,8 +437,8 @@ def test_create_conical_horn_a_value_error(a):
     
     with pytest.raises(
         ValueError, match="The input a"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
-        
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
+
 @pytest.mark.parametrize("b", [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term"])
 def test_create_conical_horn_b_type_error(b):
     """Test `create_transmission_line` error for b input."""
@@ -449,8 +449,8 @@ def test_create_conical_horn_b_type_error(b):
 
     with pytest.raises(
         TypeError, match="The input b"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
-        
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
+
 @pytest.mark.parametrize("b", [0, -5, 2j])
 def test_create_conical_horn_b_value_error(b):
     """Test `create_transmission_line` error for b input."""
@@ -461,7 +461,7 @@ def test_create_conical_horn_b_value_error(b):
 
     with pytest.raises(
         ValueError, match="The input b"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
 
 @pytest.mark.parametrize("Omega", [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term"])
 def test_create_conical_horn_Omega_type_error(Omega):
@@ -473,7 +473,7 @@ def test_create_conical_horn_Omega_type_error(Omega):
 
     with pytest.raises(
         TypeError, match="The input Omega"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
 
 @pytest.mark.parametrize("Omega", [0, -5, 2j])
 def test_create_conical_horn_Omega_value_error(Omega):
@@ -485,7 +485,7 @@ def test_create_conical_horn_Omega_value_error(Omega):
 
     with pytest.raises(
         ValueError, match="The input Omega"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
 
 @pytest.mark.parametrize("k", [2j, np.array([1, 2, 3]), "term"])
 def test_create_conical_horn_k_errors(k):
@@ -497,7 +497,7 @@ def test_create_conical_horn_k_errors(k):
 
     with pytest.raises(
         TypeError, match="The wave number k"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
 
 @pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
 def test_create_conical_horn_medium_impedance_errors(Z):
@@ -509,34 +509,7 @@ def test_create_conical_horn_medium_impedance_errors(Z):
 
     with pytest.raises(
         TypeError, match="The input medium_impedance"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
-
-@pytest.mark.parametrize("direction", [{"a": 1, "b": 2}, np.array([1, 2, 3]), 123, None])
-def test_create_conical_horn_direction_type_error(direction):
-    """Test `create_conical_horn` error for direction input type."""
-    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
-    Z = 4+0.1j
-    a = 0.3
-    b = 0.5
-    Omega = 0.4
-
-    with pytest.raises(
-        TypeError, match="The input direction"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, direction)
-
-@pytest.mark.parametrize("direction", ["invalid", "", "left", "right"])
-def test_create_conical_horn_direction_value_error(direction):
-    """Test `create_conical_horn` error for direction input value."""
-    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
-    Z = 4+0.1j
-    a = 0.3
-    b = 0.5
-    Omega = 0.4
-
-    # Only 'forwards' and 'backwards' are valid
-    with pytest.raises(
-        ValueError, match="The input direction"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, direction)
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
 
 def test_create_conical_horn_frequency_matching():
     """Test `create_conical_horn` frequency matching."""
@@ -549,7 +522,7 @@ def test_create_conical_horn_frequency_matching():
 
     with pytest.raises(
         ValueError, match="The frequencies of"):
-        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z)
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -328,7 +328,7 @@ def test_create_transmission_line_frequency_matching():
         ValueError, match="The frequencies do not match"):
         TransmissionMatrix.create_transmission_line(kl, Z)
 
-def test_create_conical_horn_section_number():
+def test_create_conical_horn_number():
     """Test `create_transmission_line` with impedance as number."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
@@ -337,8 +337,8 @@ def test_create_conical_horn_section_number():
     b = 0.5
     Omega = 0.4
     
-    tmat_backwards = TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
-    tmat_forwards = TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'forwards')
+    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+    tmat_forwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'forwards')
 
     A = b/a * np.cos(k.freq*(b-a)) - 1/(k.freq*a) * np.sin(k.freq*(b-a))
     B = 1j * Z / (a*b*Omega) * np.sin(k.freq*(b-a))
@@ -357,7 +357,7 @@ def test_create_conical_horn_section_number():
         tmat_forwards,
         inv_prefix * D, -1 * inv_prefix * B, -1 * inv_prefix * C, inv_prefix * A)
 
-def test_create_conical_horn_section_frequency_data():
+def test_create_conical_horn_frequency_data():
     """Test `create_transmission_line` with impedance as FrequencyData."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = FrequencyData([1+1j, 2+2j, 3+1j], [1, 2, 3])
@@ -366,8 +366,8 @@ def test_create_conical_horn_section_frequency_data():
     b = 0.5
     Omega = 0.4
     
-    tmat_backwards = TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
-    tmat_forwards = TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'forwards')
+    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+    tmat_forwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'forwards')
 
     A = b/a * np.cos(k.freq*(b-a)) - 1/(k.freq*a) * np.sin(k.freq*(b-a))
     B = 1j * Z.freq / (a*b*Omega) * np.sin(k.freq*(b-a))
@@ -386,7 +386,7 @@ def test_create_conical_horn_section_frequency_data():
         tmat_forwards,
         inv_prefix * D, -1 * inv_prefix * B, -1 * inv_prefix * C, inv_prefix * A)
 
-def test_create_conical_horn_section_broadcasting():
+def test_create_conical_horn_broadcasting():
     """Test `create_transmission_line` broadcasting."""
     k = FrequencyData(np.array([[1j, 2, 3j],[4j, 5, 6j]]) , [1, 2, 3])
     Z = FrequencyData([1+1j, 2+2j, 3+1j], [1, 2, 3])
@@ -395,8 +395,8 @@ def test_create_conical_horn_section_broadcasting():
     b = 0.5
     Omega = 0.4
     
-    tmat_backwards = TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
-    tmat_forwards = TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'forwards')
+    tmat_backwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
+    tmat_forwards = TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'forwards')
 
     A = b/a * np.cos(k.freq*(b-a)) - 1/(k.freq*a) * np.sin(k.freq*(b-a))
     B = 1j * Z.freq / (a*b*Omega) * np.sin(k.freq*(b-a))
@@ -416,7 +416,7 @@ def test_create_conical_horn_section_broadcasting():
         inv_prefix * D, -1 * inv_prefix * B, -1 * inv_prefix * C, inv_prefix * A)
 
 @pytest.mark.parametrize("a", [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term"])
-def test_create_conical_horn_section_a_type_error(a):
+def test_create_conical_horn_a_type_error(a):
     """Test `create_transmission_line` error for a input."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
@@ -425,10 +425,10 @@ def test_create_conical_horn_section_a_type_error(a):
     
     with pytest.raises(
         TypeError, match="The input a"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
         
 @pytest.mark.parametrize("a", [0, -5, 2j])
-def test_create_conical_horn_section_a_value_error(a):
+def test_create_conical_horn_a_value_error(a):
     """Test `create_transmission_line` error for a input."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
@@ -437,10 +437,10 @@ def test_create_conical_horn_section_a_value_error(a):
     
     with pytest.raises(
         ValueError, match="The input a"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
         
 @pytest.mark.parametrize("b", [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term"])
-def test_create_conical_horn_section_b_type_error(b):
+def test_create_conical_horn_b_type_error(b):
     """Test `create_transmission_line` error for b input."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
@@ -449,10 +449,10 @@ def test_create_conical_horn_section_b_type_error(b):
 
     with pytest.raises(
         TypeError, match="The input b"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
         
 @pytest.mark.parametrize("b", [0, -5, 2j])
-def test_create_conical_horn_section_b_value_error(b):
+def test_create_conical_horn_b_value_error(b):
     """Test `create_transmission_line` error for b input."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
@@ -461,11 +461,11 @@ def test_create_conical_horn_section_b_value_error(b):
 
     with pytest.raises(
         ValueError, match="The input b"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
 
 @pytest.mark.parametrize("Omega", [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term"])
-def test_create_conical_horn_section_Omega_type_error(Omega):
-    """Test `create_conical_horn_section` error for Omega input type."""
+def test_create_conical_horn_Omega_type_error(Omega):
+    """Test `create_conical_horn` error for Omega input type."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
     a = 0.3
@@ -473,11 +473,11 @@ def test_create_conical_horn_section_Omega_type_error(Omega):
 
     with pytest.raises(
         TypeError, match="The input Omega"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
 
 @pytest.mark.parametrize("Omega", [0, -5, 2j])
-def test_create_conical_horn_section_Omega_value_error(Omega):
-    """Test `create_conical_horn_section` error for Omega input value."""
+def test_create_conical_horn_Omega_value_error(Omega):
+    """Test `create_conical_horn` error for Omega input value."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
     a = 0.3
@@ -485,11 +485,11 @@ def test_create_conical_horn_section_Omega_value_error(Omega):
 
     with pytest.raises(
         ValueError, match="The input Omega"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
 
 @pytest.mark.parametrize("k", [2j, np.array([1, 2, 3]), "term"])
-def test_create_conical_horn_section_k_errors(k):
-    """Test `create_conical_horn_section` error for k input."""
+def test_create_conical_horn_k_errors(k):
+    """Test `create_conical_horn` error for k input."""
     Z = 4+0.1j
     a = 0.3
     b = 0.5
@@ -497,11 +497,11 @@ def test_create_conical_horn_section_k_errors(k):
 
     with pytest.raises(
         TypeError, match="The wave number k"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
 
 @pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
-def test_create_conical_horn_section_medium_impedance_errors(Z):
-    """Test `create_conical_horn_section` errors for impedance parameter."""
+def test_create_conical_horn_medium_impedance_errors(Z):
+    """Test `create_conical_horn` errors for impedance parameter."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     a = 0.3
     b = 0.5
@@ -509,11 +509,11 @@ def test_create_conical_horn_section_medium_impedance_errors(Z):
 
     with pytest.raises(
         TypeError, match="The input medium_impedance"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
 
 @pytest.mark.parametrize("direction", [{"a": 1, "b": 2}, np.array([1, 2, 3]), 123, None])
-def test_create_conical_horn_section_direction_type_error(direction):
-    """Test `create_conical_horn_section` error for direction input type."""
+def test_create_conical_horn_direction_type_error(direction):
+    """Test `create_conical_horn` error for direction input type."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
     a = 0.3
@@ -522,11 +522,11 @@ def test_create_conical_horn_section_direction_type_error(direction):
 
     with pytest.raises(
         TypeError, match="The input direction"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, direction)
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, direction)
 
 @pytest.mark.parametrize("direction", ["invalid", "", "left", "right"])
-def test_create_conical_horn_section_direction_value_error(direction):
-    """Test `create_conical_horn_section` error for direction input value."""
+def test_create_conical_horn_direction_value_error(direction):
+    """Test `create_conical_horn` error for direction input value."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4+0.1j
     a = 0.3
@@ -536,10 +536,10 @@ def test_create_conical_horn_section_direction_value_error(direction):
     # Only 'forwards' and 'backwards' are valid
     with pytest.raises(
         ValueError, match="The input direction"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, direction)
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, direction)
 
-def test_create_conical_horn_section_frequency_matching():
-    """Test `create_conical_horn_section` frequency matching."""
+def test_create_conical_horn_frequency_matching():
+    """Test `create_conical_horn` frequency matching."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = FrequencyData([1+1j, 2+2j, 3+1j], [1, 2, 4])
     
@@ -549,7 +549,7 @@ def test_create_conical_horn_section_frequency_matching():
 
     with pytest.raises(
         ValueError, match="The frequencies of"):
-        TransmissionMatrix.create_conical_horn_section(a, b, Omega, k, Z, 'backwards')
+        TransmissionMatrix.create_conical_horn(a, b, Omega, k, Z, 'backwards')
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct


### PR DESCRIPTION
### Changes proposed in this pull request:
In the same vein as the `new create_transmission_line` class, this adds support for conical horns to the `TransmissionMatrix` class according to Lampton, 1978 Eq. 5-18.

#### Parameters
- **a, b:** Distances from the horn's narrow (a) and wide (b) end to the virtual point, where the cone's walls would converge
- **Omega ($\Omega$):** Area constant. The horn's cross-sectional area follows $A(l) = \Omega l^2 \quad \forall a\leq l \leq b$
- **k:** Wave number
- **medium_impedance:** The medium impedance. Crucially **not** the characteristic impedance, as due to the varying cross-section, I found relating the medium impedance to it correctly before calling the function to be too error-prone.

#### Points to discuss
##### Medium Impedance
As explained above, I chose to take in the medium impedance and not the characteristic impedance. This is different from the current implementation of the `create_transmission_line` function. If these two should be consistent with each other, some other solution has to be found.

##### Propagation direction
In the standard form (as presented e.g. in Lampton), the horn matrix expresses $p_a$ and $u_a$ at the narrow end in terms of $p_b$ and $u_b$ at the wider end, so it models propagation through the horn "in reverse" (from wide to narrow). If one wants to model propagation from narrow to wide, `a` and `b` have to be switched when calling the function. I find this slightly unintuitive, but kept it like this for now as it corresponds to the standard definition in literature. 

##### Tests
I added tests for the proposed function. However, I checked the reciprocal case by interchanging `a` and `b` when calling and comparing that to the inverse of the desired matrix as these two cases have to be equal. This required changing `_compare_tmat_vs_abcd` to use `np.allclose` instead of `np.all`. 
