### PR TITLE
[ENH] Ticker module: Update frequency formatter

### DIFF
--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -3,7 +3,7 @@ from pyfar import Signal, TimeData, FrequencyData
 import pyfar.dsp as dsp
 from . import _utils
 from .ticker import (
-    LogFormatterITAToolbox,
+    UnitLogFormatter,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
@@ -99,7 +99,7 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax.xaxis.set_major_formatter(UnitLogFormatter())
 
     return ax
 
@@ -193,7 +193,7 @@ def _phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax.xaxis.set_major_formatter(UnitLogFormatter())
 
     return ax
 
@@ -244,7 +244,7 @@ def _group_delay(signal, unit="s", freq_scale='log', ax=None, side='right',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax.xaxis.set_major_formatter(UnitLogFormatter())
 
     return ax
 

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -3,7 +3,7 @@ from pyfar import Signal, TimeData, FrequencyData
 import pyfar.dsp as dsp
 from . import _utils
 from .ticker import (
-    FrequencyLogFormatter,
+    FrequencyFormatter,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
@@ -99,7 +99,7 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(FrequencyLogFormatter())
+    ax.xaxis.set_major_formatter(FrequencyFormatter())
 
     return ax
 
@@ -193,7 +193,7 @@ def _phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(FrequencyLogFormatter())
+    ax.xaxis.set_major_formatter(FrequencyFormatter())
 
     return ax
 
@@ -244,7 +244,7 @@ def _group_delay(signal, unit="s", freq_scale='log', ax=None, side='right',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(FrequencyLogFormatter())
+    ax.xaxis.set_major_formatter(FrequencyFormatter())
 
     return ax
 

--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -3,7 +3,7 @@ from pyfar import Signal, TimeData, FrequencyData
 import pyfar.dsp as dsp
 from . import _utils
 from .ticker import (
-    UnitLogFormatter,
+    FrequencyLogFormatter,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
@@ -99,7 +99,7 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(UnitLogFormatter())
+    ax.xaxis.set_major_formatter(FrequencyLogFormatter())
 
     return ax
 
@@ -193,7 +193,7 @@ def _phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(UnitLogFormatter())
+    ax.xaxis.set_major_formatter(FrequencyLogFormatter())
 
     return ax
 
@@ -244,7 +244,7 @@ def _group_delay(signal, unit="s", freq_scale='log', ax=None, side='right',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(UnitLogFormatter())
+    ax.xaxis.set_major_formatter(FrequencyLogFormatter())
 
     return ax
 

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -4,7 +4,7 @@ import pyfar.dsp as dsp
 from . import _utils
 import warnings
 from .ticker import (
-    LogFormatterITAToolbox,
+    UnitLogFormatter,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
@@ -108,7 +108,7 @@ def _freq_2d(signal, dB, log_prefix, log_reference, freq_scale, indices,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(LogFormatterITAToolbox())
+    axis[0].set_major_formatter(UnitLogFormatter())
 
     # color limits
     if dB and "vmin" not in kwargs:
@@ -173,7 +173,7 @@ def _phase_2d(signal, deg, unwrap, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(LogFormatterITAToolbox())
+    axis[0].set_major_formatter(UnitLogFormatter())
 
     # colorbar
     cb = _utils._add_colorbar(colorbar, fig, ax, qm,
@@ -236,7 +236,7 @@ def _group_delay_2d(signal, unit, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(LogFormatterITAToolbox())
+    axis[0].set_major_formatter(UnitLogFormatter())
 
     # color limits
     if "vmin" not in kwargs:
@@ -405,7 +405,7 @@ def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         ax[0].set_yscale('symlog')
         ax[0].yaxis.set_major_locator(LogLocatorITAToolbox())
         ax[0].yaxis.set_minor_formatter(NullFormatter())
-    ax[0].yaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax[0].yaxis.set_major_formatter(UnitLogFormatter())
     ax[0].grid(ls='dotted', color='white')
 
     # colorbar

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -4,7 +4,7 @@ import pyfar.dsp as dsp
 from . import _utils
 import warnings
 from .ticker import (
-    FrequencyLogFormatter,
+    FrequencyFormatter,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
@@ -108,7 +108,7 @@ def _freq_2d(signal, dB, log_prefix, log_reference, freq_scale, indices,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(FrequencyLogFormatter())
+    axis[0].set_major_formatter(FrequencyFormatter())
 
     # color limits
     if dB and "vmin" not in kwargs:
@@ -173,7 +173,7 @@ def _phase_2d(signal, deg, unwrap, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(FrequencyLogFormatter())
+    axis[0].set_major_formatter(FrequencyFormatter())
 
     # colorbar
     cb = _utils._add_colorbar(colorbar, fig, ax, qm,
@@ -236,7 +236,7 @@ def _group_delay_2d(signal, unit, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(FrequencyLogFormatter())
+    axis[0].set_major_formatter(FrequencyFormatter())
 
     # color limits
     if "vmin" not in kwargs:
@@ -405,7 +405,7 @@ def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         ax[0].set_yscale('symlog')
         ax[0].yaxis.set_major_locator(LogLocatorITAToolbox())
         ax[0].yaxis.set_minor_formatter(NullFormatter())
-    ax[0].yaxis.set_major_formatter(FrequencyLogFormatter())
+    ax[0].yaxis.set_major_formatter(FrequencyFormatter())
     ax[0].grid(ls='dotted', color='white')
 
     # colorbar

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -4,7 +4,7 @@ import pyfar.dsp as dsp
 from . import _utils
 import warnings
 from .ticker import (
-    UnitLogFormatter,
+    FrequencyLogFormatter,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
@@ -108,7 +108,7 @@ def _freq_2d(signal, dB, log_prefix, log_reference, freq_scale, indices,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(UnitLogFormatter())
+    axis[0].set_major_formatter(FrequencyLogFormatter())
 
     # color limits
     if dB and "vmin" not in kwargs:
@@ -173,7 +173,7 @@ def _phase_2d(signal, deg, unwrap, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(UnitLogFormatter())
+    axis[0].set_major_formatter(FrequencyLogFormatter())
 
     # colorbar
     cb = _utils._add_colorbar(colorbar, fig, ax, qm,
@@ -236,7 +236,7 @@ def _group_delay_2d(signal, unit, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(UnitLogFormatter())
+    axis[0].set_major_formatter(FrequencyLogFormatter())
 
     # color limits
     if "vmin" not in kwargs:
@@ -405,7 +405,7 @@ def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         ax[0].set_yscale('symlog')
         ax[0].yaxis.set_major_locator(LogLocatorITAToolbox())
         ax[0].yaxis.set_minor_formatter(NullFormatter())
-    ax[0].yaxis.set_major_formatter(UnitLogFormatter())
+    ax[0].yaxis.set_major_formatter(FrequencyLogFormatter())
     ax[0].grid(ls='dotted', color='white')
 
     # colorbar

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -77,16 +77,25 @@ class UnitLogFormatter(LogFormatter):
 
     Examples
     --------
-    The formatter is used by :py:func:`pyfar.plot.freq` per default for the
-    x-axis. It can also be set manually:
+    The formatter is used per default for frequency axes in pyfar plots:
 
     .. plot::
 
         >>> import pyfar as pf
         >>> signal = pf.signals.noise(1e3)
-        >>> ax = pf.plot.freq(signal)
-        >>> ax.xaxis.set_major_formatter(
-        ...     pf.plot.ticker.UnitLogFormatter())
+        >>> pf.plot.freq(signal)
+
+    It can also be used manually:
+
+    .. plot::
+
+        >>> import pyfar as pf
+        >>> import matplotlib.pyplot as plt
+        >>> fig, ax = plt.subplots()
+        >>> ax.plot([20, 20e3], [1, 2])
+        >>> ax.set_xscale('log')
+        >>> ax.xaxis.set_major_formatter(pf.plot.ticker.UnitLogFormatter())
+
 
     """
 

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -65,10 +65,9 @@ class LogLocatorITAToolbox(LogLocator):
             numticks=numticks)
 
 
-class LogFormatterITAToolbox(LogFormatter):
+class UnitLogFormatter(LogFormatter):
     """
-    Log-formatter inspired by the tick labels used in the ITA-Toolbox
-    for MATLAB. Uses unit inspired labels e.g. `1e3 = 1k`, `1e6 = 1M`.
+    Log-formatter which uses unit inspired labels e.g. `1e3 = 1k`, `1e6 = 1M`.
     """
 
     def __init__(

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -4,7 +4,6 @@ from matplotlib import transforms as mtransforms
 from matplotlib.ticker import (
     FixedFormatter,
     FixedLocator,
-    LogFormatter,
     LogLocator,
     MultipleLocator,
     Formatter)
@@ -65,16 +64,16 @@ class LogLocatorITAToolbox(LogLocator):
             numticks=numticks)
 
 
-class FrequencyLogFormatter(LogFormatter):
+class FrequencyFormatter(Formatter):
     """
-    Log-formatter which uses unit inspired labels particularly
+    Formatter which uses unit inspired labels particularly
     suitable for frequency axes, e.g. `1e3 = 1k`, `1e6 = 1M`.
 
 
     Parameters
     ----------
     **kwargs
-        Keyword arguments to be passed to :py:func:`LogFormatter`.
+        Keyword arguments to be passed to :py:func:`Formatter`.
 
     Examples
     --------
@@ -93,10 +92,9 @@ class FrequencyLogFormatter(LogFormatter):
         >>> import pyfar as pf
         >>> import matplotlib.pyplot as plt
         >>> fig, ax = plt.subplots()
-        >>> ax.plot([20, 20e3], [1, 2])
-        >>> ax.set_xscale('log')
+        >>> ax.plot([500, 1000, 1500], [1, 2, 3])
         >>> ax.xaxis.set_major_formatter(
-        ...     pf.plot.ticker.FrequencyLogFormatter())
+        ...     pf.plot.ticker.FrequencyFormatter())
 
 
     """
@@ -115,7 +113,7 @@ class FrequencyLogFormatter(LogFormatter):
             try:
                 s = self._pprint_val(x, vmax - vmin)
             except AttributeError:
-                s = self.pprint_val(x, vmax - vmin)
+                s = str(x).rstrip('0').rstrip('.')
         return s
 
     def __call__(self, x, pos=None):  # noqa: ARG002

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -2,32 +2,10 @@
 import numpy as np
 from matplotlib import transforms as mtransforms
 from matplotlib.ticker import (
-    FixedFormatter,
     FixedLocator,
     LogLocator,
     MultipleLocator,
     Formatter)
-
-
-class FractionalOctaveFormatter(FixedFormatter):
-    """Formatter for fractional octave bands."""
-
-    def __init__(self, n_fractions=1):
-        if n_fractions == 1:
-            ticks = [
-                '16', '31.5', '63', '125', '250', '500',
-                '1k', '2k', '4k', '8k', '16k']
-        elif n_fractions == 3:
-            ticks = [
-                '12.5', '16', '20', '25', '31.5', '40',
-                '50', '63', '80', '100', '125', '160',
-                '200', '250', '315', '400', '500', '630',
-                '800', '1k', '1.25k', '1.6k', '2k', '2.5k',
-                '3.15k', '4k', '5k', '6.3k', '8k', '10k',
-                '12.5k', '16k', '20k']
-        else:
-            raise ValueError("Unsupported number of fractions.")
-        super().__init__(ticks)
 
 
 class FractionalOctaveLocator(FixedLocator):

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -65,9 +65,10 @@ class LogLocatorITAToolbox(LogLocator):
             numticks=numticks)
 
 
-class UnitLogFormatter(LogFormatter):
+class FrequencyLogFormatter(LogFormatter):
     """
-    Log-formatter which uses unit inspired labels e.g. `1e3 = 1k`, `1e6 = 1M`.
+    Log-formatter which uses unit inspired labels particularly
+    suitable for frequency axes, e.g. `1e3 = 1k`, `1e6 = 1M`.
 
 
     Parameters
@@ -94,7 +95,8 @@ class UnitLogFormatter(LogFormatter):
         >>> fig, ax = plt.subplots()
         >>> ax.plot([20, 20e3], [1, 2])
         >>> ax.set_xscale('log')
-        >>> ax.xaxis.set_major_formatter(pf.plot.ticker.UnitLogFormatter())
+        >>> ax.xaxis.set_major_formatter(
+        ...     pf.plot.ticker.FrequencyLogFormatter())
 
 
     """

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -68,20 +68,30 @@ class LogLocatorITAToolbox(LogLocator):
 class UnitLogFormatter(LogFormatter):
     """
     Log-formatter which uses unit inspired labels e.g. `1e3 = 1k`, `1e6 = 1M`.
+
+
+    Parameters
+    ----------
+    **kwargs
+        Keyword arguments to be passed to :py:func:`LogFormatter`.
+
+    Examples
+    --------
+    The formatter is used by :py:func:`pyfar.plot.freq` per default for the
+    x-axis. It can also be set manually:
+
+    .. plot::
+
+        >>> import pyfar as pf
+        >>> signal = pf.signals.noise(1e3)
+        >>> ax = pf.plot.freq(signal)
+        >>> ax.xaxis.set_major_formatter(
+        ...     pf.plot.ticker.UnitLogFormatter())
+
     """
 
-    def __init__(
-        self,
-        base=10.0,
-        labelOnlyBase=False,
-        minor_thresholds=None,
-        linthresh=None,
-    ):
-        super().__init__(
-            base=base,
-            labelOnlyBase=labelOnlyBase,
-            minor_thresholds=minor_thresholds,
-            linthresh=linthresh)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
     def _num_to_string(self, x, vmin, vmax):
         if x >= 1000 and x < 1e6:


### PR DESCRIPTION
Part of adding the ticker module in #877.

### Changes proposed in this pull request:

- Renamed LogFormatterITAToolbox to FrequencyFormatter
- Added example to docs
- Replaced LogFormatter with Formatter: This make the formatter more generalizable. For example, it can be used on linear axes (see example) and for formatting fixed standardized fractional octave frequencies.
- This replacement made the FractionalOctaveFormatter obsolete, so removed it.

