### PR TITLE
Update air attenuation docstring

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -31,6 +31,7 @@ Changed
 - Files accessed by the module `pyfar.signals.files` are now stored on https://github.com/pyfar/files (PR #807)
 - Remove command line cluttering print outs when loading `pf.signals.files.binaural_room_impulse_response` and `pf.signals.files.headphone_impulse_responses` (PR #718)
 - Improved internal documentation of the `_codec` module that handles reading and writing pyfar data from and to disk (PR #712)
+- Improved docstrings in `pyfar.constants` (PR #899)
 
 Deprecated
 ^^^^^^^^^^

--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -37,9 +37,9 @@ def air_attenuation(
         Pure tone air attenuation coefficient in decibels per meter for
         atmospheric absorption.
     m : :py:class:`~pyfar.FrequencyData`
-        Pure tone air attenuation coefficient per meter for
-        atmospheric absorption. The parameter ``m`` is calculated as
-        :math:`m = \alpha / (10 \cdot \log_{10}(e))`.
+        Pure tone energy attenuation coefficient in 1/m for atmospheric
+        absorption. The parameter ``m`` is calculated as
+        :math:`m = \alpha / (10 \log_{10}(e))`.
     accuracy : :py:class:`~pyfar.FrequencyData`
         accuracy of the results according to the standard:
 

--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -19,7 +19,7 @@ def air_attenuation(
     Parameters
     ----------
     temperature : float, array_like
-        Temperature in degree Celsius.
+        Temperature in °C.
         Must be in the range of -20°C to 50°C for accuracy of +/-10% or
         must be greater than -70°C for accuracy of +/-50%.
     frequencies : float, array_like
@@ -34,8 +34,8 @@ def air_attenuation(
     Returns
     -------
     alpha : np.ndarray[float]
-        Pure tone air attenuation coefficient in decibels per meter for
-        atmospheric absorption.
+        Pure tone air attenuation coefficient in dB/m for atmospheric
+        absorption.
     m : :py:class:`~pyfar.FrequencyData`
         Pure tone energy attenuation coefficient in 1/m for atmospheric
         absorption. The parameter ``m`` is calculated as

--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -44,15 +44,15 @@ def air_attenuation(
         accuracy of the results according to the standard:
 
         ``10``, +/- 10% accuracy
-            - molar concentration of water vapour: 0.05% to 5 %.
-            - air temperature: 253.15 K to 323.15 (-20 °C to +50°C)
+            - molar concentration of water vapour: 0.05% to 5%.
+            - air temperature: 253.15 K to 323.15 (-20 °C to +50 °C)
             - atmospheric pressure: less than 200 000 Pa (2 atm)
             - frequency-to-pressure ratio: 0.0004 Hz/Pa to 10 Hz/Pa.
 
         ``20``, +/- 20% accuracy
-            - molar concentration of water vapour: 0.005 % to 0.05 %,
+            - molar concentration of water vapour: 0.005% to 0.05%,
               and greater than 5%
-            - air temperature: 253.15 K to 323.15 (-20 °C to +50°C)
+            - air temperature: 253.15 K to 323.15 (-20 °C to +50 °C)
             - atmospheric pressure: less than 200 000 Pa (2 atm)
             - frequency-to-pressure ratio: 0.0004 Hz/Pa to 10 Hz/Pa.
 
@@ -193,13 +193,13 @@ def _air_attenuation_accuracy(
         accuracy of the results according to the standard:
 
             ``10``, +/- 10% accuracy
-                - molar concentration of water vapour: 0.05% to 5 %.
+                - molar concentration of water vapour: 0.05% to 5%.
                 - air temperature: 253.15 K to 323.15 (-20 °C to +50°C)
                 - atmospheric pressure: less than 200 000 Pa (2 atm)
                 - frequency-to-pressure ratio: 4 x 10-4 Hz/Pa to 10 Hz/Pa.
 
             ``20``, +/- 20% accuracy
-                - molar concentration of water vapour: 0.005 % to 0.05 %,
+                - molar concentration of water vapour: 0.005% to 0.05%,
                   and greater than 5%
                 - air temperature: 253.15 K to 323.15 (-20 °C to +50°C)
                 - atmospheric pressure: less than 200 000 Pa (2 atm)
@@ -247,9 +247,9 @@ def _air_attenuation_accuracy(
         frequency_pressure_ratio <= 10)
     common_mask = atm_mask & frequency_pressure_ratio_mask
 
-    # molar concentration of water vapour: 0.05% to 5 %
+    # molar concentration of water vapour: 0.05% to 5%
     vapor_10_mask = (0.05 <= h_water_vapor) & (h_water_vapor <= 5)
-    # molar concentration of water vapour: 0.005% to 0.05 % and greater than 5%
+    # molar concentration of water vapour: 0.005% to 0.05% and greater than 5%
     vapor_20_mask = (5 < h_water_vapor) | (
         (0.005 <= h_water_vapor) & (h_water_vapor < 0.05))
     # molar concentration of water vapour: less than 0.005%

--- a/pyfar/constants/constants.py
+++ b/pyfar/constants/constants.py
@@ -20,8 +20,8 @@ def air_attenuation(
     ----------
     temperature : float, array_like
         Temperature in °C.
-        Must be in the range of -20°C to 50°C for accuracy of +/-10% or
-        must be greater than -70°C for accuracy of +/-50%.
+        Must be in the range of -20 °C to 50 °C for accuracy of +/-10% or
+        must be greater than -70 °C for accuracy of +/-50%.
     frequencies : float, array_like
         Frequency in Hz. Must be greater than 50 Hz.
         Just one dimensional array is allowed.
@@ -45,14 +45,14 @@ def air_attenuation(
 
         ``10``, +/- 10% accuracy
             - molar concentration of water vapour: 0.05% to 5%.
-            - air temperature: 253.15 K to 323.15 (-20 °C to +50 °C)
+            - air temperature: 253.15 K to 323.15 K (-20 °C to +50 °C)
             - atmospheric pressure: less than 200 000 Pa (2 atm)
             - frequency-to-pressure ratio: 0.0004 Hz/Pa to 10 Hz/Pa.
 
         ``20``, +/- 20% accuracy
             - molar concentration of water vapour: 0.005% to 0.05%,
               and greater than 5%
-            - air temperature: 253.15 K to 323.15 (-20 °C to +50 °C)
+            - air temperature: 253.15 K to 323.15 K (-20 °C to +50 °C)
             - atmospheric pressure: less than 200 000 Pa (2 atm)
             - frequency-to-pressure ratio: 0.0004 Hz/Pa to 10 Hz/Pa.
 
@@ -194,14 +194,14 @@ def _air_attenuation_accuracy(
 
             ``10``, +/- 10% accuracy
                 - molar concentration of water vapour: 0.05% to 5%.
-                - air temperature: 253.15 K to 323.15 (-20 °C to +50°C)
+                - air temperature: 253.15 K to 323.15 K (-20 °C to +50 °C)
                 - atmospheric pressure: less than 200 000 Pa (2 atm)
                 - frequency-to-pressure ratio: 4 x 10-4 Hz/Pa to 10 Hz/Pa.
 
             ``20``, +/- 20% accuracy
                 - molar concentration of water vapour: 0.005% to 0.05%,
                   and greater than 5%
-                - air temperature: 253.15 K to 323.15 (-20 °C to +50°C)
+                - air temperature: 253.15 K to 323.15 K (-20 °C to +50 °C)
                 - atmospheric pressure: less than 200 000 Pa (2 atm)
                 - frequency-to-pressure ratio: 4 x 10-4 Hz/Pa to 10 Hz/Pa.
 


### PR DESCRIPTION
Hey all,

I updated the docstrings in `constants.py`:
1. The air attenuation docstring now explicitely explains that $m$ is an _energy_-based attenuation coefficient (as opposed to pressure-based).
2. Consistent use of SI symbols instead of written out units.
3. Consistent spaces between value and unit (single space for SI units, no space for percentages)

ruff gives me no complaints.