### PR TITLE
Normalize in the signal's domain

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 
 Fixed
 ^^^^^
-* Apply normalization in the signal's native domain to prevent floating point errors (PR #900)
+* Make `pyfar.dsp.normalize` use the signal's native domain to avoid floating point errors (PR #900)
 
 0.7.4 (2026-02-02)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ History
 
 Fixed
 ^^^^^
-* Make `pyfar.dsp.normalize` use the signal's native domain to avoid floating point errors (PR #900)
+* Make `pyfar.dsp.normalize` use the signal's current domain to avoid floating point errors (PR #900)
 
 0.7.4 (2026-02-02)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 History
 =======
 
+
+[Unreleased]
+------------
+
+Fixed
+^^^^^
+* Apply normalization in the signal's native domain to prevent floating point errors (PR #900)
+
 0.7.4 (2026-02-02)
 ------------------
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2592,6 +2592,9 @@ def normalize(signal, reference_method='max', domain='auto',
         raise TypeError(("Input data has to be of type 'Signal', 'TimeData' "
                          "or 'FrequencyData'."))
 
+    # Store signal domain for later.
+    signal_domain = signal.domain
+
     if domain not in ('time', 'freq', 'auto'):
         raise ValueError("domain must be 'time', 'freq' or 'auto' but is"
                          f" '{domain}'.")
@@ -2693,6 +2696,12 @@ def normalize(signal, reference_method='max', domain='auto',
     normalized_signal = pyfar.divide(
         (pyfar.multiply((signal.copy(), target), domain=signal.domain),
          reference_norm), domain=signal.domain)
+
+    # Restore original domain of Signals. This only affects edge cases where
+    # normalization is not applied in the signal's native domain.
+    if isinstance(normalized_signal, pyfar.Signal):
+        normalized_signal.domain = signal_domain
+
     if return_reference:
         return normalized_signal, reference_norm
     else:

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -2687,8 +2687,12 @@ def normalize(signal, reference_method='max', domain='auto',
         reference_norm = np.sqrt(reference_norm)
         target = np.sqrt(target)
 
-    # apply normalization
-    normalized_signal = signal.copy() * target / reference_norm
+    # Apply normalization in the current domain of the signal. This avoids
+    # unnecessary conversions between the time and frequency domain which
+    # introduce numerical errors.
+    normalized_signal = pyfar.divide(
+        (pyfar.multiply((signal.copy(), target), domain=signal.domain),
+         reference_norm), domain=signal.domain)
     if return_reference:
         return normalized_signal, reference_norm
     else:


### PR DESCRIPTION
This is related to #813 but was easier to fix.

Normalizing a signal in the wrong domain introduces noise, depending on the numerical precision.
I fixed `pf.dsp.normalize`, so it uses `signal.domain` instead of always defaulting do multiplication and division in the frequency domain.

This plot reproduces the issue. The second row shows `signal*1`, which still defaults to frequency domain multiplication.

<img width="500" alt="precision_normalization" src="https://github.com/user-attachments/assets/f9f33269-7b53-433b-a290-68ed88a928d9" />

Code to reproduce:
```python
import pyfar as pf
import numpy as np
import matplotlib.pyplot as plt

data_double = np.logspace(0, -20, 10000)
data_single = np.logspace(0, -20, 10000, dtype=np.float32)
signal_double = pf.Signal(data_double, 44100, domain='time')
signal_single = pf.Signal(data_single, 44100, domain='time')

fig, ax = plt.subplots(3,1, figsize=(5, 6))
pf.plot.time(signal_single, dB=True, label='single', ax=ax[0])
pf.plot.time(signal_double, dB=True, label='double', ax=ax[0])
pf.plot.time(signal_single * 1, dB=True, ax=ax[1], label='single*1, time domain')
pf.plot.time(signal_double * 1, dB=True, ax=ax[1], label='double*1, time domain')
pf.plot.time(pf.dsp.normalize(signal_double), dB=True, label='norm double', ax=ax[2])
pf.plot.time(pf.dsp.normalize(signal_single), dB=True, label='norm single', ax=ax[2])

ax[0].set_title('Original Signals')
ax[1].set_title('Before: Normalization always in frequency domain')
ax[2].set_title('After: Normalization in signal.domain')
ax[0].legend()

for a in ax:
    a.set_ylim(-400, 0)
plt.tight_layout()
```
