### PR TITLE
Feature/conical transmission line

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,7 @@ Added
 - Common acoustic constants are now defined in the module `pyfar.constants`. This includes the speed of sound, air density, air impedance, air temperature, sound attenuation in air, the saturation vapor pressure, reference sound pressure and power, exact and nominal fractional octave frequencies, fractional octave band tolerances, and frequency weighting curves and values (PRs #827, #824, #818, #774, #773, #771, #770, #744, #739, #734, #732)
 - Functions to get and apply A and C-weighting curves standardized in IEC 61672-1. This includes `pyfar.dsp.filter.frequency_weighting_filter` for filtering signals, `pyfar.constants.frequency_weighting_curve` for evaluating the weighting curves at arbitrary frequencies, and `pyfar.constants.frequency_weighting_band_corrections` for obtaining weighting values for nominal (fractional) octave bands (PRs #811, #852)
 - The `pyfar.TransmissionMatrix` can now be created from a transmission line. (PRs #783)
+- The `pyfar.TransmissionMatrix` now has a method `create_conical_horn` to create a conical horn transmission matrix (PR #842)
 - The new class `pyfar.dsp.RegularizedSpectrumInversion` handles regularized inversion. It replaces `pyfar.dsp.regularized_spectrum_inversion` (PR #716)
 - `pyfar.dsp.correlate` to compute the auto or cross correlation between pyfar Signals as a function of the delay applied to one Signal (PR #719, #713, #733)
 - `pyfar.dsp.time_crop` for quickly cropping a pyfar Signal or TimeData object (PR #849)

--- a/docs/resources/plot_shortcuts.rst
+++ b/docs/resources/plot_shortcuts.rst
@@ -64,9 +64,7 @@ Note that not all plots are available for TimeData and FrequencyData objects as 
    * - shift+c
      - toggle colormap unit (see below for more information)
    * - shift+m
-     - toggle showing real, imaginary, or absolute data.
-   * - shift+o
-     - toggle left or right-sided spectrum of complex signals
+     - toggle display of complex audio data (real, imaginary, or absolute time data; left or right-sided spectrum)
    * - shift+a
      - toggle between plotting all channels and plotting single channels
    * - <
@@ -93,5 +91,3 @@ Note that not all plots are available for TimeData and FrequencyData objects as 
 - Toggling the y-axis style is supported by: :py:func:`~pyfar.plot.time`, :py:func:`~pyfar.plot.freq`, :py:func:`~pyfar.plot.phase`, :py:func:`~pyfar.plot.group_delay`, :py:func:`~pyfar.plot.spectrogram`, :py:func:`~pyfar.plot.time_freq`, :py:func:`~pyfar.plot.freq_phase`, :py:func:`~pyfar.plot.freq_group_delay` (and their 2d versions)
 - Toggling the colormap style is supported by all 2d plots
 - Toggling between line and 2D plots is not supported by: :py:func:`~pyfar.plot.spectrogram`
-- Toggling between the left and right sided spectrum is supported by all frequency domain plots of complexSignals,
-- Toggling between absolute, real, and imaginary values is supported for :py:func:`~pyfar.plot.time` and :py:func:`~pyfar.plot.freq` (and their 2d versions) if plotting complex signals.

--- a/docs/resources/plot_shortcuts.rst
+++ b/docs/resources/plot_shortcuts.rst
@@ -64,7 +64,9 @@ Note that not all plots are available for TimeData and FrequencyData objects as 
    * - shift+c
      - toggle colormap unit (see below for more information)
    * - shift+m
-     - toggle display of complex audio data (real, imaginary, or absolute time data; left or right-sided spectrum)
+     - toggle showing real, imaginary, or absolute data.
+   * - shift+o
+     - toggle left or right-sided spectrum of complex signals
    * - shift+a
      - toggle between plotting all channels and plotting single channels
    * - <
@@ -91,3 +93,5 @@ Note that not all plots are available for TimeData and FrequencyData objects as 
 - Toggling the y-axis style is supported by: :py:func:`~pyfar.plot.time`, :py:func:`~pyfar.plot.freq`, :py:func:`~pyfar.plot.phase`, :py:func:`~pyfar.plot.group_delay`, :py:func:`~pyfar.plot.spectrogram`, :py:func:`~pyfar.plot.time_freq`, :py:func:`~pyfar.plot.freq_phase`, :py:func:`~pyfar.plot.freq_group_delay` (and their 2d versions)
 - Toggling the colormap style is supported by all 2d plots
 - Toggling between line and 2D plots is not supported by: :py:func:`~pyfar.plot.spectrogram`
+- Toggling between the left and right sided spectrum is supported by all frequency domain plots of complexSignals,
+- Toggling between absolute, real, and imaginary values is supported for :py:func:`~pyfar.plot.time` and :py:func:`~pyfar.plot.freq` (and their 2d versions) if plotting complex signals.

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -34,7 +34,6 @@ import numpy as np
 import numpy.testing as npt
 from pyfar.classes.audio import FrequencyData
 from pyfar.constants import reference_air_impedance, reference_speed_of_sound
-from numbers import Number
 
 
 class TransmissionMatrix(FrequencyData):

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -941,6 +941,8 @@ class TransmissionMatrix(FrequencyData):
         propagation_direction: str = "expanding",
     ) -> np.ndarray | TransmissionMatrix:
         r"""Create a transmission matrix representing a conical horn.
+        It expresses sound pressure and volume velocity at one end of the horn
+        as a function of sound pressure and volume velocity at the other end.
 
         The transmission matrix is determined based on the surface
         area of the horn's narrow end, the surface area of the
@@ -953,19 +955,19 @@ class TransmissionMatrix(FrequencyData):
 
         .. math::
             \begin{bmatrix}
-                p_1\quad[Pa] \\
-                q_1\quad[m^3/s]
+            p_1\quad[Pa] \\
+            q_1\quad[m^3/s]
             \end{bmatrix}
             =
             \begin{bmatrix}
-                \frac{b}{a}\cos(kl) - \frac{1}{ka}\sin(kl) &
-                \frac{jZ_0}{ab\Omega}\sin(kl) \\[6pt]
-                \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab)\sin(kl) - kl\cos(kl) \right) &
-                \frac{a}{b}\cos(kl) - \frac{1}{kb}\sin(kl)
+            \frac{b}{a}\cos(kl) - \frac{1}{ka}\sin(kl) &
+            \frac{jZ_0}{ab\Omega}\sin(kl) \\[6pt]
+            \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab)\sin(kl) - kl\cos(kl) \right) &
+            \frac{a}{b}\cos(kl) - \frac{1}{kb}\sin(kl)
             \end{bmatrix}
             \begin{bmatrix}
-                p_2\quad[Pa] \\
-                q_2\quad[m^3/s]
+            p_2\quad[Pa] \\
+            q_2\quad[m^3/s]
             \end{bmatrix}
 
         Parameters

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -893,7 +893,7 @@ class TransmissionMatrix(FrequencyData):
 
         Returns
         -------
-        tuple[float, float, float]
+        Omega, a, b: tuple[float, float, float]
             A tuple containing the area constant Omega, the distance a from the
             narrow end to the virtual apex of the cone, and the distance b from
             the wide end to the same virtual apex.
@@ -914,23 +914,11 @@ class TransmissionMatrix(FrequencyData):
 
         r0 = np.sqrt(S0 / np.pi)
         r1 = np.sqrt(S1 / np.pi)
-
-        d0 = 2 * r0
-        d1 = 2 * r1
-
-        a = r0 * (2 * L) / (d1 - d0)
+        
+        a = r0 * L / (r1 - r0)
         b = a + L
 
-        Omega0 = S0 / a**2
-        Omega1 = S1 / b**2
-
-        if not np.isclose(Omega0, Omega1, atol=1e-15):
-            raise ValueError(
-                f"S0/a² is not equal to S1/b²: {Omega0} != {Omega1}."
-                "This should never happen.",
-            )
-
-        Omega = Omega0  # or Omega1, they are equal
+        Omega = S0 / a**2   # equal to S1 / b**2
 
         return Omega, a, b
 
@@ -947,7 +935,7 @@ class TransmissionMatrix(FrequencyData):
 
         The transmission matrix is determined based on the surface
         area of the horn's narrow end, the surface area of the
-        horn's wide end, the horn's length, wave number, and
+        horn's wide end, the horn's length, wavenumber, and
         medium impedance.The surface areas are internally
         transformed into starting point :math:`a`,
         end point :math:`b`, and area constant :math:`\Omega`
@@ -972,7 +960,7 @@ class TransmissionMatrix(FrequencyData):
             The distance between the narrow and wide end of the horn,
             i.e. the horn's length.
         wave_number : FrequencyData, scalar
-            Wave number.
+            Wavenumber.
         medium_impedance : FrequencyData, scalar
             The impedance of the medium filling the horn. Default is
             ``pyfar.constants.reference_air_impedance``
@@ -1014,7 +1002,7 @@ class TransmissionMatrix(FrequencyData):
         if not (isinstance(wave_number, FrequencyData)
                 or isinstance(wave_number, Number)):
             raise TypeError(
-                "The wave number k must be a float, complex, "
+                "The wavenumber k must be a float, complex, "
                 "or FrequencyData object.",
             )
         elif isinstance(wave_number, FrequencyData):
@@ -1079,8 +1067,8 @@ class TransmissionMatrix(FrequencyData):
             / (a * b * Omega) * np.sin(wave_number * horn_length))
         C = (
             1j * Omega
-            / (wave_number * wave_number * medium_impedance)
-            * ((1 + wave_number * wave_number * a * b)
+            / (wave_number ** 2 * medium_impedance)
+            * ((1 + wave_number ** 2 * a * b)
             * np.sin(wave_number * horn_length) - wave_number * horn_length
             * np.cos(wave_number * horn_length))
         )

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -884,16 +884,16 @@ class TransmissionMatrix(FrequencyData):
 
         Parameters
         ----------
-        area_narrow_end : float
+        area_narrow_end : Number
             Cross-sectional area at the narrow end of the horn.
-        area_wide_end : float
+        area_wide_end : Number
             Cross-sectional area at the wide end of the horn.
-        horn_length : float
+        horn_length : Number
             Length of the horn.
 
         Returns
         -------
-        Omega, a, b: tuple[float, float, float]
+        Omega, a, b: tuple[Number, Number, Number]
             A tuple containing the area constant Omega, the distance a from the
             narrow end to the virtual apex of the cone, and the distance b from
             the wide end to the same virtual apex.
@@ -939,7 +939,7 @@ class TransmissionMatrix(FrequencyData):
         wave_number: Number | FrequencyData,
         medium_impedance: Number | FrequencyData = reference_air_impedance,
         propagation_direction: str = "forwards",
-    ) -> TransmissionMatrix:
+    ) -> np.ndarray | TransmissionMatrix:
         r"""Create a transmission matrix representing a conical horn.
 
         The transmission matrix is determined based on the surface
@@ -961,11 +961,11 @@ class TransmissionMatrix(FrequencyData):
 
         Parameters
         ----------
-        area_narrow_end : float
+        area_narrow_end : Number
             The surface area of the horn's narrow end.
-        area_wide_end : float
+        area_wide_end : Number
             The surface area of the horn's wide end.
-        horn_length : float
+        horn_length : Number
             The distance between the narrow and wide end of the horn,
             i.e. the horn's length.
         wave_number : FrequencyData, scalar
@@ -1008,21 +1008,18 @@ class TransmissionMatrix(FrequencyData):
             >>> pf.plot.freq(T.input_impedance(np.inf))
 
         """
-        if not (isinstance(wave_number, FrequencyData)
-                or isinstance(wave_number, Number)):
+        if isinstance(wave_number, FrequencyData):
+            frequencies = wave_number.frequencies
+            wave_number = wave_number.freq
+            singular_frequency = False
+        elif isinstance(wave_number, complex) or isinstance(wave_number, Number):
+            frequencies = []
+            singular_frequency = True
+        else:
             raise TypeError(
                 "The wavenumber k must be a float, complex, "
                 "or FrequencyData object.",
             )
-        elif isinstance(wave_number, FrequencyData):
-            frequencies = wave_number.frequencies
-            wave_number = wave_number.freq
-        else:
-            if isinstance(wave_number, complex):
-                k_re = wave_number.real
-            else:
-                k_re = wave_number
-            frequencies = (k_re * reference_speed_of_sound) / (2 * np.pi)
         if isinstance(medium_impedance, FrequencyData):
             if not np.allclose(
                 medium_impedance.frequencies,
@@ -1084,7 +1081,10 @@ class TransmissionMatrix(FrequencyData):
         D = (a / b * np.cos(wave_number * horn_length)
             + 1 / (wave_number * b) * np.sin(wave_number * horn_length))
 
-        return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)
+        if(singular_frequency == False):
+            return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)
+        else:
+            return TransmissionMatrix.create_frequency_independent_abcd(A, B, C, D)
 
     def __repr__(self):
         """String representation of TransmissionMatrix class."""

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -1014,6 +1014,7 @@ class TransmissionMatrix(FrequencyData):
             singular_frequency = False
         elif isinstance(wave_number, complex) \
             or isinstance(wave_number, Number):
+            k = wave_number
             frequencies = []
             singular_frequency = True
         else:

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -912,10 +912,7 @@ class TransmissionMatrix(FrequencyData):
             or isinstance(horn_length, complex) or horn_length <= 0:
             raise ValueError("The input horn_length "
                              "must be a positive real number.")
-        if area_narrow_end > area_wide_end:
-            raise ValueError("area_narrow_end must be "
-                             "strictly smaller than area_wide_end.")
-        if area_narrow_end == area_wide_end:
+        if area_narrow_end >= area_wide_end:
             raise ValueError(
                 "For a conical horn area_narrow_end "
                 "must be strictly smaller than area_wide_end."

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -952,12 +952,21 @@ class TransmissionMatrix(FrequencyData):
         matrix following Equation (5-18) of Reference [1]_:
 
         .. math::
-            T = \begin{bmatrix}
-                \frac{b}{a}cos(kl)-\frac{1}{ka}sin(kl) &
-                \frac{jZ_0}{ab\Omega} \sin{kl} \\
-                \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab) \sin{kl} -
-                kl \cos{kl} \right) & \frac{a}{b}cos(kl)-\frac{1}{kb}sin(kl)
-                \end{bmatrix}
+            \begin{bmatrix}
+                p_1\quad[Pa] \\
+                q_1\quad[m^3/s]
+            \end{bmatrix}
+            =
+            \begin{bmatrix}
+                \frac{b}{a}\cos(kl) - \frac{1}{ka}\sin(kl) &
+                \frac{jZ_0}{ab\Omega}\sin(kl) \\[6pt]
+                \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab)\sin(kl) - kl\cos(kl) \right) &
+                \frac{a}{b}\cos(kl) - \frac{1}{kb}\sin(kl)
+            \end{bmatrix}
+            \begin{bmatrix}
+                p_2\quad[Pa] \\
+                q_2\quad[m^3/s]
+            \end{bmatrix}
 
         Parameters
         ----------

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -33,6 +33,8 @@ from numbers import Number
 import numpy as np
 import numpy.testing as npt
 from pyfar.classes.audio import FrequencyData
+from pyfar.constants import reference_air_impedance, reference_speed_of_sound
+from numbers import Number
 
 
 class TransmissionMatrix(FrequencyData):
@@ -873,6 +875,210 @@ class TransmissionMatrix(FrequencyData):
         return TransmissionMatrix.from_abcd(
             A, B, C, D, kl.frequencies)
 
+    @staticmethod
+    def _calculate_horn_geometry_parameters(
+        S0: Number,
+        S1: Number,
+        L: Number,
+    ) -> tuple[Number, Number, Number]:
+        """Calculate the geometry parameters of a conical horn.
+
+        Parameters
+        ----------
+        S0 : float
+            Cross-sectional area at the narrow end of the horn.
+        S1 : float
+            Cross-sectional area at the wide end of the horn.
+        L : float
+            Length of the horn.
+
+        Returns
+        -------
+        tuple[float, float, float]
+            A tuple containing the area constant Omega, the distance a from the
+            narrow end to the virtual apex of the cone, and the distance b from
+            the wide end to the same virtual apex.
+        """
+        if not isinstance(S0, Number) or isinstance(S0, complex) or S0 <= 0:
+            raise ValueError("The input S0 must be a positive number.")
+        if not isinstance(S1, Number) or isinstance(S1, complex) or S1 <= 0:
+            raise ValueError("The input S1 must be a positive number.")
+        if not isinstance(L, Number) or isinstance(L, complex) or L <= 0:
+            raise ValueError("The input L must be a positive number.")
+        if S0 > S1:
+            raise ValueError("S0 must be strictly smaller than S1.")
+        if S0 == S1:
+            raise ValueError(
+                "For a conical horn S0 must be strictly smaller than S1."
+                "If S0 == S1, use :fun:`create_transmission_line` instead.",
+            )
+
+        r0 = np.sqrt(S0 / np.pi)
+        r1 = np.sqrt(S1 / np.pi)
+
+        d0 = 2 * r0
+        d1 = 2 * r1
+
+        a = r0 * (2 * L) / (d1 - d0)
+        b = a + L
+
+        Omega0 = S0 / a**2
+        Omega1 = S1 / b**2
+
+        if not np.isclose(Omega0, Omega1, atol=1e-15):
+            raise ValueError(
+                f"S0/a² is not equal to S1/b²: {Omega0} != {Omega1}."
+                "This should never happen.",
+            )
+
+        Omega = Omega0  # or Omega1, they are equal
+
+        return Omega, a, b
+
+    @staticmethod
+    def create_conical_horn(
+        S0: Number,
+        S1: Number,
+        L: Number,
+        k: Number | FrequencyData,
+        medium_impedance: Number | FrequencyData = reference_air_impedance,
+        propagation_direction: str = "forwards",
+    ) -> TransmissionMatrix:
+        r"""Create a transmission matrix representing a conical horn.
+
+        The transmission matrix is calculated based on the starting point
+        :math:`a`, end point :math:`b`, area constant :math:`\Omega`,
+        wave number :math:`k`, and medium impedance :math:`Z_0`
+        following Equation (5-18) of Reference [1]_:
+
+        .. math::
+            T = \begin{bmatrix}
+                \frac{b}{a}cos(kl)-\frac{1}{ka}sin(kl) &
+                \frac{jZ_0}{ab\Omega} \sin{kl} \\
+                \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab) \sin{kl} -
+                kl \cos{kl} \right) & \frac{a}{b}cos(kl)-\frac{1}{kb}sin(kl)
+                \end{bmatrix}
+
+        Parameters
+        ----------
+        S0 : float
+            The surface area of the horn's narrow end.
+        S1 : float
+            The surface area of the horn's wide end.
+        L : float
+            The distance between the narrow and wide end of the horn,
+            i.e. the horn's length.
+        k : FrequencyData, scalar
+            Wave number.
+        medium_impedance : FrequencyData, scalar
+            The impedance of the medium filling the horn. Defautl is
+            ``pyfar.constants.reference_air_impedance``
+        propagation_direction: str = {'forwards', 'backwards'}
+            Defines the direction of sound propagation through the horn,
+            where ``'forwards'`` means from narrow to wide end
+            and ``'backwards'`` means from wide to narrow end.
+            Default is ``'forwards'``.
+
+        Returns
+        -------
+        pf.TransmissionMatrix
+            Transmission matrix for the conical horn section.
+
+        Example
+        -------
+        Arbitrarily sized lossless conical horn section.
+
+        .. plot::
+
+            >>> import pyfar as pf
+            >>> import numpy as np
+            >>> # Horn parameters
+            >>> S0 = 0.003
+            >>> S1 = 0.005
+            >>> L = 0.3
+            >>> frequencies = np.linspace(20, 20e3, 1000)
+            >>> omega = 2 * np.pi * frequencies
+            >>> k = pf.FrequencyData(
+            >>>    omega / pf.constants.reference_speed_of_sound, frequencies)
+            >>> Z0 = pf.constants.reference_air_impedance
+            >>> # Create the transmission matrix
+            >>> T = pf.TransmissionMatrix.create_conical_horn(
+            >>>    S0, S1, L, k, Z0, 'backwards')
+            >>> # Plot the transmission matrix
+            >>> pf.plot.freq(T.input_impedance(np.inf))
+
+        """
+        if not (isinstance(k, FrequencyData) or isinstance(k, Number)):
+            raise TypeError(
+                "The wave number k must be a float, complex,"
+                "or FrequencyData object.",
+            )
+        elif isinstance(k, FrequencyData):
+            frequencies = k.frequencies
+            k = k.freq
+        else:
+            if isinstance(k, complex):
+                k_re = k.real
+            else:
+                k_re = k
+            frequencies = (k_re * reference_speed_of_sound) / (2 * np.pi)
+        if isinstance(medium_impedance, FrequencyData):
+            if not np.allclose(
+                medium_impedance.frequencies,
+                frequencies,
+                atol=1e-15,
+            ):
+                raise ValueError(
+                    "The frequencies of characteristic_impedance must"
+                    "match those of k.",
+                )
+            else:
+                medium_impedance = medium_impedance.freq
+        elif not isinstance(medium_impedance, Number):
+            raise TypeError(
+                "The input medium_impedance must be a number"
+                "or a FrequencyData object.",
+            )
+        if not isinstance(propagation_direction, str):
+            raise TypeError(
+                "The input propagation_direction must be a string"
+                "with value 'forwards' or 'backwards'.",
+            )
+        if propagation_direction not in ("forwards", "backwards"):
+            raise ValueError(
+                "The string propagation_direction must either be"
+                "'forwards' or 'backwards'.",
+            )
+
+        if propagation_direction == "backwards":
+            Omega, a, b = (
+                TransmissionMatrix._calculate_horn_geometry_parameters(
+                    S0,
+                    S1,
+                    L,
+                )
+            )  # Error handling inside the helper function
+        else:
+            Omega, b, a = (
+                TransmissionMatrix._calculate_horn_geometry_parameters(
+                    S0,
+                    S1,
+                    L,
+                )
+            )  # Error handling inside the helper function
+            L = -1 * L
+
+        A = b / a * np.cos(k * L) - 1 / (k * a) * np.sin(k * L)
+        B = 1j * medium_impedance / (a * b * Omega) * np.sin(k * L)
+        C = (
+            1j
+            * Omega
+            / (k * k * medium_impedance)
+            * ((1 + k * k * a * b) * np.sin(k * L) - k * L * np.cos(k * L))
+        )
+        D = a / b * np.cos(k * L) + 1 / (k * b) * np.sin(k * L)
+
+        return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)
 
     def __repr__(self):
         """String representation of TransmissionMatrix class."""

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -33,7 +33,7 @@ from numbers import Number
 import numpy as np
 import numpy.testing as npt
 from pyfar.classes.audio import FrequencyData
-from pyfar.constants import reference_air_impedance, reference_speed_of_sound
+from pyfar.constants import reference_air_impedance
 
 
 class TransmissionMatrix(FrequencyData):
@@ -1012,7 +1012,8 @@ class TransmissionMatrix(FrequencyData):
             frequencies = wave_number.frequencies
             wave_number = wave_number.freq
             singular_frequency = False
-        elif isinstance(wave_number, complex) or isinstance(wave_number, Number):
+        elif isinstance(wave_number, complex) \
+            or isinstance(wave_number, Number):
             frequencies = []
             singular_frequency = True
         else:
@@ -1081,10 +1082,11 @@ class TransmissionMatrix(FrequencyData):
         D = (a / b * np.cos(wave_number * horn_length)
             + 1 / (wave_number * b) * np.sin(wave_number * horn_length))
 
-        if(singular_frequency == False):
+        if not singular_frequency:
             return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)
         else:
-            return TransmissionMatrix.create_frequency_independent_abcd(A, B, C, D)
+            return TransmissionMatrix.\
+                        create_frequency_independent_abcd(A, B, C, D)
 
     def __repr__(self):
         """String representation of TransmissionMatrix class."""

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -971,7 +971,7 @@ class TransmissionMatrix(FrequencyData):
         k : FrequencyData, scalar
             Wave number.
         medium_impedance : FrequencyData, scalar
-            The impedance of the medium filling the horn. Defautl is
+            The impedance of the medium filling the horn. Default is
             ``pyfar.constants.reference_air_impedance``
         propagation_direction: str = {'forwards', 'backwards'}
             Defines the direction of sound propagation through the horn,

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -1009,7 +1009,7 @@ class TransmissionMatrix(FrequencyData):
         """
         if not (isinstance(k, FrequencyData) or isinstance(k, Number)):
             raise TypeError(
-                "The wave number k must be a float, complex,"
+                "The wave number k must be a float, complex, "
                 "or FrequencyData object.",
             )
         elif isinstance(k, FrequencyData):
@@ -1028,7 +1028,7 @@ class TransmissionMatrix(FrequencyData):
                 atol=1e-15,
             ):
                 raise ValueError(
-                    "The frequencies of characteristic_impedance must"
+                    "The frequencies of characteristic_impedance must "
                     "match those of k.",
                 )
             else:
@@ -1040,7 +1040,7 @@ class TransmissionMatrix(FrequencyData):
             )
         if propagation_direction not in ("forwards", "backwards"):
             raise ValueError(
-                "The string propagation_direction must either be"
+                "The string propagation_direction must either be "
                 "'forwards' or 'backwards'.",
             )
 

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -1038,6 +1038,11 @@ class TransmissionMatrix(FrequencyData):
                 "The input medium_impedance must be a number"
                 "or a FrequencyData object.",
             )
+        if not isinstance(propagation_direction, str):
+            raise TypeError(
+            "The input propagation_direction must be a string"
+            "with value 'forwards' or 'backwards'.",
+            )
         if propagation_direction not in ("forwards", "backwards"):
             raise ValueError(
                 "The string propagation_direction must either be "
@@ -1062,6 +1067,7 @@ class TransmissionMatrix(FrequencyData):
             )  # Error handling inside the helper function
             L = -1 * L
 
+        # Calculate T-matrix entries according to Equation (5-18) of [1]
         A = b / a * np.cos(k * L) - 1 / (k * a) * np.sin(k * L)
         B = 1j * medium_impedance / (a * b * Omega) * np.sin(k * L)
         C = (

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -946,7 +946,7 @@ class TransmissionMatrix(FrequencyData):
         The transmission matrix is determined based on the surface
         area of the horn's narrow end, the surface area of the
         horn's wide end, the horn's length, wavenumber, and
-        medium impedance.The surface areas are internally
+        medium impedance. The surface areas are internally
         transformed into starting point :math:`a`,
         end point :math:`b`, and area constant :math:`\Omega`
         of the horn to calculate the transmission

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -938,7 +938,7 @@ class TransmissionMatrix(FrequencyData):
         horn_length: Number,
         wave_number: Number | FrequencyData,
         medium_impedance: Number | FrequencyData = reference_air_impedance,
-        propagation_direction: str = "forwards",
+        propagation_direction: str = "forward",
     ) -> np.ndarray | TransmissionMatrix:
         r"""Create a transmission matrix representing a conical horn.
 
@@ -973,11 +973,11 @@ class TransmissionMatrix(FrequencyData):
         medium_impedance : FrequencyData, scalar
             The impedance of the medium filling the horn. Default is
             ``pyfar.constants.reference_air_impedance``
-        propagation_direction : {'forwards', 'backwards'}
+        propagation_direction : {'forward', 'backwards'}, optional
             Defines the direction of sound propagation through the horn,
-            where ``'forwards'`` means from narrow to wide end
-            and ``'backwards'`` means from wide to narrow end.
-            Default is ``'forwards'``.
+            where ``'forward'`` means from narrow to wide end
+            and ``'backward'`` means from wide to narrow end.
+            Default is ``'forward'``.
 
         Returns
         -------
@@ -1041,15 +1041,15 @@ class TransmissionMatrix(FrequencyData):
         if not isinstance(propagation_direction, str):
             raise TypeError(
             "The input propagation_direction must be a string"
-            "with value 'forwards' or 'backwards'.",
+            "with value 'forward' or 'backward'.",
             )
-        if propagation_direction not in ("forwards", "backwards"):
+        if propagation_direction not in ("forward", "backward"):
             raise ValueError(
                 "The string propagation_direction must either be "
-                "'forwards' or 'backwards'.",
+                "'forward' or 'backward'.",
             )
 
-        if propagation_direction == "backwards":
+        if propagation_direction == "backward":
             Omega, a, b = (
                 TransmissionMatrix._calculate_horn_geometry_parameters(
                     area_narrow_end,

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -893,10 +893,12 @@ class TransmissionMatrix(FrequencyData):
 
         Returns
         -------
-        Omega, a, b: tuple[Number, Number, Number]
-            A tuple containing the area constant Omega, the distance a from the
-            narrow end to the virtual apex of the cone, and the distance b from
-            the wide end to the same virtual apex.
+        Omega : Number
+            The area constant.
+        a : Number
+            The distance from the narrow end to the virtual apex of the cone.
+        b : Number
+            The distance from the wide end to the same virtual apex.
         """
         if not isinstance(area_narrow_end, Number) \
             or isinstance(area_narrow_end, complex) or area_narrow_end <= 0:

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -1038,11 +1038,6 @@ class TransmissionMatrix(FrequencyData):
                 "The input medium_impedance must be a number"
                 "or a FrequencyData object.",
             )
