### PR TITLE
Fix warning when casting from complex to real Signals

### DIFF
--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -388,7 +388,7 @@ class TimeData(_Audio):
                 raise ValueError("Signal has complex-valued time data"
                                  " is_complex flag cannot be `False`.")
             self._complex = value
-            self._data = self._data.astype(float)
+            self._data = np.real(self._data).astype(float)
         # from complex=False to complex=True
         if not self._complex and value:
             self._complex = value


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Converting complex Signals to real raised a ComplexWarning: Casting complex values to real discards the imaginary part.

### Changes proposed in this pull request:

- take real part before casting from complex to float

