### PR TITLE
Feature: Support for pf.Coordinates in the pyfar.utils.broadcast_cshape function

### DIFF
--- a/pyfar/utils.py
+++ b/pyfar/utils.py
@@ -1,9 +1,10 @@
 """
 The utilities contain functions that are helpful when working with multiple
-pyfar audio objects. The pyfar gallery gives background information to
-:ref:`work with audio objects </gallery/interactive/pyfar_audio_objects.ipynb>`
-including an introduction to the channel shape (`cshape`), channel axis
-(`caxis`), and channel dimension (`cdim`).
+pyfar audio and coordinates objects. The pyfar gallery gives background
+information to :ref:`work with audio objects
+</gallery/interactive/pyfar_audio_objects.ipynb>` including an introduction to
+the channel shape (`cshape`), channel axis (`caxis`), and channel dimension
+(`cdim`).
 """
 import pyfar as pf
 import numpy as np
@@ -13,30 +14,37 @@ def broadcast_cshape(signal, cshape):
     """
     Broadcast a signal to a certain cshape.
 
-    The channel shape (`cshape`) gives the shape of the audio data excluding
-    the last dimension, which is ``n_samples`` for time domain objects and
-    ``n_bins`` for frequency domain objects. The broadcasting follows the
+    The channel shape (`cshape`) gives the shape of the audio or coordinates
+    data excluding the last dimension, which is ``n_samples`` for time domain
+    objects, ``n_bins`` for frequency domain objects and always equals ``3``
+    for coordinates. The broadcasting follows the
     :doc:`numpy broadcasting rules <numpy:user/basics.broadcasting>`.
 
     Parameters
     ----------
-    signal : Signal, TimeData, FrequencyData
+    signal : Signal, TimeData, FrequencyData, Coordinates
         The signal to be broadcasted.
     cshape : tuple
         The cshape to which `signal` is broadcasted.
 
     Returns
     -------
-    signal : Signal, TimeData, FrequencyData
+    signal : Signal, TimeData, FrequencyData, Coordinates
         Broadcasted copy of the input signal
     """
 
-    if not isinstance(signal, (pf.Signal, pf.TimeData, pf.FrequencyData)):
-        raise TypeError("Input data must be a pyfar audio object")
+    if not isinstance(signal, (pf.Signal, pf.TimeData, pf.FrequencyData,
+                               pf.Coordinates)):
+        raise TypeError("Input data must be a pyfar audio object or a" \
+        " pyfar coordinates object ")
 
     signal = signal.copy()
-    signal._data = np.broadcast_to(
-        signal._data, cshape + (signal._data.shape[-1], ))
+    if isinstance(signal, (pf.Coordinates)):
+        signal.cartesian = np.broadcast_to(
+                signal.cartesian, cshape + (signal.cartesian.shape[-1], ))
+    else:
+        signal._data = np.broadcast_to(
+            signal._data, cshape + (signal._data.shape[-1], ))
     return signal
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,13 +9,24 @@ import numpy.testing as npt
     pf.TimeData([1, 2, 3], [1, 2, 4]),
     pf.FrequencyData([1, 2, 3], [1, 2, 4])])
 def test_broadcast_cshape(signal):
-    """Test broadcasting for all audio classes."""
+    """Test broadcasting for pf.Signal, pf.TimeData and pf.FrequencyData
+    audio classes.
+    """
 
     broadcasted = pf.utils.broadcast_cshape(signal, (2, 3))
     assert signal.cshape == (1, )
     assert broadcasted.cshape == (2, 3)
     assert isinstance(broadcasted, type(signal))
 
+
+def test_broadcast_cshape_coordinates():
+    """Test broadcasting for the pf.Coordinates class."""
+
+    signal = pf.Coordinates([1, 2, 3, 1], [4, 5, 6, 1], [7, 8, 9, 1])
+    broadcasted = pf.utils.broadcast_cshape(signal, (2, 4))
+    assert signal.cshape == (4, )
+    assert broadcasted.cshape == (2, 4)
+    assert isinstance(broadcasted, type(signal))
 
 def test_broadcast_cshape_assertions():
     """Test assertions."""


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Only partially closes #832

### Changes proposed in this pull request:

- Extension of the [broadcast_cshape](https://pyfar.readthedocs.io/en/stable/modules/pyfar.utils.html#pyfar.utils.broadcast_cshape) function so that an object of the pf.Coordinates class can also be passed as a parameter.
- Additional test function for broadcast_cshape function with pf.Coordinates class object as a parameter.