-        if not isinstance(propagation_direction, str):
-            raise TypeError(
-                "The input propagation_direction must be a string"
-                "with value 'forwards' or 'backwards'.",
-            )
         if propagation_direction not in ("forwards", "backwards"):
             raise ValueError(
                 "The string propagation_direction must either be"

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -1010,7 +1010,7 @@ class TransmissionMatrix(FrequencyData):
         """
         if isinstance(wave_number, FrequencyData):
             frequencies = wave_number.frequencies
-            wave_number = wave_number.freq
+            k = wave_number.freq
             singular_frequency = False
         elif isinstance(wave_number, complex) \
             or isinstance(wave_number, Number):
@@ -1018,7 +1018,7 @@ class TransmissionMatrix(FrequencyData):
             singular_frequency = True
         else:
             raise TypeError(
-                "The wavenumber k must be a float, complex, "
+                "wave_number must be a float, complex, "
                 "or FrequencyData object.",
             )
         if isinstance(medium_impedance, FrequencyData):
@@ -1028,16 +1028,18 @@ class TransmissionMatrix(FrequencyData):
                 atol=1e-15,
             ):
                 raise ValueError(
-                    "The frequencies of characteristic_impedance must "
-                    "match those of k.",
+                    "The frequencies of medium_impedance must "
+                    "match those of wave_number.",
                 )
             else:
-                medium_impedance = medium_impedance.freq
+                Z = medium_impedance.freq
         elif not isinstance(medium_impedance, Number):
             raise TypeError(
-                "The input medium_impedance must be a number"
+                "The input medium_impedance must be a number "
                 "or a FrequencyData object.",
             )
+        else:
+            Z = medium_impedance
         if not isinstance(propagation_direction, str):
             raise TypeError(
             "The input propagation_direction must be a string"
@@ -1068,19 +1070,19 @@ class TransmissionMatrix(FrequencyData):
             horn_length = -1 * horn_length
 
         # Calculate T-matrix entries according to Equation (5-18) of [1]
-        A = (b / a * np.cos(wave_number * horn_length)
-            - 1 / (wave_number * a) * np.sin(wave_number * horn_length))
-        B = (1j * medium_impedance
-            / (a * b * Omega) * np.sin(wave_number * horn_length))
+        A = (b / a * np.cos(k * horn_length)
+            - 1 / (k * a) * np.sin(k * horn_length))
+        B = (1j * Z
+            / (a * b * Omega) * np.sin(k * horn_length))
         C = (
             1j * Omega
-            / (wave_number ** 2 * medium_impedance)
-            * ((1 + wave_number ** 2 * a * b)
-            * np.sin(wave_number * horn_length) - wave_number * horn_length
-            * np.cos(wave_number * horn_length))
+            / (k ** 2 * Z)
+            * ((1 + k ** 2 * a * b)
+            * np.sin(k * horn_length) - k * horn_length
+            * np.cos(k * horn_length))
         )
-        D = (a / b * np.cos(wave_number * horn_length)
-            + 1 / (wave_number * b) * np.sin(wave_number * horn_length))
+        D = (a / b * np.cos(k * horn_length)
+            + 1 / (k * b) * np.sin(k * horn_length))
 
         if not singular_frequency:
             return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -972,7 +972,7 @@ class TransmissionMatrix(FrequencyData):
         medium_impedance : FrequencyData, scalar
             The impedance of the medium filling the horn. Default is
             ``pyfar.constants.reference_air_impedance``
-        propagation_direction: str = {'forwards', 'backwards'}
+        propagation_direction : {'forwards', 'backwards'}
             Defines the direction of sound propagation through the horn,
             where ``'forwards'`` means from narrow to wide end
             and ``'backwards'`` means from wide to narrow end.

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -876,19 +876,19 @@ class TransmissionMatrix(FrequencyData):
 
     @staticmethod
     def _calculate_horn_geometry_parameters(
-        S0: Number,
-        S1: Number,
-        L: Number,
+        area_narrow_end: Number,
+        area_wide_end: Number,
+        horn_length: Number,
     ) -> tuple[Number, Number, Number]:
         """Calculate the geometry parameters of a conical horn.
 
         Parameters
         ----------
-        S0 : float
+        area_narrow_end : float
             Cross-sectional area at the narrow end of the horn.
-        S1 : float
+        area_wide_end : float
             Cross-sectional area at the wide end of the horn.
-        L : float
+        horn_length : float
             Length of the horn.
 
         Returns
@@ -898,27 +898,27 @@ class TransmissionMatrix(FrequencyData):
             narrow end to the virtual apex of the cone, and the distance b from
             the wide end to the same virtual apex.
         """
-        if not isinstance(S0, Number) or isinstance(S0, complex) or S0 <= 0:
+        if not isinstance(area_narrow_end, Number) or isinstance(area_narrow_end, complex) or area_narrow_end <= 0:
             raise ValueError("The input S0 must be a positive real number.")
-        if not isinstance(S1, Number) or isinstance(S1, complex) or S1 <= 0:
+        if not isinstance(area_wide_end, Number) or isinstance(area_wide_end, complex) or area_wide_end <= 0:
             raise ValueError("The input S1 must be a positive real number.")
-        if not isinstance(L, Number) or isinstance(L, complex) or L <= 0:
+        if not isinstance(horn_length, Number) or isinstance(horn_length, complex) or horn_length <= 0:
             raise ValueError("The input L must be a positive real number.")
-        if S0 > S1:
+        if area_narrow_end > area_wide_end:
             raise ValueError("S0 must be strictly smaller than S1.")
-        if S0 == S1:
+        if area_narrow_end == area_wide_end:
             raise ValueError(
                 "For a conical horn S0 must be strictly smaller than S1."
                 "If S0 == S1, use :fun:`create_transmission_line` instead.",
             )
 
-        r0 = np.sqrt(S0 / np.pi)
-        r1 = np.sqrt(S1 / np.pi)
+        r0 = np.sqrt(area_narrow_end / np.pi)
+        r1 = np.sqrt(area_wide_end / np.pi)
         
-        a = r0 * L / (r1 - r0)
-        b = a + L
+        a = r0 * horn_length / (r1 - r0)
+        b = a + horn_length
 
-        Omega = S0 / a**2   # equal to S1 / b**2
+        Omega = area_narrow_end / a**2   # equal to S1 / b**2
 
         return Omega, a, b
 

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -898,23 +898,32 @@ class TransmissionMatrix(FrequencyData):
             narrow end to the virtual apex of the cone, and the distance b from
             the wide end to the same virtual apex.
         """
-        if not isinstance(area_narrow_end, Number) or isinstance(area_narrow_end, complex) or area_narrow_end <= 0:
-            raise ValueError("The input S0 must be a positive real number.")
-        if not isinstance(area_wide_end, Number) or isinstance(area_wide_end, complex) or area_wide_end <= 0:
-            raise ValueError("The input S1 must be a positive real number.")
-        if not isinstance(horn_length, Number) or isinstance(horn_length, complex) or horn_length <= 0:
-            raise ValueError("The input L must be a positive real number.")
+        if not isinstance(area_narrow_end, Number) \
+            or isinstance(area_narrow_end, complex) or area_narrow_end <= 0:
+            raise ValueError("The input area_narrow_end "
+                             "must be a positive real number.")
+        if not isinstance(area_wide_end, Number) \
+            or isinstance(area_wide_end, complex) or area_wide_end <= 0:
+            raise ValueError("The input area_wide_end "
+                             "must be a positive real number.")
+        if not isinstance(horn_length, Number) \
+            or isinstance(horn_length, complex) or horn_length <= 0:
+            raise ValueError("The input horn_length "
+                             "must be a positive real number.")
         if area_narrow_end > area_wide_end:
-            raise ValueError("S0 must be strictly smaller than S1.")
+            raise ValueError("area_narrow_end must be "
+                             "strictly smaller than area_wide_end.")
         if area_narrow_end == area_wide_end:
             raise ValueError(
-                "For a conical horn S0 must be strictly smaller than S1."
-                "If S0 == S1, use :fun:`create_transmission_line` instead.",
+                "For a conical horn area_narrow_end "
+                "must be strictly smaller than area_wide_end."
+                "If area_narrow_end == area_wide_end, "
+                "use :fun:`create_transmission_line` instead.",
             )
 
         r0 = np.sqrt(area_narrow_end / np.pi)
         r1 = np.sqrt(area_wide_end / np.pi)
-        
+
         a = r0 * horn_length / (r1 - r0)
         b = a + horn_length
 

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -936,19 +936,22 @@ class TransmissionMatrix(FrequencyData):
 
     @staticmethod
     def create_conical_horn(
-        S0: Number,
-        S1: Number,
-        L: Number,
-        k: Number | FrequencyData,
+        area_narrow_end: Number,
+        area_wide_end: Number,
+        horn_length: Number,
+        wave_number: Number | FrequencyData,
         medium_impedance: Number | FrequencyData = reference_air_impedance,
         propagation_direction: str = "forwards",
     ) -> TransmissionMatrix:
         r"""Create a transmission matrix representing a conical horn.
 
-        The transmission matrix is calculated based on the starting point
-        :math:`a`, end point :math:`b`, area constant :math:`\Omega`,
-        wave number :math:`k`, and medium impedance :math:`Z_0`
-        following Equation (5-18) of Reference [1]_:
+        The transmission matrix is determined based on the surface
+        area of the horn's narrow end, the surface area of the
+        horn's wide end, the horn's length, wave number, and
+        medium impedance.The surface areas are internally
+        transformed into starting point, end point, and area
+        constant of the horn to calculate the transmission
+        matrix following Equation (5-18) of Reference [1]_:
 
         .. math::
             T = \begin{bmatrix}
@@ -960,14 +963,14 @@ class TransmissionMatrix(FrequencyData):
 
         Parameters
         ----------
-        S0 : float
+        area_narrow_end : float
             The surface area of the horn's narrow end.
-        S1 : float
+        area_wide_end : float
             The surface area of the horn's wide end.
-        L : float
+        horn_length : float
             The distance between the narrow and wide end of the horn,
             i.e. the horn's length.
-        k : FrequencyData, scalar
+        wave_number : FrequencyData, scalar
             Wave number.
         medium_impedance : FrequencyData, scalar
             The impedance of the medium filling the horn. Default is
@@ -1007,19 +1010,19 @@ class TransmissionMatrix(FrequencyData):
             >>> pf.plot.freq(T.input_impedance(np.inf))
 
         """
-        if not (isinstance(k, FrequencyData) or isinstance(k, Number)):
+        if not (isinstance(wave_number, FrequencyData) or isinstance(wave_number, Number)):
             raise TypeError(
                 "The wave number k must be a float, complex, "
                 "or FrequencyData object.",
             )
-        elif isinstance(k, FrequencyData):
-            frequencies = k.frequencies
-            k = k.freq
+        elif isinstance(wave_number, FrequencyData):
+            frequencies = wave_number.frequencies
+            wave_number = wave_number.freq
         else:
-            if isinstance(k, complex):
-                k_re = k.real
+            if isinstance(wave_number, complex):
+                k_re = wave_number.real
             else:
-                k_re = k
+                k_re = wave_number
             frequencies = (k_re * reference_speed_of_sound) / (2 * np.pi)
         if isinstance(medium_impedance, FrequencyData):
             if not np.allclose(
@@ -1052,31 +1055,31 @@ class TransmissionMatrix(FrequencyData):
         if propagation_direction == "backwards":
             Omega, a, b = (
                 TransmissionMatrix._calculate_horn_geometry_parameters(
-                    S0,
-                    S1,
-                    L,
+                    area_narrow_end,
+                    area_wide_end,
+                    horn_length,
                 )
             )  # Error handling inside the helper function
         else:
             Omega, b, a = (
                 TransmissionMatrix._calculate_horn_geometry_parameters(
-                    S0,
-                    S1,
-                    L,
+                    area_narrow_end,
+                    area_wide_end,
+                    horn_length,
                 )
             )  # Error handling inside the helper function
-            L = -1 * L
+            horn_length = -1 * horn_length
 
         # Calculate T-matrix entries according to Equation (5-18) of [1]
-        A = b / a * np.cos(k * L) - 1 / (k * a) * np.sin(k * L)
-        B = 1j * medium_impedance / (a * b * Omega) * np.sin(k * L)
+        A = b / a * np.cos(wave_number * horn_length) - 1 / (wave_number * a) * np.sin(wave_number * horn_length)
+        B = 1j * medium_impedance / (a * b * Omega) * np.sin(wave_number * horn_length)
         C = (
             1j
             * Omega
-            / (k * k * medium_impedance)
-            * ((1 + k * k * a * b) * np.sin(k * L) - k * L * np.cos(k * L))
+            / (wave_number * wave_number * medium_impedance)
+            * ((1 + wave_number * wave_number * a * b) * np.sin(wave_number * horn_length) - wave_number * horn_length * np.cos(wave_number * horn_length))
         )
-        D = a / b * np.cos(k * L) + 1 / (k * b) * np.sin(k * L)
+        D = a / b * np.cos(wave_number * horn_length) + 1 / (wave_number * b) * np.sin(wave_number * horn_length)
 
         return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)
 

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -949,8 +949,9 @@ class TransmissionMatrix(FrequencyData):
         area of the horn's narrow end, the surface area of the
         horn's wide end, the horn's length, wave number, and
         medium impedance.The surface areas are internally
-        transformed into starting point, end point, and area
-        constant of the horn to calculate the transmission
+        transformed into starting point :math:`a`,
+        end point :math:`b`, and area constant :math:`\Omega`
+        of the horn to calculate the transmission
         matrix following Equation (5-18) of Reference [1]_:
 
         .. math::
@@ -1010,7 +1011,8 @@ class TransmissionMatrix(FrequencyData):
             >>> pf.plot.freq(T.input_impedance(np.inf))
 
         """
-        if not (isinstance(wave_number, FrequencyData) or isinstance(wave_number, Number)):
+        if not (isinstance(wave_number, FrequencyData)
+                or isinstance(wave_number, Number)):
             raise TypeError(
                 "The wave number k must be a float, complex, "
                 "or FrequencyData object.",
@@ -1071,15 +1073,19 @@ class TransmissionMatrix(FrequencyData):
             horn_length = -1 * horn_length
 
         # Calculate T-matrix entries according to Equation (5-18) of [1]
-        A = b / a * np.cos(wave_number * horn_length) - 1 / (wave_number * a) * np.sin(wave_number * horn_length)
-        B = 1j * medium_impedance / (a * b * Omega) * np.sin(wave_number * horn_length)
+        A = (b / a * np.cos(wave_number * horn_length)
+            - 1 / (wave_number * a) * np.sin(wave_number * horn_length))
+        B = (1j * medium_impedance
+            / (a * b * Omega) * np.sin(wave_number * horn_length))
         C = (
-            1j
-            * Omega
+            1j * Omega
             / (wave_number * wave_number * medium_impedance)
-            * ((1 + wave_number * wave_number * a * b) * np.sin(wave_number * horn_length) - wave_number * horn_length * np.cos(wave_number * horn_length))
+            * ((1 + wave_number * wave_number * a * b)
+            * np.sin(wave_number * horn_length) - wave_number * horn_length
+            * np.cos(wave_number * horn_length))
         )
-        D = a / b * np.cos(wave_number * horn_length) + 1 / (wave_number * b) * np.sin(wave_number * horn_length)
+        D = (a / b * np.cos(wave_number * horn_length)
+            + 1 / (wave_number * b) * np.sin(wave_number * horn_length))
 
         return TransmissionMatrix.from_abcd(A, B, C, D, frequencies)
 

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -964,7 +964,8 @@ class TransmissionMatrix(FrequencyData):
             \begin{bmatrix}
             \frac{b}{a}\cos(kl) - \frac{1}{ka}\sin(kl) &
             \frac{jZ_0}{ab\Omega}\sin(kl) \\[6pt]
-            \frac{j\Omega}{k^2Z_0}\left( (1 + k^2ab)\sin(kl) - kl\cos(kl) \right) &
+            \frac{j\Omega}{k^2Z_0}\left(
+                (1 + k^2ab)\sin(kl) - kl\cos(kl) \right) &
             \frac{a}{b}\cos(kl) - \frac{1}{kb}\sin(kl)
             \end{bmatrix}
             \begin{bmatrix}

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -938,7 +938,7 @@ class TransmissionMatrix(FrequencyData):
         horn_length: Number,
         wave_number: Number | FrequencyData,
         medium_impedance: Number | FrequencyData = reference_air_impedance,
-        propagation_direction: str = "forward",
+        propagation_direction: str = "expanding",
     ) -> np.ndarray | TransmissionMatrix:
         r"""Create a transmission matrix representing a conical horn.
 
@@ -973,11 +973,11 @@ class TransmissionMatrix(FrequencyData):
         medium_impedance : FrequencyData, scalar
             The impedance of the medium filling the horn. Default is
             ``pyfar.constants.reference_air_impedance``
-        propagation_direction : {'forward', 'backward'}, optional
+        propagation_direction : {'expanding', 'tapering'}, optional
             Defines the direction of sound propagation through the horn,
-            where ``'forward'`` means from narrow to wide end
-            and ``'backward'`` means from wide to narrow end.
-            Default is ``'forward'``.
+            where ``'expanding'`` means from narrow to wide end
+            and ``'tapering'`` means from wide to narrow end.
+            Default is ``'expanding'``.
 
         Returns
         -------
@@ -1003,7 +1003,7 @@ class TransmissionMatrix(FrequencyData):
             >>> Z0 = pf.constants.reference_air_impedance
             >>> # Create the transmission matrix
             >>> T = pf.TransmissionMatrix.create_conical_horn(
-            >>>    S0, S1, L, k, Z0, 'backward')
+            >>>    S0, S1, L, k, Z0, 'tapering')
             >>> # Plot the transmission matrix
             >>> pf.plot.freq(T.input_impedance(np.inf))
 
