### PR TITLE
Exact and nominal center frequencies moved to constants

### DIFF
--- a/pyfar/constants/__init__.py
+++ b/pyfar/constants/__init__.py
@@ -5,6 +5,8 @@ from typing import Final
 from .constants import (
     saturation_vapor_pressure_magnus,
     density_of_air,
+    fractional_octave_frequencies_nominal,
+    fractional_octave_frequencies_exact
 )
 
 from .speed_of_sound import (
@@ -24,6 +26,8 @@ __all__ = [
     'speed_of_sound_cramer',
     'speed_of_sound_ideal_gas',
     'air_attenuation',
+    'fractional_octave_frequencies_nominal',
+    'fractional_octave_frequencies_exact'
 ]
 
 

--- a/tests/test_constants_center_frequencies.py
+++ b/tests/test_constants_center_frequencies.py
@@ -1,0 +1,62 @@
+import numpy as np
+import pytest
+from numpy import testing as npt
+import pyfar
+
+from pyfar.dsp import filter
+from pyfar import FilterSOS, Signal
+import pyfar.constants 
+
+
+
+def test_center_frequencies_iec():
+    nominal_octs = [16, 31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
+    actual_octs = pyfar.constants.fractional_octave_frequencies_nominal()
+    npt.assert_allclose(actual_octs, nominal_octs)
+
+    nominal_thirds = [
+        10, 12.5, 16, 20, 25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 
+        315, 400, 500, 630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 
+        5000, 6300, 8000, 10000, 12500, 16000, 20000]
+    actual_thirds = pyfar.constants.fractional_octave_frequencies_nominal(
+        num_fractions=3, frequency_range=(9, 20e3))
+    npt.assert_allclose(actual_thirds, nominal_thirds)
+
+    with pytest.raises(ValueError, match="lower and upper limit"):
+        pyfar.constants.fractional_octave_frequencies_nominal(frequency_range=(1,))
+
+    with pytest.raises(ValueError, match="lower and upper limit"):
+        pyfar.constants.fractional_octave_frequencies_nominal(frequency_range=(3, 4, 5))
+
+    with pytest.raises(
+            ValueError, match="second frequency needs to be higher"):
+        pyfar.constants.fractional_octave_frequencies_nominal(
+            frequency_range=(8e3, 1e3))
+
+    actual_octs = pyfar.constants.fractional_octave_frequencies_nominal(
+        num_fractions=1, frequency_range=(100, 4e3))
+    nominal_octs_part = [125, 250, 500, 1000, 2000, 4000]
+    npt.assert_allclose(actual_octs, nominal_octs_part)
+
+
+def test_fractional_frequencies_exact():
+    actual_exact = pyfar.constants.fractional_octave_frequencies_exact(
+        num_fractions=1, frequency_range=(4e3, 64e3))
+    npt.assert_allclose(actual_exact, [3981.071706, 7943.282347, 15848.93192, 31622.7766, 63095.73445])
+
+
+def test_fract_oct_bands_non_iec():
+    exact = pyfar.constants.fractional_octave_frequencies_exact(1, (2e3, 20e3))
+    expected = np.array([1995.262315, 3981.071706, 7943.282347, 15848.93192])
+
+    np.testing.assert_allclose(exact, expected)
+
+    frac = 5
+    exact, f_crit = pyfar.constants.fractional_octave_frequencies_exact(
+        frac, (2e3, 20e3), return_cutoff=True)
+
+    octave_ratio = 10**(3/10)
+    np.testing.assert_allclose(
+        f_crit[0], exact*octave_ratio**(-1/2/frac))
+    np.testing.assert_allclose(
+        f_crit[1], exact*octave_ratio**(1/2/frac))


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #815 

### Changes proposed in this pull request:

- The function pyfar.dsp.filter.fractional_octave_frequencies was splitted into pyfar.constants.fractional_octave_frequencies_nominal and pyfar.constants.fractional_octave_frequencies_exact.
- G=2 was replaced by G = 10**(3/10)) ≈ 1.99526 in most calculations. Nmax and Nmin in the fractional_octave_frequencies_exact function are still calculated with the logarithm to base 2 and not to base 1.99526.
- The exact center frequencies are now calculated depending on b. If b is even, the formula f_m = f_r G^{(2x+1)/(2b)} is used. If b is odd f_m = f_r G^{x/b}  is used.
- The frequency range for nominal center frequencies has been expanded. Now it starts at 10Hz for num_fractions = 3 (instead of 25Hz) and at 16Hz for num_fractions = 1 (instead of 31.5 Hz).
- Due to the change in the frequency range, the lower limit frequency for fractional_octave_frequencies_nominal also had to be changed. Now the lower limit frequencies for num_fractions = 3 and num_fractions = 1 are different.

All changes in the calculations were made according to IEC 61260-1:2014 and DIN EN 61672-1:2014-07.