### PR TITLE
BUG: return decible air attenuation as numpy array

### DIFF
--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -30,7 +30,7 @@ def air_attenuation(
 
     Returns
     -------
-    alpha : :py:class:`~pyfar.FrequencyData`
+    alpha : np.ndarray[float]
         Pure tone air attenuation coefficient in decibels per meter for
         atmospheric absorption.
     m : :py:class:`~pyfar.FrequencyData`
@@ -147,17 +147,15 @@ def air_attenuation(
         (T/T_0)**(-5/2)*(0.01275*np.exp(-2239.1/T)*(f_rO + (f**2/f_rO))**(-1)
         +0.1068*np.exp(-3352/T) * (f_rN + (f**2/f_rN))**(-1)))
 
-    alpha = pf.FrequencyData(
-        air_attenuation, frequencies=frequencies)
-
     # Equation 3: ISO 17497-1:2004
-    m = alpha / (10*np.log10(np.exp(1)))
+    m = pf.FrequencyData(
+        air_attenuation / (10*np.log10(np.exp(1))), frequencies=frequencies)
 
     # calculate accuracy
     accuracy = _air_attenuation_accuracy(
-        h, temperature, atmospheric_pressure, frequencies, alpha.freq.shape)
+        h, temperature, atmospheric_pressure, frequencies, m.freq.shape)
 
-    return alpha, m, accuracy
+    return air_attenuation, m, accuracy
 
 
 def _air_attenuation_accuracy(

--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -12,6 +12,7 @@ def air_attenuation(
     Calculation is in accordance with ISO 9613-1 [#]_. The shape of the
     outputs is broadcasted from the shapes of the ``temperature``,
     ``relative_humidity``, and ``atmospheric_pressure``.
+    The frequency bins represents the last dimension.
 
     Parameters
     ----------
@@ -143,19 +144,19 @@ def air_attenuation(
         -4.17*((T/T_0)**(-1/3)-1)))
 
     # air attenuation (Eq. 5)
-    air_attenuation = 8.686*f**2*((1.84e-11*p_r/p_a*(T/T_0)**(1/2)) + \
+    alpha = 8.686*f**2*((1.84e-11*p_r/p_a*(T/T_0)**(1/2)) + \
         (T/T_0)**(-5/2)*(0.01275*np.exp(-2239.1/T)*(f_rO + (f**2/f_rO))**(-1)
         +0.1068*np.exp(-3352/T) * (f_rN + (f**2/f_rN))**(-1)))
 
     # Equation 3: ISO 17497-1:2004
     m = pf.FrequencyData(
-        air_attenuation / (10*np.log10(np.exp(1))), frequencies=frequencies)
+        alpha / (10*np.log10(np.exp(1))), frequencies=frequencies)
 
     # calculate accuracy
     accuracy = _air_attenuation_accuracy(
         h, temperature, atmospheric_pressure, frequencies, m.freq.shape)
 
-    return air_attenuation, m, accuracy
+    return alpha, m, accuracy
 
 
 def _air_attenuation_accuracy(

--- a/tests/test_constants_air_attenuation.py
+++ b/tests/test_constants_air_attenuation.py
@@ -25,7 +25,7 @@ def test_air_attenuation_after_table_iso(
     """
     alpha, m, accuracy = pf.constants.air_attenuation(
         temperature, frequency, relative_humidity)
-    npt.assert_allclose(alpha.freq, expected, atol=1e-3)
+    npt.assert_allclose(alpha, expected, atol=1e-3)
     npt.assert_allclose(accuracy.freq, expected_accuracy)
 
 
@@ -54,11 +54,10 @@ def test_air_attenuation_array(
     alpha, m, accuracy = pf.constants.air_attenuation(
         temperature, frequency, relative_humidity, atmospheric_pressure)
     # test air attenuation alpha
-    expected = 2.16e1*1e-3 + np.zeros_like(alpha.freq[..., 0])
-    npt.assert_allclose(alpha.freq[..., 0], expected, atol=1e-3)
-    npt.assert_allclose(alpha.frequencies, frequency, atol=1e-3)
+    expected = 2.16e1*1e-3 + np.zeros_like(alpha[..., 0])
+    npt.assert_allclose(alpha[..., 0], expected, atol=1e-3)
     # test air attenuation factor m
-    expected = 2.16e1*1e-3/4.34 + np.zeros_like(alpha.freq[..., 0])
+    expected = 2.16e1*1e-3/4.34 + np.zeros_like(alpha[..., 0])
     npt.assert_allclose(m.freq[..., 0], expected, atol=1e-3)
     npt.assert_allclose(m.frequencies, frequency, atol=1e-3)
     # test accuracy


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

kind of followed from the discussion in #825
- no decible values are allowed in FrequencyData

### Changes proposed in this pull request:

- return decible values ``alpha`` as a numpy array instead of FrequencyData