@@ -1044,15 +1044,15 @@ class TransmissionMatrix(FrequencyData):
         if not isinstance(propagation_direction, str):
             raise TypeError(
             "The input propagation_direction must be a string"
-            "with value 'forward' or 'backward'.",
+            "with value 'expanding' or 'tapering'.",
             )
-        if propagation_direction not in ("forward", "backward"):
+        if propagation_direction not in ("expanding", "tapering"):
             raise ValueError(
                 "The string propagation_direction must either be "
-                "'forward' or 'backward'.",
+                "'expanding' or 'tapering'.",
             )
 
-        if propagation_direction == "backward":
+        if propagation_direction == "tapering":
             Omega, a, b = (
                 TransmissionMatrix._calculate_horn_geometry_parameters(
                     area_narrow_end,

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -899,11 +899,11 @@ class TransmissionMatrix(FrequencyData):
             the wide end to the same virtual apex.
         """
         if not isinstance(S0, Number) or isinstance(S0, complex) or S0 <= 0:
-            raise ValueError("The input S0 must be a positive number.")
+            raise ValueError("The input S0 must be a positive real number.")
         if not isinstance(S1, Number) or isinstance(S1, complex) or S1 <= 0:
-            raise ValueError("The input S1 must be a positive number.")
+            raise ValueError("The input S1 must be a positive real number.")
         if not isinstance(L, Number) or isinstance(L, complex) or L <= 0:
-            raise ValueError("The input L must be a positive number.")
+            raise ValueError("The input L must be a positive real number.")
         if S0 > S1:
             raise ValueError("S0 must be strictly smaller than S1.")
         if S0 == S1:

--- a/pyfar/classes/transmission_matrix.py
+++ b/pyfar/classes/transmission_matrix.py
@@ -973,7 +973,7 @@ class TransmissionMatrix(FrequencyData):
         medium_impedance : FrequencyData, scalar
             The impedance of the medium filling the horn. Default is
             ``pyfar.constants.reference_air_impedance``
-        propagation_direction : {'forward', 'backwards'}, optional
+        propagation_direction : {'forward', 'backward'}, optional
             Defines the direction of sound propagation through the horn,
             where ``'forward'`` means from narrow to wide end
             and ``'backward'`` means from wide to narrow end.
@@ -1003,7 +1003,7 @@ class TransmissionMatrix(FrequencyData):
             >>> Z0 = pf.constants.reference_air_impedance
             >>> # Create the transmission matrix
             >>> T = pf.TransmissionMatrix.create_conical_horn(
-            >>>    S0, S1, L, k, Z0, 'backwards')
+            >>>    S0, S1, L, k, Z0, 'backward')
             >>> # Plot the transmission matrix
             >>> pf.plot.freq(T.input_impedance(np.inf))
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -663,8 +663,57 @@ def test_create_conical_horn_imp_frequency_data():
         inv_prefix * A,
     )
 
+
+def test_create_conical_horn_k_number():
+    """Test `create_conical_horn` with wave_number as Number."""
+    k = 1j
+    Z = 1 + 1j
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
+
+    tmat_backward = TransmissionMatrix.create_conical_horn(
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
+        k,
+        Z,
+        "backward",
+    )
+    tmat_forward = TransmissionMatrix.create_conical_horn(
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
+        k,
+        Z,
+        "forward",
+    )
+
+    A = 1.02899125+0.j
+
+    B = -3.35560004 -3.35560004j
+
+    C = -0.00657555+0.00657555j
+
+    D = 1.01471206+0.j
+
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat_backward, np.ndarray)
+    assert np.allclose(tmat_backward, [[A, B], [C, D]], atol=1e-15)
+
+    assert isinstance(tmat_forward, np.ndarray)
+    assert np.allclose(tmat_forward, [[inv_prefix * D, -1 * inv_prefix * B],\
+        [-1 * inv_prefix * C, inv_prefix * A]], atol=1e-15)
+
+
 def test_create_conical_horn_k_frequency_data():
-    """Test `create_conical_horn` with impedance as FrequencyData."""
+    """Test `create_conical_horn` with wave_number as FrequencyData."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -567,21 +567,21 @@ def test_create_conical_horn_imp_number():
     area_wide_end = Omega * b**2
     horn_length = b - a
 
-    tmat_backwards = TransmissionMatrix.create_conical_horn(
+    tmat_backward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         wave_number,
         Z,
-        "backwards",
+        "backward",
     )
-    tmat_forwards = TransmissionMatrix.create_conical_horn(
+    tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         wave_number,
         Z,
-        "forwards",
+        "forward",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
@@ -596,12 +596,12 @@ def test_create_conical_horn_imp_number():
 
     inv_prefix = 1 / (A * D - B * C)
 
-    assert isinstance(tmat_backwards, TransmissionMatrix)
-    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+    assert isinstance(tmat_backward, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backward, A, B, C, D)
 
-    assert isinstance(tmat_forwards, TransmissionMatrix)
+    assert isinstance(tmat_forward, TransmissionMatrix)
     _compare_tmat_vs_abcd(
-        tmat_forwards,
+        tmat_forward,
         inv_prefix * D,
         -1 * inv_prefix * B,
         -1 * inv_prefix * C,
@@ -622,21 +622,21 @@ def test_create_conical_horn_imp_frequency_data():
     area_wide_end = Omega * b**2
     horn_length = b - a
 
-    tmat_backwards = TransmissionMatrix.create_conical_horn(
+    tmat_backward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         k,
         Z,
-        "backwards",
+        "backward",
     )
-    tmat_forwards = TransmissionMatrix.create_conical_horn(
+    tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         k,
         Z,
-        "forwards",
+        "forward",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
@@ -651,12 +651,12 @@ def test_create_conical_horn_imp_frequency_data():
 
     inv_prefix = 1 / (A * D - B * C)
 
-    assert isinstance(tmat_backwards, TransmissionMatrix)
-    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+    assert isinstance(tmat_backward, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backward, A, B, C, D)
 
-    assert isinstance(tmat_forwards, TransmissionMatrix)
+    assert isinstance(tmat_forward, TransmissionMatrix)
     _compare_tmat_vs_abcd(
-        tmat_forwards,
+        tmat_forward,
         inv_prefix * D,
         -1 * inv_prefix * B,
         -1 * inv_prefix * C,
@@ -676,21 +676,21 @@ def test_create_conical_horn_k_frequency_data():
     area_wide_end = Omega * b**2
     horn_length = b - a
 
-    tmat_backwards = TransmissionMatrix.create_conical_horn(
+    tmat_backward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         k,
         Z,
-        "backwards",
+        "backward",
     )
-    tmat_forwards = TransmissionMatrix.create_conical_horn(
+    tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         k,
         Z,
-        "forwards",
+        "forward",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
@@ -705,12 +705,12 @@ def test_create_conical_horn_k_frequency_data():
 
     inv_prefix = 1 / (A * D - B * C)
 
-    assert isinstance(tmat_backwards, TransmissionMatrix)
-    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+    assert isinstance(tmat_backward, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backward, A, B, C, D)
 
-    assert isinstance(tmat_forwards, TransmissionMatrix)
+    assert isinstance(tmat_forward, TransmissionMatrix)
     _compare_tmat_vs_abcd(
-        tmat_forwards,
+        tmat_forward,
         inv_prefix * D,
         -1 * inv_prefix * B,
         -1 * inv_prefix * C,
@@ -731,21 +731,21 @@ def test_create_conical_horn_broadcasting():
     area_wide_end = Omega * b**2
     horn_length = b - a
 
-    tmat_backwards = TransmissionMatrix.create_conical_horn(
+    tmat_backward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         k,
         Z,
-        "backwards",
+        "backward",
     )
-    tmat_forwards = TransmissionMatrix.create_conical_horn(
+    tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
         area_wide_end,
         horn_length,
         k,
         Z,
-        "forwards",
+        "forward",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j],
@@ -766,12 +766,12 @@ def test_create_conical_horn_broadcasting():
 
     inv_prefix = 1 / (A * D - B * C)
 
-    assert isinstance(tmat_backwards, TransmissionMatrix)
-    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+    assert isinstance(tmat_backward, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backward, A, B, C, D)
 
-    assert isinstance(tmat_forwards, TransmissionMatrix)
+    assert isinstance(tmat_forward, TransmissionMatrix)
     _compare_tmat_vs_abcd(
-        tmat_forwards,
+        tmat_forward,
         inv_prefix * D,
         -1 * inv_prefix * B,
         -1 * inv_prefix * C,
@@ -831,7 +831,7 @@ def test_create_conical_horn_k_errors(k):
     with pytest.raises(TypeError, match=\
         "The wavenumber k"):
         TransmissionMatrix.create_conical_horn\
-            (area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
 
 
 @pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
@@ -845,7 +845,7 @@ def test_create_conical_horn_medium_impedance_errors(Z):
     with pytest.raises(TypeError, match=\
         "The input medium_impedance"):
         TransmissionMatrix.create_conical_horn\
-            (area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
 
 
 @pytest.mark.parametrize(
@@ -874,7 +874,7 @@ def test_create_conical_horn_propagation_direction_type_errors(
         )
 
 
-@pytest.mark.parametrize("propagation_direction", ["test", "", "forward"])
+@pytest.mark.parametrize("propagation_direction", ["test", "", "forwards"])
 def test_create_conical_horn_propagation_direction_value_errors(
     propagation_direction,
 ):
@@ -911,7 +911,7 @@ def test_create_conical_horn_frequency_matching():
 
     with pytest.raises(ValueError, match="The frequencies of"):
         TransmissionMatrix.create_conical_horn\
-            (area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -5,7 +5,6 @@ import re
 import pyfar as pf
 from pyfar import TransmissionMatrix
 from pyfar import FrequencyData
-from pyfar.constants import reference_air_impedance
 
 @pytest.fixture(scope="module")
 def frequencies():
@@ -573,22 +572,15 @@ def test_create_conical_horn_imp_number():
         "forwards",
     )
 
-    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
-        k.freq * (b - a),
-    )
-    B = 1j * Z / (a * b * Omega) * np.sin(k.freq * (b - a))
-    C = (
-        1j
-        * Omega
-        / (k.freq * k.freq * Z)
-        * (
-            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
-            - k.freq * (b - a) * np.cos(k.freq * (b - a))
-        )
-    )
-    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
-        k.freq * (b - a),
-    )
+    A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
+
+    B = np.array([[-13.42240017 -0.33556j, -0.64903057+25.96122282j,
+        -42.44357214 -1.0610893j ]])
+
+    C = np.array([[-0.00328572+8.21430330e-05j, 0.00015905+6.36214741e-03j,
+        -0.01037249+2.59312342e-04j]])
+
+    D = np.array([[1.01471206+0.j, 0.94205494+0.j, 1.13571485+0.j]])
 
     inv_prefix = 1 / (A * D - B * C)
 
@@ -635,22 +627,15 @@ def test_create_conical_horn_imp_frequency_data():
         "forwards",
     )
 
-    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
-        k.freq * (b - a),
-    )
-    B = 1j * Z.freq / (a * b * Omega) * np.sin(k.freq * (b - a))
-    C = (
-        1j
-        * Omega
-        / (k.freq * k.freq * Z.freq)
-        * (
-            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
-            - k.freq * (b - a) * np.cos(k.freq * (b - a))
-        )
-    )
-    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
-        k.freq * (b - a),
-    )
+    A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
+
+    B = np.array([[ -3.35560004 -3.35560004j, -12.98061141+12.98061141j,
+        -31.83267911-10.61089304j]])
+
+    C = np.array([[-0.00657555+0.00657555j, 0.00636612+0.00636612j,
+        -0.01245477+0.00415159j]])
+
+    D = np.array([[1.01471206+0.j, 0.94205494+0.j, 1.13571485+0.j]])
 
     inv_prefix = 1 / (A * D - B * C)
 
@@ -697,22 +682,14 @@ def test_create_conical_horn_k_number():
         "forwards",
     )
 
-    A = b / a * np.cos(k * (b - a)) - 1 / (k * a) * np.sin(
-        k * (b - a),
-    )
-    B = 1j * Z / (a * b * Omega) * np.sin(k * (b - a))
-    C = (
-        1j
-        * Omega
-        / (k * k * Z)
-        * (
-            (1 + k * k * a * b) * np.sin(k * (b - a))
-            - k * (b - a) * np.cos(k * (b - a))
-        )
-    )
-    D = a / b * np.cos(k * (b - a)) + 1 / (k * b) * np.sin(
-        k * (b - a),
-    )
+    A = np.float64(-0.6787560082005961)
+
+    B = np.complex64(1.4526262873559803-58.10505149423922j)
+
+    C = np.complex64(-0.00031990900057045704-0.01279636002281828j)
+
+    D = np.float64(-0.3771637092247614)
+
     inv_prefix = 1 / (A * D - B * C)
 
     assert isinstance(tmat_backwards, TransmissionMatrix)
@@ -758,22 +735,15 @@ def test_create_conical_horn_k_frequency_data():
         "forwards",
     )
 
-    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
-        k.freq * (b - a),
-    )
-    B = 1j * Z.freq / (a * b * Omega) * np.sin(k.freq * (b - a))
-    C = (
-        1j
-        * Omega
-        / (k.freq * k.freq * Z.freq)
-        * (
-            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
-            - k.freq * (b - a) * np.cos(k.freq * (b - a))
-        )
-    )
-    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
-        k.freq * (b - a),
-    )
+    A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
+
+    B = np.array([[ -3.35560004 -3.35560004j, -12.98061141+12.98061141j,
+        -31.83267911-10.61089304j]])
+
+    C = np.array([[-0.00657555+0.00657555j, 0.00636612+0.00636612j,
+        -0.01245477+0.00415159j]])
+
+    D = np.array([[1.01471206+0.j, 0.94205494+0.j, 1.13571485+0.j]])
 
     inv_prefix = 1 / (A * D - B * C)
 
@@ -820,22 +790,21 @@ def test_create_conical_horn_broadcasting():
         "forwards",
     )
 
-    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
-        k.freq * (b - a),
-    )
-    B = 1j * Z.freq / (a * b * Omega) * np.sin(k.freq * (b - a))
-    C = (
-        1j
-        * Omega
-        / (k.freq * k.freq * Z.freq)
-        * (
-            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
-            - k.freq * (b - a) * np.cos(k.freq * (b - a))
-        )
-    )
-    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
-        k.freq * (b - a),
-    )
+    A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j],
+       [1.48896993+0.j, 0.33952319+0.j, 2.17916964+0.j]])
+
+    B = np.array([[ -3.35560004 -3.35560004j, -12.98061141+12.98061141j,
+        -31.83267911-10.61089304j],
+       [-14.80176637-14.80176637j, -28.04903283+28.04903283j,
+        -75.47306777-25.15768926j]])
+
+    C = np.array([[-0.00657555+0.00657555j,  0.00636612+0.00636612j,
+        -0.01245477+0.00415159j],
+       [-0.0289162 +0.0289162j ,  0.01382674+0.01382674j,
+        -0.02938139+0.0097938j ]])
+
+    D = np.array([[1.01471206+0.j, 0.94205494+0.j, 1.13571485+0.j],
+       [1.24651396+0.j, 0.66076978+0.j, 1.58954713+0.j]])
 
     inv_prefix = 1 / (A * D - B * C)
 
