### PR TITLE
Use CircleCI trigger to create GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ jobs:
           name: build distribution
           command: |
             python -m build
-            twine_check dist/*
+            twine check dist/*
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
### Changes proposed in this pull request:

- Create a GitHub release from CircleCI on version tags after successful publication on PyPI.

Additional changes
- Separate building the package from uploading
- Use shared workspace folders to re-use the source and binary distributions from the build step
