### PR TITLE
Deprecate `dsp.fractional octave frequencies`

### DIFF
--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -458,7 +458,7 @@ def fractional_octave_filter_tolerance(
     ----------
     exact_center_frequency : float
         The exact center frequency of the band filter in Hz (see
-        :py:func:`~pyfar.dsp.filter.fractional_octave_frequencies`).
+        :py:func:`~pyfar.constants.fractional_octave_frequencies_exact`).
     num_fractions : Literal[1, 3]
         The number of bands an octave is divided into. ``1`` for octave bands
         and ``3`` for third octave bands.

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -280,8 +280,8 @@ def test_deprecations_reconstructing_fractional_octave_bands_frequencies():
     with pytest.warns(
         PyfarDeprecationWarning, match="Return parameter 'frequencies' will be"
         " removed in pyfar 0.9.0. To get the fractional octave center "
-        "frequencies, use `pyfar.dsp.filter.fractional_octave_frequencies` "
-        "instead."):
+        "frequencies, use `pyfar.constants.fractional_octave_frequencies_"
+        "exact` instead."):
         pfilt.reconstructing_fractional_octave_bands(None,
                                                      sampling_rate=44.1e3)
 

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -6,6 +6,7 @@ import pyfar as pf
 from pyfar import Signal
 import pyfar.dsp.filter as pfilt
 import pyfar.classes.filter as pclass
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 
 def test_butterworth(impulse):
@@ -322,8 +323,10 @@ def test_reconstructing_fractional_octave_bands():
     """Test the reconstructing fractional octave filter bank."""
 
     # test filter object
-    f_obj, f = pfilt.reconstructing_fractional_octave_bands(
-        None, sampling_rate=44100)
+    message = "Return parameter 'frequencies' will be removed in pyfar 0.9.0."
+    with pytest.warns(PyfarDeprecationWarning, match=message):
+        f_obj, f = pfilt.reconstructing_fractional_octave_bands(
+            None, sampling_rate=44100)
     assert isinstance(f_obj, pclass.FilterFIR)
     assert f_obj.comment == \
         ("Reconstructing linear phase fractional octave filter bank."
@@ -331,13 +334,14 @@ def test_reconstructing_fractional_octave_bands():
     assert f_obj.sampling_rate == 44100
 
     # test frequencies
-    _, f_test = pfilt.fractional_octave_frequencies(
-        frequency_range=(63, 16000))
+    f_test, *_ = pf.constants.fractional_octave_frequencies_exact(
+        num_fractions=1, frequency_range=(63, 16000))
     npt.assert_allclose(f, f_test)
 
     # test filtering
     x = pf.signals.impulse(2**12)
-    y, f = pfilt.reconstructing_fractional_octave_bands(x)
+    with pytest.warns(PyfarDeprecationWarning, match=message):
+        y, f = pfilt.reconstructing_fractional_octave_bands(x)
     assert isinstance(y, Signal)
     assert y.cshape == (9, 1)
     assert y.fft_norm == 'none'
@@ -354,10 +358,13 @@ def test_reconstructing_fractional_octave_bands_filter_slopes():
     # test different filter slopes against reference
     x = pf.signals.impulse(2**10)
 
+    message = "Return parameter 'frequencies' will be removed in pyfar 0.9.0."
+
     for overlap, slope in zip([1, 1, 0], [0, 3, 0]):
-        y, _ = pfilt.reconstructing_fractional_octave_bands(
-            x, frequency_range=(8e3, 16e3), overlap=overlap, slope=slope,
-            n_samples=2**10)
+        with pytest.warns(PyfarDeprecationWarning, match=message):
+            y, _ = pfilt.reconstructing_fractional_octave_bands(
+                x, frequency_range=(8e3, 16e3), overlap=overlap, slope=slope,
+                n_samples=2**10)
         reference = np.loadtxt(os.path.join(
             os.path.dirname(__file__), "references",
             f"filter.reconstructing_octaves_{overlap}_{slope}.csv"))
@@ -369,9 +376,13 @@ def test_reconstructing_fractional_octave_bands_filter_slopes():
 
 def test_reconstructing_fractional_octave_bands_warning():
     """Test warning for octave frequency exceeding half the sampling rate."""
+
+    message = "Return parameter 'frequencies' will be removed in pyfar 0.9.0."
+
     with pytest.warns(UserWarning):
         x = pf.signals.impulse(2**12, sampling_rate=16e3)
-        y, f = pfilt.reconstructing_fractional_octave_bands(x)
+        with pytest.warns(PyfarDeprecationWarning, match=message):
+            y, f = pfilt.reconstructing_fractional_octave_bands(x)
 
 
 def test_notch(impulse):

--- a/tests/test_fractional_octaves.py
+++ b/tests/test_fractional_octaves.py
@@ -6,6 +6,10 @@ import pyfar
 from pyfar.dsp import filter
 from pyfar import FilterSOS, Signal
 
+message = ('pyfar.dsp.filter.fractional_octave_frequencies '
+           'will removed in pyfar 0.10.0')
+pytestmark = pytest.mark.filterwarnings(
+    f"ignore:{message}:pyfar.classes.warnings.PyfarDeprecationWarning")
 
 def test_center_frequencies_iec():
     nominal_octs = [31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Deprecate `dsp.fractional octave frequencies` in favour of `constants.fractional octave frequencies_nominal` and `constants.fractional octave frequencies_exact`

### Changes proposed in this pull request:

- add and test deprecation warning to `dsp.fractional octave frequencies`
- replace use of `dsp.fractional octave frequencies` everywhere

Tests fail because of #857 and should be fixed there. To fix them it would be required to change

- test_fractional_octaves, line 76 to `sr, 1, frequency_range=(10e3, 20e3), order=order)` and
- test_fractional_octaves, line 193 to `frequency_range = (30, 20000)`