@@ -855,7 +824,6 @@ def test_create_conical_horn_broadcasting():
 def test_create_conical_horn_default_parameters():
     """Test `create_conical_horn` default parameters."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
-    Z = reference_air_impedance
 
     a = 0.3
     b = 0.5
@@ -872,22 +840,15 @@ def test_create_conical_horn_default_parameters():
         k,
     )  # using default Z and default propagation_direction
 
-    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
-        k.freq * (b - a),
-    )
-    B = 1j * Z / (a * b * Omega) * np.sin(k.freq * (b - a))
-    C = (
-        1j
-        * Omega
-        / (k.freq * k.freq * Z)
-        * (
-            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
-            - k.freq * (b - a) * np.cos(k.freq * (b - a))
-        )
-    )
-    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
-        k.freq * (b - a),
-    )
+    A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
+
+    B = np.array([[-1386.57688918+0.j,0.+2681.87739328j,
+        -4384.55682183+0.j]])
+
+    C = np.array([[-3.18264574e-05+0.0e+00j, 0.0e+00+6.162562e-05j,
+        -1.00471007e-04+0.0e+00j]])
+
+    D = np.array([[1.01471206+0.j, 0.94205494+0.j, 1.13571485+0.j]])
 
     inv_prefix = 1 / (A * D - B * C)
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -467,46 +467,29 @@ def test_create_transmission_line_frequency_matching():
         ValueError, match="The frequencies do not match"):
         TransmissionMatrix.create_transmission_line(kl, Z)
 
-@pytest.mark.parametrize(
+@pytest.mark.parametrize("param", [
     "area_narrow_end",
-    [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
-)
-def test_calculate_horn_geometry_parameters_S0_value_error(area_narrow_end):
-    area_wide_end = 0.2
-    horn_length = 0.35
-
-    with pytest.raises(ValueError, match="The input area_narrow_end"):
-        TransmissionMatrix.\
-            _calculate_horn_geometry_parameters\
-            (area_narrow_end, area_wide_end, horn_length)
-
-
-@pytest.mark.parametrize(
     "area_wide_end",
-    [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
-)
-def test_calculate_horn_geometry_parameters_S1_value_error(area_wide_end):
-    area_narrow_end = 0.2
-    horn_length = 0.35
-
-    with pytest.raises(ValueError, match="The input area_wide_end"):
-        TransmissionMatrix.\
-            _calculate_horn_geometry_parameters\
-            (area_narrow_end, area_wide_end, horn_length)
-
-
-@pytest.mark.parametrize(
     "horn_length",
+])
+@pytest.mark.parametrize(
+    "invalid_value",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_L_value_error(horn_length):
-    area_narrow_end = 0.2
-    area_wide_end = 0.3
+def test_calculate_horn_geometry_parameters_value_error(param, invalid_value):
+    parameters = {
+        "area_narrow_end": 0.2,
+        "area_wide_end": 0.3,
+        "horn_length": 0.35,
+    }
+    parameters[param] = invalid_value
+    with pytest.raises(ValueError, match=f"The input {param} must be"
+                                            " a positive real number."):
+        TransmissionMatrix._calculate_horn_geometry_parameters(
+            parameters["area_narrow_end"],
+            parameters["area_wide_end"],
+            parameters["horn_length"])
 
-    with pytest.raises(ValueError, match="The input horn_length"):
-        TransmissionMatrix.\
-            _calculate_horn_geometry_parameters\
-            (area_narrow_end, area_wide_end, horn_length)
 
 
 def test_calculate_horn_geometry_parameters_S0_larger_S1_value_error():

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -651,60 +651,6 @@ def test_create_conical_horn_imp_frequency_data():
         inv_prefix * A,
     )
 
-
-def test_create_conical_horn_k_number():
-    """Test `create_conical_horn` with impedance as number."""
-    k = 21
-    Z = 4 + 0.1j
-
-    a = 0.3
-    b = 0.5
-    Omega = 0.4
-
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
-
-    tmat_backwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
-        k,
-        Z,
-        "backwards",
-    )
-    tmat_forwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
-        k,
-        Z,
-        "forwards",
-    )
-
-    A = np.float64(-0.6787560082005961)
-
-    B = np.complex64(1.4526262873559803-58.10505149423922j)
-
-    C = np.complex64(-0.00031990900057045704-0.01279636002281828j)
-
-    D = np.float64(-0.3771637092247614)
-
-    inv_prefix = 1 / (A * D - B * C)
-
-    assert isinstance(tmat_backwards, TransmissionMatrix)
-    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
-
-    assert isinstance(tmat_forwards, TransmissionMatrix)
-    _compare_tmat_vs_abcd(
-        tmat_forwards,
-        inv_prefix * D,
-        -1 * inv_prefix * B,
-        -1 * inv_prefix * C,
-        inv_prefix * A,
-    )
-
-
 def test_create_conical_horn_k_frequency_data():
     """Test `create_conical_horn` with impedance as FrequencyData."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -816,7 +816,7 @@ def test_create_conical_horn_k_errors(k):
     S1 = 0.04
     L = 0.25
 
