### PR TITLE
deprecate fractional_octave_frequencies

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -36,6 +36,7 @@ Changed
 Deprecated
 ^^^^^^^^^^
 - The return parameter `frequencies` from `pyfar.dsp.filter.reconstructing_fractional_octave_bands` is deprecated and will be removed in pyfar v0.9.0 (PR #725)
+- `pyfar.dsp.filter.fractional_octave_frequencies` is deprecated in favour of `pyfar.constants.fractional_octave_frequencies_exact` and `pyfar.constants.fractional_octave_frequencies_nominal` and will be removed in pyfar v0.10.0 (PR #902)
 
 Removed
 ^^^^^^^

--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -40,6 +40,13 @@ def fractional_octave_frequencies(
         The lower and upper critical frequencies in Hz of the bandpass filters
         for each band as a tuple corresponding to ``(f_lower, f_upper)``.
     """
+
+    warnings.warn(("`pyfar.dsp.filter.fractional_octave_frequencies` will be "
+                   "deprecated in pyfar 0.10.0. Use "
+                   "`pyfar.constants.fractional_octave_frequencies_exact` or "
+                   "`pyfar.constants.fractional_octave_frequencies_nominal`"
+                   " instead."), PyfarDeprecationWarning, stacklevel=1)
+
     nominal = None
 
     f_lims = np.asarray(frequency_range)
@@ -332,11 +339,9 @@ def _coefficients_fractional_octave_bands(
     increased numeric accuracy and stability.
     """
 
-    f_crit = fractional_octave_frequencies(
-        num_fractions, frequency_range, return_cutoff=True)[2]
-
-    freqs_upper = f_crit[1]
-    freqs_lower = f_crit[0]
+    _, freqs_lower, freqs_upper = \
+        pf.constants.fractional_octave_frequencies_exact(
+            num_fractions, frequency_range)
 
     # normalize interval such that the Nyquist frequency is 1
     Wns = np.vstack((freqs_lower, freqs_upper)).T / sampling_rate * 2
@@ -426,8 +431,9 @@ def check_fractional_octave_band_filter_tolerance(
     if tolerance_class not in [1, 2]:
         raise ValueError('tolerance_class must be 1 or 2')
 
-    exact_center_frequencies = fractional_octave_frequencies(
-        num_fractions, frequency_range)[1]
+    exact_center_frequencies = \
+        pf.constants.fractional_octave_frequencies_exact(
+            num_fractions, frequency_range)[0]
 
     ir = fractional_octave_band_filter.impulse_response(n_samples)
     log_magnitude = pf.dsp.decibel(ir).squeeze()
@@ -549,8 +555,8 @@ def reconstructing_fractional_octave_bands(
         >>> x = pf.signals.impulse(2**12)
         >>> y = pf.dsp.filter.reconstructing_fractional_octave_bands(x)[0]
         >>> # get center frequencies
-        >>> f = pf.dsp.filter.fractional_octave_frequencies(
-        ...    frequency_range=(60, 16000))[1]
+        >>> f = pf.constants.fractional_octave_frequencies_exact(
+        ...    frequency_range=(60, 16000))[0]
         >>> y_sum = pf.Signal(np.sum(y.time, 0), y.sampling_rate)
         >>> # time domain plot
         >>> ax = pf.plot.time_freq(y_sum, color='k', unit='ms')
@@ -583,8 +589,8 @@ def reconstructing_fractional_octave_bands(
     n_bins = int(n_samples // 2 + 1)
 
     # fractional octave frequencies
-    _, f_m, f_cut_off = pf.dsp.filter.fractional_octave_frequencies(
-        num_fractions, frequency_range, return_cutoff=True)
+    f_m, f_lower, f_upper = pf.constants.fractional_octave_frequencies_exact(
+        num_fractions, frequency_range)
 
     # discard fractional octaves, if the center frequency exceeds
     # half the sampling rate
@@ -595,9 +601,9 @@ def reconstructing_fractional_octave_bands(
 
     # DFT lines of the lower cut-off and center frequency as in
     # Antoni, Eq. (14)
-    k_1 = np.round(n_samples * f_cut_off[0][f_id] / sampling_rate).astype(int)
+    k_1 = np.round(n_samples * f_lower[f_id] / sampling_rate).astype(int)
     k_m = np.round(n_samples * f_m[f_id] / sampling_rate).astype(int)
-    k_2 = np.round(n_samples * f_cut_off[1][f_id] / sampling_rate).astype(int)
+    k_2 = np.round(n_samples * f_upper[f_id] / sampling_rate).astype(int)
 
     # overlap in samples (symmetrical around the cut-off frequencies)
     P = np.round(overlap / 2 * (k_2 - k_m)).astype(int)
@@ -654,10 +660,11 @@ def reconstructing_fractional_octave_bands(
         f"(num_fractions={num_fractions}, frequency_range={frequency_range}, "
         f"overlap={overlap}, slope={slope})")
 
-    warnings.warn(("Return parameter 'frequencies' will be removed in pyfar"
-                   " 0.9.0. To get the fractional octave center frequencies,"
-                   " use `pyfar.dsp.filter.fractional_octave_frequencies` "
-                   "instead."), PyfarDeprecationWarning, stacklevel=2)
+    warnings.warn(("Return parameter 'frequencies' will be removed in pyfar "
+                   "0.9.0. To get the fractional octave center frequencies, "
+                   "use `pyfar.constants.fractional_octave_frequencies_exact` "
+                   "or `fractional_octave_frequencies_nominal` instead."),
+                   PyfarDeprecationWarning, stacklevel=2)
 
     if signal is None:
         # return the filter object

--- a/pyfar/dsp/filter/fractional_octaves.py
+++ b/pyfar/dsp/filter/fractional_octaves.py
@@ -661,7 +661,7 @@ def reconstructing_fractional_octave_bands(
         f"overlap={overlap}, slope={slope})")
 
     warnings.warn(("Return parameter 'frequencies' will be removed in pyfar "
-                   "0.9.0. To get the fractional octave center frequencies, "
+                   "0.10.0. To get the fractional octave center frequencies, "
                    "use `pyfar.constants.fractional_octave_frequencies_exact` "
                    "or `fractional_octave_frequencies_nominal` instead."),
                    PyfarDeprecationWarning, stacklevel=2)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -12,6 +12,7 @@ Test deprecations. For each deprecation two things must be tested:
 """
 import numpy as np
 from packaging import version
+import re
 
 import pytest
 
@@ -180,6 +181,7 @@ def test_deprecations_freq_range_parameter_warnings():
                                                   freq_range=(20, 20e3))
 
 
+# deprecate in 0.9.0 ----------------------------------------------------------
 def test_deprecation_shelve_functions():
     # test high_shelve()
     with pytest.warns(
@@ -287,8 +289,18 @@ def test_deprecations_audio_io():
 def test_deprecations_reconstructing_fractional_octave_bands_frequencies():
     with pytest.warns(
         PyfarDeprecationWarning, match="Return parameter 'frequencies' will be"
-        " removed in pyfar 0.9.0. To get the fractional octave center "
-        "frequencies, use `pyfar.dsp.filter.fractional_octave_frequencies` "
-        "instead."):
+        " removed in pyfar 0.9.0."):
         pfilt.reconstructing_fractional_octave_bands(None,
                                                      sampling_rate=44.1e3)
+
+# deprecate in 0.10.0 ---------------------------------------------------------
+def test_deprecations_ractional_octave_frequencies():
+    message = re.escape("`pyfar.dsp.filter.fractional_octave_frequencies` "
+                        "will be deprecated in pyfar 0.10.0")
+    with pytest.warns(PyfarDeprecationWarning, match=message):
+        pfilt.fractional_octave_frequencies()
+
+    # remove statement from pyfar 0.10.0!
+    if version.parse(pf.__version__) >= version.parse('0.10.0'):
+        with pytest.raises(AttributeError):
+            pfilt.fractional_octave_frequencies()

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -294,7 +294,7 @@ def test_deprecations_reconstructing_fractional_octave_bands_frequencies():
                                                      sampling_rate=44.1e3)
 
 # deprecate in 0.10.0 ---------------------------------------------------------
-def test_deprecations_ractional_octave_frequencies():
+def test_deprecations_fractional_octave_frequencies():
     message = re.escape("`pyfar.dsp.filter.fractional_octave_frequencies` "
                         "will be deprecated in pyfar 0.10.0")
     with pytest.warns(PyfarDeprecationWarning, match=message):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -286,14 +286,21 @@ def test_deprecations_audio_io():
             pf.io.audio_subtypes(format='wav')
 
 
+# deprecate in 0.10.0 ---------------------------------------------------------
 def test_deprecations_reconstructing_fractional_octave_bands_frequencies():
     with pytest.warns(
         PyfarDeprecationWarning, match="Return parameter 'frequencies' will be"
-        " removed in pyfar 0.9.0."):
+        " removed in pyfar 0.10.0."):
         pfilt.reconstructing_fractional_octave_bands(None,
                                                      sampling_rate=44.1e3)
 
-# deprecate in 0.10.0 ---------------------------------------------------------
+    # remove second return argument in pyfar 0.10.0!
+    if version.parse(pf.__version__) >= version.parse('0.10.0'):
+        with pytest.raises(TypeError):
+            _, _ = pfilt.reconstructing_fractional_octave_bands(
+                None, sampling_rate=44.1e3)
+
+
 def test_deprecations_fractional_octave_frequencies():
     message = re.escape("`pyfar.dsp.filter.fractional_octave_frequencies` "
                         "will be deprecated in pyfar 0.10.0")

--- a/tests/test_fractional_octaves.py
+++ b/tests/test_fractional_octaves.py
@@ -5,11 +5,13 @@ import pyfar
 
 from pyfar.dsp import filter
 from pyfar import FilterSOS, Signal
+from pyfar.classes.warnings import PyfarDeprecationWarning
 
 
 def test_center_frequencies_iec():
     nominal_octs = [31.5, 63, 125, 250, 500, 1000, 2000, 4000, 8000, 16000]
-    actual_octs = filter.fractional_octave_frequencies(num_fractions=1)
+    with pytest.warns(PyfarDeprecationWarning):
+        actual_octs = filter.fractional_octave_frequencies(num_fractions=1)
     actual_octs_nom = actual_octs[0]
     npt.assert_allclose(actual_octs_nom, nominal_octs)
 
@@ -17,24 +19,29 @@ def test_center_frequencies_iec():
         25, 31.5, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630,
         800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000,
         12500, 16000, 20000]
-    actual_thirds = filter.fractional_octave_frequencies(
-        num_fractions=3)
+    with pytest.warns(PyfarDeprecationWarning):
+        actual_thirds = filter.fractional_octave_frequencies(
+            num_fractions=3)
     actual_thirds_nom = actual_thirds[0]
     npt.assert_allclose(actual_thirds_nom, nominal_thirds)
 
     with pytest.raises(ValueError, match="lower and upper limit"):
-        filter.fractional_octave_frequencies(frequency_range=(1,))
+        with pytest.warns(PyfarDeprecationWarning):
+            filter.fractional_octave_frequencies(frequency_range=(1,))
 
     with pytest.raises(ValueError, match="lower and upper limit"):
-        filter.fractional_octave_frequencies(frequency_range=(3, 4, 5))
+        with pytest.warns(PyfarDeprecationWarning):
+            filter.fractional_octave_frequencies(frequency_range=(3, 4, 5))
 
     with pytest.raises(
             ValueError, match="second frequency needs to be higher"):
-        filter.fractional_octave_frequencies(
-            frequency_range=(8e3, 1e3))
+        with pytest.warns(PyfarDeprecationWarning):
+            filter.fractional_octave_frequencies(
+                frequency_range=(8e3, 1e3))
 
-    actual_octs = filter.fractional_octave_frequencies(
-        num_fractions=1, frequency_range=(100, 4e3))
+    with pytest.warns(PyfarDeprecationWarning):
+        actual_octs = filter.fractional_octave_frequencies(
+            num_fractions=1, frequency_range=(100, 4e3))
     actual_octs_nom = actual_octs[0]
     nominal_octs_part = [125, 250, 500, 1000, 2000, 4000]
     npt.assert_allclose(actual_octs_nom, nominal_octs_part)
@@ -69,14 +76,15 @@ def test_fractional_coeff_oct_filter_iec():
         with pytest.warns(UserWarning, match="The upper frequency limit"):
             actual = filter.fractional_octaves. \
                         _coefficients_fractional_octave_bands(
-                            sr, 1, frequency_range=(5e3, 20e3), order=order)
+                            sr, 1, frequency_range=(8e3, 20e3), order=order)
 
     assert actual.shape == (1, order, 6)
 
 
 def test_fractional_frequencies_non_iec():
-    actual_nominal, actual_exact = filter.fractional_octave_frequencies(
-        num_fractions=1, frequency_range=(4e3, 64e3))
+    with pytest.warns(PyfarDeprecationWarning):
+        actual_nominal, actual_exact = filter.fractional_octave_frequencies(
+            num_fractions=1, frequency_range=(4e3, 64e3))
     npt.assert_allclose(actual_exact, [4e3, 8e3, 16e3, 32e3, 64e3])
     assert actual_nominal is None
 
@@ -116,14 +124,15 @@ def test_fract_oct_bands_non_iec():
     expected = np.array([2e3, 4e3, 8e3, 16e3])
 
     np.testing.assert_allclose(exact, expected)
-
-    nominal, exact = filter.fractional_octave_frequencies(
-        5, (2e3, 20e3), return_cutoff=False)
+    with pytest.warns(PyfarDeprecationWarning):
+        nominal, exact = filter.fractional_octave_frequencies(
+            5, (2e3, 20e3), return_cutoff=False)
     assert nominal is None
 
     frac = 5
-    nominal, exact, f_crit = filter.fractional_octave_frequencies(
-        frac, (2e3, 20e3), return_cutoff=True)
+    with pytest.warns(PyfarDeprecationWarning):
+        nominal, exact, f_crit = filter.fractional_octave_frequencies(
+            frac, (2e3, 20e3), return_cutoff=True)
 
     octave_ratio = 10**(3/10)
     np.testing.assert_allclose(
@@ -186,7 +195,7 @@ def test_check_fractional_octance_band_filter_tolerance_n_samples():
 
     sampling_rate = 44100
     num_fractions = 1
-    frequency_range = (20, 20000)
+    frequency_range = (30, 20000)
 
     with pytest.warns(UserWarning, match='The upper frequency limit'):
         fractional_octave_bands = filter.fractional_octave_bands(


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #815

### Changes proposed in this pull request:

- deprecated `pyfar.dsp.filter.fractional_octave_frequencies`
- adapted code calling the deprecated function
- adapted tests

### Note:

The new fractional octave frequency functions in `pyfar.constants` return all bands whose band limits overlap with the specified frequency range. The old function returned only bands whos center frequencies overallped with frequency range. Because we have existing functions that depend on the fractional octave frequencies, I replaced the old with the new function. This may break backwards compatability in some cases depending on how users specified the frequency range.
