### PR TITLE
fix bug in case caxis is not iteratable

### DIFF
--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2359,7 +2359,7 @@ def average(signal, mode='linear', caxis=None, weights=None, keepdims=False,
 
     # check if averaging over one dimensional caxis
     if 1 in signal.cshape:
-        for ax in caxis:
+        for ax in np.atleast_1d(caxis):
             if signal.cshape[ax] == 1:
                 warnings.warn(
                     f"Averaging one dimensional caxis={caxis}.", stacklevel=2)

--- a/tests/test_dsp_average.py
+++ b/tests/test_dsp_average.py
@@ -106,10 +106,7 @@ def test_error_raises():
     with pytest.raises(ValueError,
                 match="mode must be 'linear', 'magnitude_zerophase',"):
         pf.dsp.average(signal, mode='invalid_mode')
-    with pytest.warns(UserWarning,
-                      match="Averaging one dimensional caxis"):
-        pf.dsp.average(pf.Signal(np.zeros((5, 2, 1, 1)), 44100), caxis=(1, 2))
-
+    # invalid nan-policy
     with pytest.raises(
             ValueError, match=("nan_policy has to be 'propagate',")):
         pf.dsp.average(pf.Signal(np.zeros((5, 2)), 44100),
@@ -122,3 +119,14 @@ def test_error_raises():
     with pytest.raises(ValueError,
                 match="'power' is not implemented for complex time signals."):
         pf.dsp.average(signal, 'power')
+
+
+@pytest.mark.parametrize('caxis', [2, (1, 2)])
+def test_warnings(caxis):
+    """
+    Test warning for averaging across a channel axis containing a single
+    channel.
+    """
+
+    with pytest.warns(UserWarning, match="Averaging one dimensional caxis"):
+        pf.dsp.average(pf.Signal(np.zeros((5, 2, 1, 1)), 44100), caxis=caxis)


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

An error occurred in `dsp.average` when an integer value was passed for `caxis` and the corresponding axis had only one channel.

### Changes proposed in this pull request:

- force iterable to avoid the error
- expand tests