-    with pytest.raises(TypeError, match="The wave number k"):
+    with pytest.raises(TypeError, match="The wavenumber k"):
         TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
 
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -5,6 +5,7 @@ import re
 import pyfar as pf
 from pyfar import TransmissionMatrix
 from pyfar import FrequencyData
+from pyfar.constants import reference_air_impedance
 
 @pytest.fixture(scope="module")
 def frequencies():
@@ -245,10 +246,10 @@ def _compare_tmat_vs_abcd(tmat, A, B, C, D):
         assert tmat.C == C
         assert tmat.D == D
     else:
-        assert np.all(tmat.A.freq == A)
-        assert np.all(tmat.B.freq == B)
-        assert np.all(tmat.C.freq == C)
-        assert np.all(tmat.D.freq == D)
+        assert np.allclose(tmat.A.freq, A, atol=1e-15)
+        assert np.allclose(tmat.B.freq, B, atol=1e-15)
+        assert np.allclose(tmat.C.freq, C, atol=1e-15)
+        assert np.allclose(tmat.D.freq, D, atol=1e-15)
 
 def test_tmatrix_abcd_entries(abcd_data_1x2, abcd_data_3x2, abcd_data_3x3x1,
         abcd_data_complex):
@@ -466,6 +467,527 @@ def test_create_transmission_line_frequency_matching():
     with pytest.raises(
         ValueError, match="The frequencies do not match"):
         TransmissionMatrix.create_transmission_line(kl, Z)
