### PR TITLE
Fix issue 822: Creating matrix from ABCD doesn't work with scalar values

### DIFF
--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -136,7 +136,7 @@ class TransmissionMatrix(FrequencyData):
     @staticmethod
     def create_frequency_independent_abcd(A, B, C, D):
         """Create a T-matrix from frequency-independentA-, B-, C-, D-data.
-        
+
         Parameters
         ----------
         A : scalar (real or complex)
@@ -152,11 +152,6 @@ class TransmissionMatrix(FrequencyData):
         -------
         np.ndarray
             A 2x2 numpy array representing the transmission matrix.
-            
-        Examples
-        --------
-        >>> import pyfar as pf
-        >>> tmat = pf.TransmissionMatrix.create_frequency_independent_abcd(1, 2, 3, 4)
         """
         if not (
             (isinstance(A, Number) or isinstance(A, complex))

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -277,7 +277,7 @@ def test_tmatrix_create_frequency_independent_abcd():
     assert isinstance(tmat, np.ndarray)
     assert tmat.shape == (2, 2)
     npt.assert_allclose(tmat, [[1, 2], [3, 4]], atol=1e-15)
-    
+
 @pytest.mark.parametrize("wrong_input", ["input", [1,2], (1,2), { 'A':1 }])
 def test_tmatrix_create_frequency_independent_abcd_wrong_input(wrong_input):
     """Test whether creation of frequency-independent ABCD matrix raises
@@ -285,13 +285,17 @@ def test_tmatrix_create_frequency_independent_abcd_wrong_input(wrong_input):
     """
     error_msg = "A, B, C, and D must be scalars"
     with pytest.raises(TypeError, match=error_msg):
-        TransmissionMatrix.create_frequency_independent_abcd(wrong_input, 2, 3, 4)
+        TransmissionMatrix.create_frequency_independent_abcd(
+            wrong_input, 2, 3, 4)
     with pytest.raises(TypeError, match=error_msg):
-        TransmissionMatrix.create_frequency_independent_abcd(1, wrong_input, 3, 4)
+        TransmissionMatrix.create_frequency_independent_abcd(
+            1, wrong_input, 3, 4)
     with pytest.raises(TypeError, match=error_msg):
-        TransmissionMatrix.create_frequency_independent_abcd(1, 2, wrong_input, 4)
+        TransmissionMatrix.create_frequency_independent_abcd(
+            1, 2, wrong_input, 4)
     with pytest.raises(TypeError, match=error_msg):
-        TransmissionMatrix.create_frequency_independent_abcd(1, 2, 3, wrong_input)
+        TransmissionMatrix.create_frequency_independent_abcd(
+            1, 2, 3, wrong_input)
 
 def test_tmatrix_create_identity(frequencies):
     """Test whether creation of identity matrix with frequencies."""


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #822 

### Changes proposed in this pull request:
Inside `from_abcd` the code now checks for instances of type `Number` and converts them to 1D np-arrays using:
```python
A, B, C, D = [np.atleast_1d(np.asarray(param)) if isinstance(param, Number) else param for param in (A, B, C, D)]
```

I've also added tests that test for the correct creation of matrices with all accepted input parameter types as this was missing previously.