### PR TITLE
[Bugfix] add unit checks to group_delay_2d and freq_group_delay_2d

### DIFF
--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -200,6 +200,7 @@ def _group_delay_2d(signal, unit, freq_scale, indices, orientation, method,
                     colorbar, ax, side='right', **kwargs):
 
     # check input and prepare the figure, axis, and common parameters
+    _utils._check_time_unit(unit)
     fig, ax, indices, kwargs = _utils._prepare_2d_plot(
         signal, (Signal, ), 2, indices, method, ax, colorbar, **kwargs)
     _utils._check_axis_scale(freq_scale)
@@ -306,7 +307,8 @@ def _freq_group_delay_2d(
     """
     Plot the magnitude and group delay spectrum in a 2 by 1 subplot layout.
     """
-
+    # check unit and prepare plot
+    _utils._check_time_unit(unit)
     fig, ax = _utils._prepare_plot(ax, (2, 1))
 
     _, qm_0, cb_0 = _freq_2d(signal, dB, log_prefix, log_reference, freq_scale,

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -526,17 +526,18 @@ def test_2d_time_unit(function, unit, handsome_signal_2d):
                      filename, file_type, compare_output)
 
 
-def test_2d_time_unit_assertion(handsome_signal_2d):
+@pytest.mark.parametrize(
+        ('function'),
+        [(plot.time_2d), (plot.time_freq_2d), (plot.freq_group_delay_2d),
+         (plot.group_delay_2d)],
+)
+def test_2d_time_unit_assertion(function, handsome_signal_2d):
     """Test if all 2d plots raise an assertion for a wrong unit parameter."""
 
     create_figure()
     match = 'Unit is pascal but must be s, ms, mus, samples, auto.'
     with pytest.raises(ValueError, match=match):
-        plot.time_2d(handsome_signal_2d, unit="pascal")
-
-    match = "'pascal' is not in list"
-    with pytest.raises(ValueError, match=match):
-        plot.group_delay_2d(handsome_signal_2d, unit="pascal")
+        function(handsome_signal_2d, unit="pascal")
 
     plt.close("all")
 


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

#854 

### Changes proposed in this pull request:

- Add checks for unit parameter to `group_delay_2d` and `freq_group_delay_2d`
- Adjust tests to test warnings in all 2d-time functions for wrong unit input