+
+@pytest.mark.parametrize(
+    "S0",
+    [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
+)
+def test_calculate_horn_geometry_parameters_S0_value_error(S0):
+    S1 = 0.2
+    L = 0.35
+
+    with pytest.raises(ValueError, match="The input S0"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+
+
+@pytest.mark.parametrize(
+    "S1",
+    [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
+)
+def test_calculate_horn_geometry_parameters_S1_value_error(S1):
+    S0 = 0.2
+    L = 0.35
+
+    with pytest.raises(ValueError, match="The input S1"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+
+
+@pytest.mark.parametrize(
+    "L",
+    [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
+)
+def test_calculate_horn_geometry_parameters_L_value_error(L):
+    S0 = 0.2
+    S1 = 0.3
+
+    with pytest.raises(ValueError, match="The input L"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+
+
+def test_calculate_horn_geometry_parameters_S0_larger_S1_value_error():
+    S0 = 0.35
+    S1 = 0.3
+    L = 0.35
+
+    with pytest.raises(
+        ValueError,
+        match="S0 must be strictly smaller than S1.",
+    ):
+        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+
+
+def test_calculate_horn_geometry_parameters_S0_equal_S1_value_error():
+    S0 = 0.35
+    S1 = 0.35
+    L = 0.2
+
+    with pytest.raises(ValueError, match="For a conical horn S0 must be"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+
+
+def test_calculate_horn_geometry_calculations():
+    a = 0.3
+    b = 0.7
+    Omega = 1.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    Omega_ret, a_ret, b_ret = (
+        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+    )
+
+    assert np.isclose(Omega, Omega_ret, atol=1e-15)
+    assert np.isclose(a, a_ret, atol=1e-15)
+    assert np.isclose(b, b_ret, atol=1e-15)
+
+
+def test_create_conical_horn_imp_number():
+    """Test `create_conical_horn` with impedance as number."""
+    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    Z = 4 + 0.1j
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    tmat_backwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "backwards",
+    )
+    tmat_forwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "forwards",
+    )
+
+    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
+        k.freq * (b - a),
+    )
+    B = 1j * Z / (a * b * Omega) * np.sin(k.freq * (b - a))
+    C = (
+        1j
+        * Omega
+        / (k.freq * k.freq * Z)
+        * (
+            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
+            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+        )
+    )
+    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
+        k.freq * (b - a),
+    )
+
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat_backwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+
+    assert isinstance(tmat_forwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(
+        tmat_forwards,
+        inv_prefix * D,
+        -1 * inv_prefix * B,
+        -1 * inv_prefix * C,
+        inv_prefix * A,
+    )
+
+
+def test_create_conical_horn_imp_frequency_data():
+    """Test `create_conical_horn` with impedance as FrequencyData."""
+    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    tmat_backwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "backwards",
+    )
+    tmat_forwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "forwards",
+    )
+
+    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
+        k.freq * (b - a),
+    )
+    B = 1j * Z.freq / (a * b * Omega) * np.sin(k.freq * (b - a))
+    C = (
+        1j
+        * Omega
+        / (k.freq * k.freq * Z.freq)
+        * (
+            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
+            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+        )
+    )
+    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
+        k.freq * (b - a),
+    )
+
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat_backwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+
+    assert isinstance(tmat_forwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(
+        tmat_forwards,
+        inv_prefix * D,
+        -1 * inv_prefix * B,
+        -1 * inv_prefix * C,
+        inv_prefix * A,
+    )
+
+
+def test_create_conical_horn_k_number():
+    """Test `create_conical_horn` with impedance as number."""
+    k = 21
+    Z = 4 + 0.1j
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    tmat_backwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "backwards",
+    )
+    tmat_forwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "forwards",
+    )
+
+    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
+        k.freq * (b - a),
+    )
+    B = 1j * Z / (a * b * Omega) * np.sin(k.freq * (b - a))
+    C = (
+        1j
+        * Omega
+        / (k.freq * k.freq * Z)
+        * (
+            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
+            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+        )
+    )
+    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
+        k.freq * (b - a),
+    )
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat_backwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+
+    assert isinstance(tmat_forwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(
+        tmat_forwards,
+        inv_prefix * D,
+        -1 * inv_prefix * B,
+        -1 * inv_prefix * C,
+        inv_prefix * A,
+    )
+
+
+def test_create_conical_horn_k_frequency_data():
+    """Test `create_conical_horn` with impedance as FrequencyData."""
+    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    tmat_backwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "backwards",
+    )
+    tmat_forwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "forwards",
+    )
+
+    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
+        k.freq * (b - a),
+    )
+    B = 1j * Z.freq / (a * b * Omega) * np.sin(k.freq * (b - a))
+    C = (
+        1j
+        * Omega
+        / (k.freq * k.freq * Z.freq)
+        * (
+            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
+            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+        )
+    )
+    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
+        k.freq * (b - a),
+    )
+
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat_backwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+
+    assert isinstance(tmat_forwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(
+        tmat_forwards,
+        inv_prefix * D,
+        -1 * inv_prefix * B,
+        -1 * inv_prefix * C,
+        inv_prefix * A,
+    )
+
+
+def test_create_conical_horn_broadcasting():
+    """Test `create_conical_horn` broadcasting."""
+    k = FrequencyData(np.array([[1j, 2, 3j], [4j, 5, 6j]]), [1, 2, 3])
+    Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    tmat_backwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "backwards",
+    )
+    tmat_forwards = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+        Z,
+        "forwards",
+    )
+
+    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
+        k.freq * (b - a),
+    )
+    B = 1j * Z.freq / (a * b * Omega) * np.sin(k.freq * (b - a))
+    C = (
+        1j
+        * Omega
+        / (k.freq * k.freq * Z.freq)
+        * (
+            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
+            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+        )
+    )
+    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
+        k.freq * (b - a),
+    )
+
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat_backwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(tmat_backwards, A, B, C, D)
+
+    assert isinstance(tmat_forwards, TransmissionMatrix)
+    _compare_tmat_vs_abcd(
+        tmat_forwards,
+        inv_prefix * D,
+        -1 * inv_prefix * B,
+        -1 * inv_prefix * C,
+        inv_prefix * A,
+    )
+
+
+def test_create_conical_horn_default_parameters():
+    """Test `create_conical_horn` default parameters."""
+    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    Z = reference_air_impedance
+
+    a = 0.3
+    b = 0.5
+    Omega = 0.4
+
+    S0 = Omega * a**2
+    S1 = Omega * b**2
+    L = b - a
+
+    tmat = TransmissionMatrix.create_conical_horn(
+        S0,
+        S1,
+        L,
+        k,
+    )  # using default Z and default propagation_direction
+
+    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
+        k.freq * (b - a),
+    )
+    B = 1j * Z / (a * b * Omega) * np.sin(k.freq * (b - a))
+    C = (
+        1j
+        * Omega
+        / (k.freq * k.freq * Z)
+        * (
+            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
+            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+        )
+    )
+    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
+        k.freq * (b - a),
+    )
+
+    inv_prefix = 1 / (A * D - B * C)
+
+    assert isinstance(tmat, TransmissionMatrix)
+    _compare_tmat_vs_abcd(
+        tmat,
+        inv_prefix * D,
+        -1 * inv_prefix * B,
+        -1 * inv_prefix * C,
+        inv_prefix * A,
+    )
+
+
+@pytest.mark.parametrize("k", [{"a": 1, "b": 3j}, np.array([1, 2, 3]), "term"])
+def test_create_conical_horn_k_errors(k):
+    """Test `create_conical_horn` error for k input."""
+    Z = 4 + 0.1j
+    S0 = 0.03
+    S1 = 0.04
+    L = 0.25
+
+    with pytest.raises(TypeError, match="The wave number k"):
+        TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
+
+
+@pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
+def test_create_conical_horn_medium_impedance_errors(Z):
+    """Test `create_conical_horn` errors for impedance parameter."""
+    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    S0 = 0.03
+    S1 = 0.04
+    L = 0.25
+
+    with pytest.raises(TypeError, match="The input medium_impedance"):
+        TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
+
+
+@pytest.mark.parametrize(
+    "propagation_direction",
+    [np.array([1, 2, 3]), 2, -5, 8j],
+)
+def test_create_conical_horn_propagation_direction_type_errors(
+    propagation_direction,
+):
+    """Test `create_conical_horn` errors for propagation_direction."""
+    k = FrequencyData(np.array([[1j, 2, 3j], [4j, 5, 6j]]), [1, 2, 3])
+    Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
+
+    S0 = 0.03
+    S1 = 0.04
+    L = 0.25
+
+    with pytest.raises(TypeError, match="The input propagation_direction"):
+        TransmissionMatrix.create_conical_horn(
+            S0,
+            S1,
+            L,
+            k,
+            Z,
+            propagation_direction,
+        )
+
+
+@pytest.mark.parametrize("propagation_direction", ["test", "", "forward"])
+def test_create_conical_horn_propagation_direction_value_errors(
+    propagation_direction,
+):
+    """Test `create_conical_horn` errors for propagation_direction."""
+    k = FrequencyData(np.array([[1j, 2, 3j], [4j, 5, 6j]]), [1, 2, 3])
+    Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
+
+    S0 = 0.03
+    S1 = 0.04
+    L = 0.25
+
+    with pytest.raises(
+        ValueError,
+        match="The string propagation_direction must either",
+    ):
+        TransmissionMatrix.create_conical_horn(
+            S0,
+            S1,
+            L,
+            k,
+            Z,
+            propagation_direction,
+        )
+
+
+def test_create_conical_horn_frequency_matching():
+    """Test `create_conical_horn` frequency matching."""
+    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 4])
+
+    S0 = 0.03
+    S1 = 0.04
+    L = 0.25
+
+    with pytest.raises(ValueError, match="The frequencies of"):
+        TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -573,7 +573,7 @@ def test_create_conical_horn_imp_number():
         horn_length,
         wave_number,
         Z,
