### PR TITLE
BUG: scatter and quiver were hidden in the docs

### DIFF
--- a/docs/modules/pyfar.plot.rst
+++ b/docs/modules/pyfar.plot.rst
@@ -5,4 +5,3 @@ pyfar.plot
    :members:
    :undoc-members:
    :show-inheritance:
-   :exclude-members: [, scatter, quiver,]


### PR DESCRIPTION
### Changes proposed in this pull request:

- add scatter and quiver  to the docs.

Maybe there was a reason, why they were not added, but I suggest to add them the the documentation