-        "backward",
+        "tapering",
     )
     tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
@@ -581,7 +581,7 @@ def test_create_conical_horn_imp_number():
         horn_length,
         wave_number,
         Z,
-        "forward",
+        "expanding",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
@@ -628,7 +628,7 @@ def test_create_conical_horn_imp_frequency_data():
         horn_length,
         k,
         Z,
-        "backward",
+        "tapering",
     )
     tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
@@ -636,7 +636,7 @@ def test_create_conical_horn_imp_frequency_data():
         horn_length,
         k,
         Z,
-        "forward",
+        "expanding",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
@@ -683,7 +683,7 @@ def test_create_conical_horn_k_number():
         horn_length,
         k,
         Z,
-        "backward",
+        "tapering",
     )
     tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
@@ -691,7 +691,7 @@ def test_create_conical_horn_k_number():
         horn_length,
         k,
         Z,
-        "forward",
+        "expanding",
     )
 
     A = 1.02899125+0.j
@@ -731,7 +731,7 @@ def test_create_conical_horn_k_frequency_data():
         horn_length,
         k,
         Z,
-        "backward",
+        "tapering",
     )
     tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
@@ -739,7 +739,7 @@ def test_create_conical_horn_k_frequency_data():
         horn_length,
         k,
         Z,
-        "forward",
+        "expanding",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j]])
@@ -786,7 +786,7 @@ def test_create_conical_horn_broadcasting():
         horn_length,
         k,
         Z,
-        "backward",
+        "tapering",
     )
     tmat_forward = TransmissionMatrix.create_conical_horn(
         area_narrow_end,
@@ -794,7 +794,7 @@ def test_create_conical_horn_broadcasting():
         horn_length,
         k,
         Z,
-        "forward",
+        "expanding",
     )
 
     A = np.array([[1.02899125+0.j, 0.88607109+0.j, 1.26838249+0.j],
@@ -880,7 +880,7 @@ def test_create_conical_horn_k_errors(k):
     with pytest.raises(TypeError, match=\
         "wave_number must be"):
         TransmissionMatrix.create_conical_horn\
-            (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "tapering")
 
 
 @pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
@@ -894,7 +894,7 @@ def test_create_conical_horn_medium_impedance_errors(Z):
     with pytest.raises(TypeError, match=\
         "The input medium_impedance"):
         TransmissionMatrix.create_conical_horn\
-            (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "tapering")
 
 
 @pytest.mark.parametrize(
@@ -960,7 +960,7 @@ def test_create_conical_horn_frequency_matching():
 
     with pytest.raises(ValueError, match="The frequencies of"):
         TransmissionMatrix.create_conical_horn\
-            (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "tapering")
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -468,60 +468,60 @@ def test_create_transmission_line_frequency_matching():
         TransmissionMatrix.create_transmission_line(kl, Z)
 
 @pytest.mark.parametrize(
-    "S0",
+    "area_narrow_end",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_S0_value_error(S0):
-    S1 = 0.2
-    L = 0.35
+def test_calculate_horn_geometry_parameters_area_narrow_end_value_error(area_narrow_end):
+    area_wide_end = 0.2
+    horn_length = 0.35
 
-    with pytest.raises(ValueError, match="The input S0"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+    with pytest.raises(ValueError, match="The input area_narrow_end"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
 
 
 @pytest.mark.parametrize(
-    "S1",
+    "area_wide_end",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_S1_value_error(S1):
-    S0 = 0.2
-    L = 0.35
+def test_calculate_horn_geometry_parameters_area_wide_end_value_error(area_wide_end):
+    area_narrow_end = 0.2
+    horn_length = 0.35
 
-    with pytest.raises(ValueError, match="The input S1"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+    with pytest.raises(ValueError, match="The input area_wide_end"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
 
 
 @pytest.mark.parametrize(
-    "L",
+    "horn_length",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_L_value_error(L):
-    S0 = 0.2
-    S1 = 0.3
+def test_calculate_horn_geometry_parameters_horn_length_value_error(horn_length):
+    area_narrow_end = 0.2
+    area_wide_end = 0.3
 
-    with pytest.raises(ValueError, match="The input L"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+    with pytest.raises(ValueError, match="The input horn_length"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
 
 
-def test_calculate_horn_geometry_parameters_S0_larger_S1_value_error():
-    S0 = 0.35
-    S1 = 0.3
-    L = 0.35
+def test_calculate_horn_geometry_parameters_area_narrow_end_larger_area_wide_end_value_error():
+    area_narrow_end = 0.35
+    area_wide_end = 0.3
+    horn_length = 0.35
 
     with pytest.raises(
         ValueError,
-        match="S0 must be strictly smaller than S1.",
+        match="area_narrow_end must be strictly smaller than area_wide_end.",
     ):
-        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
 
 
-def test_calculate_horn_geometry_parameters_S0_equal_S1_value_error():
-    S0 = 0.35
-    S1 = 0.35
-    L = 0.2
+def test_calculate_horn_geometry_parameters_area_narrow_end_equal_area_wide_end_value_error():
+    area_narrow_end = 0.35
+    area_wide_end = 0.35
+    horn_length = 0.2
 
-    with pytest.raises(ValueError, match="For a conical horn S0 must be"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+    with pytest.raises(ValueError, match="For a conical horn area_narrow_end must be"):
+        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
 
 
 def test_calculate_horn_geometry_calculations():
@@ -529,12 +529,12 @@ def test_calculate_horn_geometry_calculations():
     b = 0.7
     Omega = 1.4
 
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
 
     Omega_ret, a_ret, b_ret = (
-        TransmissionMatrix._calculate_horn_geometry_parameters(S0, S1, L)
+        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
     )
 
     assert np.isclose(Omega, Omega_ret, atol=1e-15)
@@ -544,30 +544,30 @@ def test_calculate_horn_geometry_calculations():
 
 def test_create_conical_horn_imp_number():
     """Test `create_conical_horn` with impedance as number."""
-    k = FrequencyData([1j, 2, 3j], [1, 2, 3])
+    wave_number = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = 4 + 0.1j
 
     a = 0.3
     b = 0.5
     Omega = 0.4
 
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
 
     tmat_backwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
-        k,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
+        wave_number,
         Z,
         "backwards",
     )
     tmat_forwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
-        k,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
+        wave_number,
         Z,
         "forwards",
     )
@@ -606,22 +606,22 @@ def test_create_conical_horn_imp_frequency_data():
     b = 0.5
     Omega = 0.4
 
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
 
     tmat_backwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
         Z,
         "backwards",
     )
     tmat_forwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
         Z,
         "forwards",
@@ -660,22 +660,22 @@ def test_create_conical_horn_k_frequency_data():
     b = 0.5
     Omega = 0.4
 
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
 
     tmat_backwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
         Z,
         "backwards",
     )
     tmat_forwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
         Z,
         "forwards",
@@ -715,22 +715,22 @@ def test_create_conical_horn_broadcasting():
     b = 0.5
     Omega = 0.4
 
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
 
     tmat_backwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
         Z,
         "backwards",
     )
     tmat_forwards = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
         Z,
         "forwards",
@@ -775,14 +775,14 @@ def test_create_conical_horn_default_parameters():
     b = 0.5
     Omega = 0.4
 
-    S0 = Omega * a**2
-    S1 = Omega * b**2
-    L = b - a
+    area_narrow_end = Omega * a**2
+    area_wide_end = Omega * b**2
+    horn_length = b - a
 
     tmat = TransmissionMatrix.create_conical_horn(
-        S0,
-        S1,
-        L,
+        area_narrow_end,
+        area_wide_end,
+        horn_length,
         k,
     )  # using default Z and default propagation_direction
 
@@ -812,24 +812,24 @@ def test_create_conical_horn_default_parameters():
 def test_create_conical_horn_k_errors(k):
     """Test `create_conical_horn` error for k input."""
     Z = 4 + 0.1j
-    S0 = 0.03
-    S1 = 0.04
-    L = 0.25
+    area_narrow_end = 0.03
+    area_wide_end = 0.04
+    horn_length = 0.25
 
     with pytest.raises(TypeError, match="The wavenumber k"):
-        TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
+        TransmissionMatrix.create_conical_horn(area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
 
 
 @pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
 def test_create_conical_horn_medium_impedance_errors(Z):
     """Test `create_conical_horn` errors for impedance parameter."""
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
-    S0 = 0.03
-    S1 = 0.04
-    L = 0.25
+    area_narrow_end = 0.03
+    area_wide_end = 0.04
+    horn_length = 0.25
 
     with pytest.raises(TypeError, match="The input medium_impedance"):
-        TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
+        TransmissionMatrix.create_conical_horn(area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
 
 
 @pytest.mark.parametrize(
@@ -843,15 +843,15 @@ def test_create_conical_horn_propagation_direction_type_errors(
     k = FrequencyData(np.array([[1j, 2, 3j], [4j, 5, 6j]]), [1, 2, 3])
     Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
 
-    S0 = 0.03
-    S1 = 0.04
-    L = 0.25
+    area_narrow_end = 0.03
+    area_wide_end = 0.04
+    horn_length = 0.25
 
     with pytest.raises(TypeError, match="The input propagation_direction"):
         TransmissionMatrix.create_conical_horn(
-            S0,
-            S1,
-            L,
+            area_narrow_end,
+            area_wide_end,
+            horn_length,
             k,
             Z,
             propagation_direction,
@@ -866,18 +866,18 @@ def test_create_conical_horn_propagation_direction_value_errors(
     k = FrequencyData(np.array([[1j, 2, 3j], [4j, 5, 6j]]), [1, 2, 3])
     Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 3])
 
-    S0 = 0.03
-    S1 = 0.04
-    L = 0.25
+    area_narrow_end = 0.03
+    area_wide_end = 0.04
+    horn_length = 0.25
 
     with pytest.raises(
         ValueError,
         match="The string propagation_direction must either",
     ):
         TransmissionMatrix.create_conical_horn(
-            S0,
-            S1,
-            L,
+            area_narrow_end,
+            area_wide_end,
+            horn_length,
             k,
             Z,
             propagation_direction,
@@ -889,12 +889,12 @@ def test_create_conical_horn_frequency_matching():
     k = FrequencyData([1j, 2, 3j], [1, 2, 3])
     Z = FrequencyData([1 + 1j, 2 + 2j, 3 + 1j], [1, 2, 4])
 
-    S0 = 0.03
-    S1 = 0.04
-    L = 0.25
+    area_narrow_end = 0.03
+    area_wide_end = 0.04
+    horn_length = 0.25
 
     with pytest.raises(ValueError, match="The frequencies of"):
-        TransmissionMatrix.create_conical_horn(S0, S1, L, k, Z, "backwards")
+        TransmissionMatrix.create_conical_horn(area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -471,39 +471,45 @@ def test_create_transmission_line_frequency_matching():
     "area_narrow_end",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_area_narrow_end_value_error(area_narrow_end):
+def test_calculate_horn_geometry_parameters_S0_value_error(area_narrow_end):
     area_wide_end = 0.2
     horn_length = 0.35
 
     with pytest.raises(ValueError, match="The input area_narrow_end"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
+        TransmissionMatrix.\
+            _calculate_horn_geometry_parameters\
+            (area_narrow_end, area_wide_end, horn_length)
 
 
 @pytest.mark.parametrize(
     "area_wide_end",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_area_wide_end_value_error(area_wide_end):
+def test_calculate_horn_geometry_parameters_S1_value_error(area_wide_end):
     area_narrow_end = 0.2
     horn_length = 0.35
 
     with pytest.raises(ValueError, match="The input area_wide_end"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
+        TransmissionMatrix.\
+            _calculate_horn_geometry_parameters\
+            (area_narrow_end, area_wide_end, horn_length)
 
 
 @pytest.mark.parametrize(
     "horn_length",
     [{"a": 1, "b": 2}, np.array([1, 2, 3]), "term", 0, -5, 2j],
 )
-def test_calculate_horn_geometry_parameters_horn_length_value_error(horn_length):
+def test_calculate_horn_geometry_parameters_L_value_error(horn_length):
     area_narrow_end = 0.2
     area_wide_end = 0.3
 
     with pytest.raises(ValueError, match="The input horn_length"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
+        TransmissionMatrix.\
+            _calculate_horn_geometry_parameters\
+            (area_narrow_end, area_wide_end, horn_length)
 
 
-def test_calculate_horn_geometry_parameters_area_narrow_end_larger_area_wide_end_value_error():
+def test_calculate_horn_geometry_parameters_S0_larger_S1_value_error():
     area_narrow_end = 0.35
     area_wide_end = 0.3
     horn_length = 0.35
@@ -512,16 +518,21 @@ def test_calculate_horn_geometry_parameters_area_narrow_end_larger_area_wide_end
         ValueError,
         match="area_narrow_end must be strictly smaller than area_wide_end.",
     ):
-        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
+        TransmissionMatrix.\
+            _calculate_horn_geometry_parameters\
+            (area_narrow_end, area_wide_end, horn_length)
 
 
-def test_calculate_horn_geometry_parameters_area_narrow_end_equal_area_wide_end_value_error():
+def test_calculate_horn_geometry_parameters_S0_equal_S1_value_error():
     area_narrow_end = 0.35
     area_wide_end = 0.35
     horn_length = 0.2
 
-    with pytest.raises(ValueError, match="For a conical horn area_narrow_end must be"):
-        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
+    with pytest.raises(ValueError, match=\
+        "For a conical horn area_narrow_end must be"):
+        TransmissionMatrix.\
+            _calculate_horn_geometry_parameters\
+            (area_narrow_end, area_wide_end, horn_length)
 
 
 def test_calculate_horn_geometry_calculations():
@@ -534,7 +545,8 @@ def test_calculate_horn_geometry_calculations():
     horn_length = b - a
 
     Omega_ret, a_ret, b_ret = (
-        TransmissionMatrix._calculate_horn_geometry_parameters(area_narrow_end, area_wide_end, horn_length)
+        TransmissionMatrix._calculate_horn_geometry_parameters\
+            (area_narrow_end, area_wide_end, horn_length)
     )
 
     assert np.isclose(Omega, Omega_ret, atol=1e-15)
@@ -816,8 +828,10 @@ def test_create_conical_horn_k_errors(k):
     area_wide_end = 0.04
     horn_length = 0.25
 
-    with pytest.raises(TypeError, match="The wavenumber k"):
-        TransmissionMatrix.create_conical_horn(area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
+    with pytest.raises(TypeError, match=\
+        "The wavenumber k"):
+        TransmissionMatrix.create_conical_horn\
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
 
 
 @pytest.mark.parametrize("Z", [np.array([1, 2, 3]), "imp"])
@@ -828,8 +842,10 @@ def test_create_conical_horn_medium_impedance_errors(Z):
     area_wide_end = 0.04
     horn_length = 0.25
 
-    with pytest.raises(TypeError, match="The input medium_impedance"):
-        TransmissionMatrix.create_conical_horn(area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
+    with pytest.raises(TypeError, match=\
+        "The input medium_impedance"):
+        TransmissionMatrix.create_conical_horn\
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
 
 
 @pytest.mark.parametrize(
@@ -894,7 +910,8 @@ def test_create_conical_horn_frequency_matching():
     horn_length = 0.25
 
     with pytest.raises(ValueError, match="The frequencies of"):
-        TransmissionMatrix.create_conical_horn(area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
+        TransmissionMatrix.create_conical_horn\
+            (area_narrow_end, area_wide_end, horn_length, k, Z, "backwards")
 
 def test_tmatrix_slicing(frequencies):
     """Test whether slicing a T-Matrix object return T-Matrix or raises correct

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -697,21 +697,21 @@ def test_create_conical_horn_k_number():
         "forwards",
     )
 
-    A = b / a * np.cos(k.freq * (b - a)) - 1 / (k.freq * a) * np.sin(
-        k.freq * (b - a),
+    A = b / a * np.cos(k * (b - a)) - 1 / (k * a) * np.sin(
+        k * (b - a),
     )
-    B = 1j * Z / (a * b * Omega) * np.sin(k.freq * (b - a))
+    B = 1j * Z / (a * b * Omega) * np.sin(k * (b - a))
     C = (
         1j
         * Omega
-        / (k.freq * k.freq * Z)
+        / (k * k * Z)
         * (
-            (1 + k.freq * k.freq * a * b) * np.sin(k.freq * (b - a))
-            - k.freq * (b - a) * np.cos(k.freq * (b - a))
+            (1 + k * k * a * b) * np.sin(k * (b - a))
+            - k * (b - a) * np.cos(k * (b - a))
         )
     )
-    D = a / b * np.cos(k.freq * (b - a)) + 1 / (k.freq * b) * np.sin(
-        k.freq * (b - a),
+    D = a / b * np.cos(k * (b - a)) + 1 / (k * b) * np.sin(
+        k * (b - a),
     )
     inv_prefix = 1 / (A * D - B * C)
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -829,7 +829,7 @@ def test_create_conical_horn_k_errors(k):
     horn_length = 0.25
 
     with pytest.raises(TypeError, match=\
-        "The wavenumber k"):
+        "wave_number must be"):
         TransmissionMatrix.create_conical_horn\
             (area_narrow_end, area_wide_end, horn_length, k, Z, "backward")
 

--- a/tests/test_transmission_matrix.py
+++ b/tests/test_transmission_matrix.py
@@ -491,31 +491,17 @@ def test_calculate_horn_geometry_parameters_value_error(param, invalid_value):
             parameters["horn_length"])
 
 
-
-def test_calculate_horn_geometry_parameters_S0_larger_S1_value_error():
+@pytest.mark.parametrize("value", [0.3, 0.35])
+def test_calculate_horn_geometry_parameters_S0_larger_S1_value_error(value):
     area_narrow_end = 0.35
-    area_wide_end = 0.3
+    area_wide_end = value
     horn_length = 0.35
-
     with pytest.raises(
         ValueError,
         match="area_narrow_end must be strictly smaller than area_wide_end.",
     ):
-        TransmissionMatrix.\
-            _calculate_horn_geometry_parameters\
-            (area_narrow_end, area_wide_end, horn_length)
-
-
-def test_calculate_horn_geometry_parameters_S0_equal_S1_value_error():
-    area_narrow_end = 0.35
-    area_wide_end = 0.35
-    horn_length = 0.2
-
-    with pytest.raises(ValueError, match=\
-        "For a conical horn area_narrow_end must be"):
-        TransmissionMatrix.\
-            _calculate_horn_geometry_parameters\
-            (area_narrow_end, area_wide_end, horn_length)
+        TransmissionMatrix._calculate_horn_geometry_parameters(
+            area_narrow_end, area_wide_end, horn_length)
 
 
 def test_calculate_horn_geometry_calculations():


### PR DESCRIPTION
### Changes proposed in this pull request:
This PR adds a function `create_conical_horn` to `pf.TransmissionMatrix` that returns the matrix representation of a conical horn transmission line section as stated e.g. in *Lampton - 1978 - Transmission Matrices in Electroacoustics.pdf*.

The function takes the arguments:
- `S0: float` - The surface area of the narrow end
- `S1: float` - The surface area of the wider end
- `L: float` - The section's length
- `k: FrequencyData, scalar` - the wave number
- `medium_impedance: FrequencyData, scalar` - the impedance of the medium filling the horn
- `propagation_direction: str = {'forwards', 'backwards'}` - The direction of sound propagation through the horn

Distances from the horns virtual apex are calculated internally using a private function `_calculate_horn_geometry_parameters`.

#### It is important to note that `medium_impedance` is **not** the same as `characteristic_impedance` taken in by `create_transmission_line`:

The latter is referenced to the cross-sectional area of the transmission line, but the conical horn has no constant cross-section so these parameters have to be distinct.
