### PR TITLE
Refactor pf.Orientations class to pf.Rotation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -21,6 +21,7 @@ Added
 - All plots showing the magnitude response now have the `mode` parameter to specify if the absolute (default), real, or imaginary value of the spectrum is shown. This can also be toggled using the shortcut 'shift+m' in interactive plots (PR #817)
 - `pyfar.signals.files.room_impulse_response` can now return the room impulse response with noise tail (PR #906)
 - Abstract `_LTISystem` base class to better structure inheritance of the pyfar Filter classes (PR #798)
+- Added new `Rotation` class as a long term replacement for `Orientations` (PR #904)
 
 Changed
 ^^^^^^^

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -20,6 +20,7 @@ Added
 - `pyfar.dsp.filter.check_fractional_octave_band_filter_tolerance` to check if a (fractional) octave filter bank meets the class I or II tolerances defined in IEC 61260-1 (PR #829)
 - All plots showing the magnitude response now have the `mode` parameter to specify if the absolute (default), real, or imaginary value of the spectrum is shown. This can also be toggled using the shortcut 'shift+m' in interactive plots (PR #817)
 - Abstract `_LTISystem` base class to better structure inheritance of the pyfar Filter classes (PR #798)
+- Added new `Rotation` class as a long term replacement for `Orientations` (PR #904)
 
 Changed
 ^^^^^^^

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -21,6 +21,7 @@ Classes
    classes/pyfar.filter
    classes/pyfar.coordinates
    classes/pyfar.orientations
+   classes/pyfar.rotation
    classes/pyfar.transmission_matrix
 
 Modules

--- a/docs/classes/pyfar.rotation.rst
+++ b/docs/classes/pyfar.rotation.rst
@@ -1,0 +1,9 @@
+Rotation
+--------
+
+.. automodule:: pyfar.classes.rotation
+
+.. autoclass:: pyfar.Rotation
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyfar/__init__.py
+++ b/pyfar/__init__.py
@@ -13,6 +13,7 @@ from .classes.audio import (add, subtract, multiply, divide, power,
 from .classes.coordinates import Coordinates
 from .classes.coordinates import (deg2rad, rad2deg, dot, cross)
 from .classes.orientations import Orientations
+from .classes.rotation import Rotation
 from .classes.filter import FilterFIR, FilterIIR, FilterSOS
 from .classes.transmission_matrix import TransmissionMatrix
 
@@ -38,6 +39,7 @@ __all__ = [
     'deg2rad',
     'rad2deg',
     'Orientations',
+    'Rotation',
     'FilterFIR',
     'FilterIIR',
     'FilterSOS',

--- a/pyfar/classes/__init__.py
+++ b/pyfar/classes/__init__.py
@@ -3,6 +3,7 @@ from . import audio
 from . import coordinates
 from . import orientations
 from . import filter
+from . import rotation
 from . import transmission_matrix
 from . import warnings
 
@@ -13,4 +14,5 @@ __all__ = [
     'filter',
     'transmission_matrix',
     'warnings',
+    'rotation',
 ]

--- a/pyfar/classes/orientations.py
+++ b/pyfar/classes/orientations.py
@@ -386,7 +386,10 @@ class Orientations(Rotation):
         # by the right-hand rule
         rights = np.cross(views, ups)
 
-        rotation_matrix = np.asarray([views, ups, rights])
+        # In a standard Cartesian right-handed coordinate system,
+        # these vectors are defined as [x, y, z] = [view, left, up], where
+        # left is the same vector as -rights
+        rotation_matrix = np.asarray([views, -rights, ups])
         rotation_matrix = np.swapaxes(rotation_matrix, 0, 1)
 
         return cls.from_matrix(rotation_matrix)
@@ -597,6 +600,13 @@ class Orientations(Rotation):
         # Apply self as a Rotation (base class) on eye i.e. generate orientions
         # as rotations relative to standard basis in 3d
         vector_triple = super().as_matrix()
+        views, lefts, ups = np.split(vector_triple, 3, axis=-2)
+
+        # In a standard Cartesian right-handed coordinate system,
+        # standard basis is defined as [x, y, z] = [view, left, up], where
+        # left is the same vector as -rights
+        vector_triple = np.concatenate((views, ups, -lefts), axis=-2)
+
         if vector_triple.ndim == 3:
             return np.swapaxes(vector_triple, 0, 1)
         return vector_triple

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -29,17 +29,54 @@ class Rotation():
         num_orientations = \
             1 if quat.ndim == 1 else quat.shape[0]
 
-        _repr = f"Pyfar Rotations object with {num_orientations} rotations."
-        return _repr
+        repr = f"Pyfar Rotations object with {num_orientations} rotations."
+        return repr
 
-    # Factory Methods
+    def __getitem__(self, idx):
+        self._rot = self._rot[idx]
+        return self
+
+    def __iter__(self):
+        raise NotImplementedError
+
+    def __setitem__(self):
+        raise NotImplementedError('Setting an item is disabled for pyfar'
+        'Rotations. If you want to modify the Rotation, use an array'
+        'representation like `as_quat()` or `as_matrix()` and create a new '
+        'object.')
+
+    def __mul__(self, other):
+        """"""
+        if isinstance(other, Rotation):
+            other = scRotation.from_quat(other.as_quat())
+        if isinstance(other, scRotation):
+            self._rot *= other
+            return self
+
+    def __rmul__(self, other):
+        """"""
+        if isinstance(other, Rotation):
+            other = scRotation.from_quat(other.as_quat())
+        if isinstance(other, scRotation):
+            self._rot *= other
+            return self
+
+    def __pow__(self, n):
+        """Compose orientation with itself n times."""
+        self._rot = self._rot.__pow__(n)
+        return self
+
+    def __eq__(self, other):
+        """Check for equality of two objects."""
+        return np.array_equal(self.as_quat(), other.as_quat())
+
+    # from-... methods
     @classmethod
     def from_davenport(cls, axes, order, angles, degrees=False):
         """"""
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_davenport(
             axes, order, angles, degrees=degrees)
-
         return instance
 
     @classmethod
@@ -48,7 +85,6 @@ class Rotation():
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_euler(
             seq, angles, degrees=degrees)
-
         return instance
 
     @classmethod
@@ -56,7 +92,12 @@ class Rotation():
         """"""
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_matrix(matrix)
+        return instance
 
+    @classmethod
+    def from_mrp(cls, mrp):
+        instance = cls.__new__(cls)
+        instance._rot = scRotation.from_mrp(mrp)
         return instance
 
     @classmethod
@@ -65,6 +106,107 @@ class Rotation():
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_quat(quat)
         return instance
+
+    @classmethod
+    def from_rotvec(cls, rotvec, degrees=False):
+        """"""
+        instance = cls.__new__(cls)
+        instance._rot = scRotation.from_rotvec(rotvec, degrees)
+        return instance
+
+    @classmethod
+    def from_view_up(cls, views, ups):
+        """Initialize Orientations from a view an up vector.
+
+        Orientations are internally stored as quaternions for better spherical
+        linear interpolation (SLERP) and spherical harmonics operations.
+        More intuitionally, they can be expressed as view and up vectors
+        which cannot be collinear. In this case, they are restricted to be
+        perpendicular to minimize rounding errors.
+
+        Parameters
+        ----------
+        views : array_like, shape (N, 3) or (3,), Coordinates
+            A single vector or a stack of vectors, giving the look-direction of
+            an object in three-dimensional space, e.g. from a listener, or the
+            acoustic axis of a loudspeaker, or the direction of a main lobe.
+            Views can also be passed as a Coordinates object.
+
+        ups : array_like, shape (N, 3) or (3,), Coordinates
+            A single vector or a stack of vectors, giving the up-direction of
+            an object, which is usually the up-direction in world-space. Views
+            can also be passed as a Coordinates object.
+
+        Returns
+        -------
+        orientations : Orientations
+            Object containing the orientations represented by quaternions.
+        """
+        instance = cls.__new__(cls)
+
+        # init views and up
+        try:
+            views = np.atleast_2d(views).astype(np.float64)
+            ups = np.atleast_2d(ups).astype(np.float64)
+        except VisibleDeprecationWarning as exc:
+            raise ValueError(
+                "Expected `views` and `ups` to have shape (N, 3)") from exc
+
+        # check views and ups
+        if (views.ndim > 2 or views.shape[-1] != 3 or
+                ups.ndim > 2 or ups.shape[-1] != 3):
+            raise ValueError(f"Expected `views` and `ups` to have shape (N, 3)"
+                             f" or (3,), got {views.shape}")
+        if views.shape == ups.shape:
+            pass
+        elif views.shape[0] > 1 and ups.shape[0] == 1:
+            ups = np.repeat(ups, views.shape[0], axis=0)
+        elif ups.shape[0] > 1 and views.shape[0] == 1:
+            views = np.repeat(views, ups.shape[0], axis=0)
+        else:
+            raise ValueError("Expected 1:1, 1:N or N:1 `views` and `ups` "
+                             f"not M:N, got {views.shape} and {ups.shape}")
+
+        if not (np.all(np.linalg.norm(views, axis=1)) and
+                np.all(np.linalg.norm(ups, axis=1))):
+            raise ValueError("View and Up Vectors must have a length.")
+        if not np.allclose(0, np.einsum('ij,kj->k', views, ups)):
+            raise ValueError("View and Up vectors must be perpendicular.")
+
+        # Assuming that the direction of the cross product is defined
+        # by the right-hand rule
+        rights = np.cross(views, ups)
+
+        # In a standard Cartesian right-handed coordinate system,
+        # these vectors are defined as [x, y, z] = [view, left, up], where
+        # left is the same vector as -rights
+        rotation_matrix = np.asarray([views, -rights, ups])
+        rotation_matrix = np.swapaxes(rotation_matrix, 0, 1)
+
+        return instance.from_matrix(rotation_matrix)
+
+    # other class methods
+    @classmethod
+    def align_vectors(a, b, weights=None, return_sensitivity=False):
+        raise NotImplementedError
+
+    @classmethod
+    def concatenate(cls, rotation):
+        raise NotImplementedError
+
+    @classmethod
+    def identity(cls, num=None, *, shape=None):
+        raise NotImplementedError
+
+    @classmethod
+    def random(cls, num=None, rng=None, *, shape=None):
+        raise NotImplementedError
+
+    # private class methods
+    @classmethod
+    def _decode(cls, obj_dict):
+        """Decode object based on its respective `_encode` counterpart."""
+        return cls.from_quat(obj_dict['quat'])
 
     @classmethod
     def _from_scipy_rotation(cls, sc_rotation):
@@ -90,6 +232,26 @@ class Rotation():
         """"""
         return self._rot.as_matrix()
 
+    def as_view_up_right(self):
+        raise NotImplementedError
+
+    def copy(self):
+        """Return a deep copy of the Orientations object."""
+        return self.from_quat(self.as_quat())
+
+    def inv(self):
+        raise NotImplementedError
+
     def mean(self, weights=None, axis=None):
         """"""
         return self._from_scipy_rotation(self._rot.mean(weights, axis))
+
+    def reduce(self, left=None, right=None, return_indices=False):
+        raise NotImplementedError
+
+    def show(self, positions=None,
+             show_views=True, show_ups=True, show_rights=True, **kwargs):
+        raise NotImplementedError
+
+    # private instance methods
+

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -95,7 +95,15 @@ class Rotation():
         'object.')
 
     def __mul__(self, other):
-        """"""
+        """
+        Multiply Rotation object with another Rotation or a
+        scipy.spatial.transform.Rotation.
+
+        Parameters
+        ----------
+        other : Rotation or scipy.spatial.transform.Rotation
+            The object to multiply with.
+        """
         if isinstance(other, Rotation):
             other = scRotation.from_quat(other.as_quat())
         if isinstance(other, scRotation):
@@ -104,7 +112,7 @@ class Rotation():
 
     def __rmul__(self, other):
         """
-        Multiply Rotation object with another Rotation or a
+        Right multiplication of Rotation object with another Rotation or a
         scipy.spatial.transform.Rotation.
 
         Parameters
@@ -579,8 +587,8 @@ class Rotation():
                 optimal matrix algorithm", Journal of Astronautical Sciences,
                 Vol. 41, No.2, 1993, pp. 261-280.
         .. [#] Bar-Itzhack, Itzhack Y., Daniel Hershkowitz, and Leiba Rodman,
-                "Pointing in Real Euclidean Space", Journal of Guidance,
-                Control, and Dynamics, Vol. 20, No. 5, 1997, pp. 916-922.
+               "Pointing in Real Euclidean Space", Journal of Guidance,
+               Control, and Dynamics, Vol. 20, No. 5, 1997, pp. 916-922.
         """
         result = scRotation.align_vectors(a, b, weights, return_sensitivity)
 
@@ -598,7 +606,7 @@ class Rotation():
 
         Parameters
         ----------
-        orientations : sequence of Orientations objects
+        rotations : sequence of Orientations objects
             The orientations to concatenate. If a single Orientations object is
             passed in, a copy is returned.
 
@@ -731,10 +739,10 @@ class Rotation():
         Parameters
         ----------
         axes : array_like, shape (..., [1 or 2 or 3], 3) or (..., 3)
-            Axis of rotation, if one dimensional. If N dimensional, describes the
-            sequence of axes for rotations, where each axes[..., i, :] is the ith
-            axis. If more than one axis is given, then the second axis must be
-            orthogonal to both the first and third axes.
+            Axis of rotation, if one dimensional. If N dimensional, describes
+            the sequence of axes for rotations, where each axes[..., i, :] is
+            the ith axis. If more than one axis is given, then the second axis
+            must be orthogonal to both the first and third axes.
         order : string
             If it belongs to the set {'e', 'extrinsic'}, the sequence will be
             extrinsic. If it belongs to the set {'i', 'intrinsic'}, sequence
@@ -760,11 +768,11 @@ class Rotation():
         References
         ----------
         .. [#] Shuster, Malcolm & Markley, Landis. (2003). Generalization of
-               the Euler Angles. Journal of the Astronautical Sciences. 51. 123-132.
-               10.1007/BF03546304.
+               the Euler Angles. Journal of the Astronautical Sciences. 51.
+               123-132. 10.1007/BF03546304.
         .. [#] Bernardes E, Viollet S (2022) Quaternion to Euler angles
-               conversion: A direct, general and computationally efficient method.
-               PLoS ONE 17(11): e0276302. 10.1371/journal.pone.0276302
+               conversion: A direct, general and computationally efficient
+               method. PLoS ONE 17(11): e0276302. 10.1371/journal.pone.0276302
         .. [#] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
 
@@ -828,7 +836,8 @@ class Rotation():
         .. [#] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
 
-        return self._rot.as_euler(seq, degrees, suppress_warnings)
+        return self._rot.as_euler(seq, degrees,
+                                  suppress_warnings=suppress_warnings)
 
     def as_matrix(self):
         """
@@ -932,7 +941,7 @@ class Rotation():
         ----------
         .. [#] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
         """
-        return self._rot.as_quat(canonical, scalar_first)
+        return self._rot.as_quat(canonical, scalar_first=scalar_first)
 
     def as_rotvec(self, degrees=False):
         """

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -19,13 +19,13 @@ class Rotation():
     Rotation in the three-dimensional space.
 
     This class is largely based on
-    :py:class:`scipy:scipy.spatial.transform.Rotation` and wraps all
+    :py:class:`scipy.spatial.transform.Rotation` and wraps all
     functionality that scipy's Rotation class provides.
     In addition the pyfar Rotation class adds the creation from perpendicular
     view and up vectors through :py:func:`~from_view_up`, and the
     representation as view / up in :py:func:`~as_view_up`.
 
-    A rotation can be visualized with the triple of view, up and right
+    A rotation can be represented with the triple of view, up and right
     vectors and it is tied to the object's local coordinate system.
     Alternatively the object's rotation can be illustrated with help of the
     right hand: Thumb (view), forefinger (up) and middle finger (right).
@@ -90,11 +90,11 @@ class Rotation():
     def __mul__(self, other):
         """
         Multiply Rotation object with another Rotation or
-        :py:class:`scipy:scipy.spatial.transform.Rotation`.
+        :py:class:`scipy.spatial.transform.Rotation`.
 
         Parameters
         ----------
-        other : Rotation or :py:class:`scipy:scipy.spatial.transform.Rotation`
+        other : Rotation or :py:class:`scipy.spatial.transform.Rotation`
             The object to multiply with.
         """
         if isinstance(other, Rotation):
@@ -105,11 +105,11 @@ class Rotation():
     def __rmul__(self, other):
         """
         Right multiplication of Rotation object with another Rotation or a
-        :py:class:`scipy:scipy.spatial.transform.Rotation`.
+        :py:class:`scipy.spatial.transform.Rotation`.
 
         Parameters
         ----------
-        other : Rotation or :py:class:`scipy:scipy.spatial.transform.Rotation`.
+        other : Rotation or :py:class:`scipy.spatial.transform.Rotation`.
             The object to multiply with.
         """
         if isinstance(other, Rotation):
@@ -148,7 +148,7 @@ class Rotation():
         """
         Initialize from Davenport angles.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_davenport`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.from_davenport`.
 
         Rotations in 3-D can be represented by a sequence of 3
         rotations around a sequence of axes.
@@ -209,7 +209,7 @@ class Rotation():
         """
         Initialize from Euler angles.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_euler`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.from_euler`.
 
         Rotations in 3-D can be represented by a sequence of 3
         rotations around a sequence of axes. In theory, any three axes spanning
@@ -251,7 +251,7 @@ class Rotation():
         """
         Initialize from rotation matrix.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_matrix`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.from_matrix`.
 
         Rotations in 3 dimensions can be represented with 3 x 3 orthogonal
         matrices [#]_. If the input is not orthogonal, an approximation is
@@ -294,7 +294,7 @@ class Rotation():
         """
         Initialize from Modified Rodrigues Parameters (MRPs).
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_mrp`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.from_mrp`.
 
         MRPs are a 3 dimensional vector co-directional to the axis of rotation
         and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
@@ -329,7 +329,7 @@ class Rotation():
         """
         Initialize from quaternions.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_quat`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.from_quat`.
 
         Rotations in 3 dimensions can be represented using unit norm
         quaternions [#]_.
@@ -387,7 +387,7 @@ class Rotation():
         """
         Initialize from rotation vectors.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_rotvec`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.from_rotvec`.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation [#]_.
@@ -484,7 +484,7 @@ class Rotation():
         r"""
         Estimate a rotation to optimally align two sets of vectors.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.align_vectors`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.align_vectors`.
 
         Find a rotation between frames A and B which best aligns a set of
         vectors `a` and `b` observed in these frames. The following loss
@@ -612,7 +612,7 @@ class Rotation():
         """
         Concatenate a sequence of Rotation objects into a single object.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.concatenate`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.concatenate`.
 
         This is useful if you want to, for example, take the mean of a set of
         rotations and need to pack them into a single object to do so.
@@ -641,7 +641,7 @@ class Rotation():
         """
         Get identity rotation(s).
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.identity`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.identity`.
 
         Composition with the identity rotation has no effect.
 
@@ -667,7 +667,7 @@ class Rotation():
         """
         Generate rotations that are uniformly distributed on a sphere.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.random`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.random`.
 
         Formally, the rotations follow the Haar-uniform distribution over
         the SO(3) group.
@@ -696,7 +696,7 @@ class Rotation():
         -----
         This function is optimized for efficiently sampling random rotation
         matrices in three dimensions. For generating random rotation matrices
-        in higher dimensions, see `scipy.stats.special_ortho_group`.
+        in higher dimensions, see :py:data:`scipy.stats.special_ortho_group`.
         """
         rot = scRotation.random(num, rng, shape=shape)
         return cls._from_scipy_rotation(rot)
@@ -720,7 +720,7 @@ class Rotation():
         """
         Represent as Davenport angles.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_davenport`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.as_davenport`.
 
 
         Any rotation can be expressed as a composition of 3 elementary
@@ -795,7 +795,7 @@ class Rotation():
         """
         Represent as Euler angles.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_euler`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.as_euler`.
 
         Any rotation can be expressed as a composition of 3 elementary
         rotations. Once the axis sequence has been chosen, Euler angles define
@@ -856,7 +856,7 @@ class Rotation():
         """
         Represent as rotation matrix.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_matrix`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.as_matrix`.
 
         3D rotations can be represented using rotation matrices, which
         are 3 x 3 real orthogonal matrices with determinant equal to +1 [#]_.
@@ -877,7 +877,7 @@ class Rotation():
         """
         Represent as Modified Rodrigues Parameters (MRPs).
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_mrp`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.as_mrp`.
 
         MRPs are a 3 dimensional vector co-directional to the axis of rotation
         and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
@@ -906,7 +906,7 @@ class Rotation():
     def as_quat(self, canonical=False, scalar_first=False):
         """Represent as quaternions.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_quat`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.as_quat`.
 
         Rotations in 3 dimensions can be represented using unit norm
         quaternions [#]_.
@@ -960,7 +960,7 @@ class Rotation():
         """
         Represent as rotation vectors.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_rotvec`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.as_rotvec`.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation [#]_.
@@ -1014,7 +1014,7 @@ class Rotation():
         """
         Invert this rotation.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.inv`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.inv`.
 
         Composition of an rotation with its inverse results in an identity
         transformation.
@@ -1032,7 +1032,7 @@ class Rotation():
         r"""
         Get the mean of the rotations.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.mean`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.mean`.
 
         The mean used is the chordal L2 mean (also called the projected or
         induced arithmetic mean) [#]_. If ``A`` is a set of rotation matrices,
@@ -1074,7 +1074,7 @@ class Rotation():
     def reduce(self, left=None, right=None, return_indices=False):
         """Reduce this rotation with the provided rotation groups.
 
-        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.reduce`.
+        Wraps :py:meth:`scipy.spatial.transform.Rotation.reduce`.
 
         Reduction of a rotation ``p`` is a transformation of the form
         ``q = l * p * r``, where ``l`` and ``r`` are chosen from `left` and

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -39,9 +39,9 @@ class Rotation():
     def __iter__(self):
         raise NotImplementedError
 
-    def __setitem__(self):
-        raise NotImplementedError('Setting an item is disabled for pyfar'
-        'Rotations. If you want to modify the Rotation, use an array'
+    def __setitem__(self, *args):
+        raise NotImplementedError('Setting an item is disabled for pyfar '
+        'Rotations. If you want to modify the Rotation, use an array '
         'representation like `as_quat()` or `as_matrix()` and create a new '
         'object.')
 

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -25,8 +25,9 @@ class Rotation():
 
     def __repr__(self):
         """String representation of Rotation object."""
+        quat = self._rot.as_quat()
         num_orientations = \
-            1 if self._quat.ndim == 1 else self._quat.shape[0]
+            1 if quat.ndim == 1 else quat.shape[0]
 
         _repr = f"Pyfar Rotations object with {num_orientations} rotations."
         return _repr
@@ -36,8 +37,8 @@ class Rotation():
     def from_davenport(cls, axes, order, angles, degrees=False):
         """"""
         instance = cls.__new__(cls)
-        instance._store_rotation(scRotation.from_davenport(
-            axes, order, angles, degrees=False))
+        instance._rot = scRotation.from_davenport(
+            axes, order, angles, degrees=False)
 
         return instance
 
@@ -45,8 +46,8 @@ class Rotation():
     def from_euler(cls, seq, angles, degrees=False):
         """"""
         instance = cls.__new__(cls)
-        instance._store_rotation(scRotation.from_euler(
-            seq, angles, degrees=False))
+        instance._rot = scRotation.from_euler(
+            seq, angles, degrees=False)
 
         return instance
 
@@ -54,7 +55,7 @@ class Rotation():
     def from_matrix(cls, matrix):
         """"""
         instance = cls.__new__(cls)
-        instance._store_rotation(scRotation.from_matrix(matrix))
+        instance._rot = scRotation.from_matrix(matrix)
 
         return instance
 
@@ -62,7 +63,7 @@ class Rotation():
     def from_quat(cls, quat):
         """"""
         instance = cls.__new__(cls)
-        instance._store_rotation(scRotation.from_quat(quat))
+        instance._rot = scRotation.from_quat(quat)
         return instance
 
 
@@ -70,7 +71,7 @@ class Rotation():
     def _from_scipy_rotation(cls, sc_rotation):
         """"""
         instance = cls.__new__(cls)
-        instance._store_rotation(sc_rotation)
+        instance._rot = sc_rotation
         return instance
 
     # Instance methods
@@ -84,7 +85,7 @@ class Rotation():
 
     def as_quat(self):
         """"""
-        return self._quat
+        return self._rot.as_quat()
 
     def as_matrix(self):
         """"""
@@ -93,18 +94,3 @@ class Rotation():
     def mean(self, weights=None, axis=None):
         """"""
         return self._from_scipy_rotation(self._rot.mean(weights, axis))
-
-    # Private methods
-    def _store_rotation(self, sc_rotation: scRotation):
-        """
-        Stores scipy rotation and raw quaternion data.
-
-        This is an auxiliary private function to save some codelines.
-
-        Parameters
-        ----------
-        sc_rotatiton : scipy.Rotation
-            Scipy Rotation object
-        """
-        self._rot = sc_rotation
-        self._quat = sc_rotation.as_quat()

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -21,7 +21,7 @@ class Rotation():
     This class for Rotation in the three-dimensional space,
     is largely based on :py:class:`scipy:scipy.spatial.transform.Rotation` and
     wraps all functionality that
-    :py:class:`scipy:scipy.spatial.transform.Rotation` provides.
+    scipy's Rotation class provides.
     In addition the pyfar Rotation class adds the creation from perpendicular
     view and up vectors through :py:func:`~from_view_up`, the representation
     as view / up in :py:func:`~as_view_up` and a convenient plot

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -1,5 +1,5 @@
 """This module contains the Rotation class."""
-from scipy.spatial.transform import Rotation as scRotation
+from scipy.spatial.transform import Rotation as ScipyRotation
 import numpy as np
 import warnings
 
@@ -16,7 +16,7 @@ warnings.filterwarnings("error", category=VisibleDeprecationWarning)
 
 class Rotation():
     """
-    Rotation in the three-dimensional space.
+    Rotation in three-dimensional space.
 
     This class is largely based on
     :py:class:`scipy.spatial.transform.Rotation` and wraps all
@@ -28,7 +28,7 @@ class Rotation():
     A rotation can be represented with the triple of view, up and right
     vectors and it is tied to the object's local coordinate system.
     Alternatively the object's rotation can be illustrated with help of the
-    right hand: Thumb (view), forefinger (up) and middle finger (right).
+    right hand: Thumb (view), index-finger (up) and middle finger (right).
 
     Examples
     --------
@@ -52,9 +52,7 @@ class Rotation():
 
     def __repr__(self):
         """String representation of Rotation object."""
-        repr_string = \
-              f"pyfar.Rotation with {self.cshape} rotations."
-        return repr_string
+        return f"pyfar.Rotation with {self.cshape} rotations."
 
     def __iter__(self):
         """Iterate over rotations."""
@@ -98,7 +96,7 @@ class Rotation():
             The object to multiply with.
         """
         if isinstance(other, Rotation):
-            other = scRotation.from_quat(other.as_quat())
+            other = ScipyRotation.from_quat(other.as_quat())
         result = self._rot * other
         return self._from_scipy_rotation(result)
 
@@ -139,7 +137,6 @@ class Rotation():
     def csize(self):
         """Number of rotations."""
         return np.prod(self.cshape)
-
 
     # from-... methods
     @classmethod
@@ -199,7 +196,7 @@ class Rotation():
                the Euler Angles. Journal of the Astronautical Sciences. 51.
                123-132. 10.1007/BF03546304.
         """
-        rot = scRotation.from_davenport(
+        rot = ScipyRotation.from_davenport(
             axes, order, angles, degrees=False)
         return cls._from_scipy_rotation(rot)
 
@@ -242,7 +239,7 @@ class Rotation():
         ----------
         .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
         """
-        rot = scRotation.from_euler(
+        rot = ScipyRotation.from_euler(
             seq, angles, degrees=False)
         return cls._from_scipy_rotation(rot)
 
@@ -286,7 +283,7 @@ class Rotation():
                Journal of guidance, control, and dynamics vol. 31.2, pp.
                440-442, 2008.
         """
-        rot = scRotation.from_matrix(matrix)
+        rot = ScipyRotation.from_matrix(matrix)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
@@ -322,7 +319,7 @@ class Rotation():
                The Journal of Astronautical Sciences, Vol. 41, No.4, 1993,
                pp. 475-476
         """
-        rot = scRotation.from_mrp(mrp)
+        rot = ScipyRotation.from_mrp(mrp)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
@@ -380,7 +377,7 @@ class Rotation():
         .. [#] Hanson, Andrew J. "Visualizing quaternions."
             Morgan Kaufmann Publishers Inc., San Francisco, CA. 2006.
         """
-        rot = scRotation.from_quat(quat)
+        rot = ScipyRotation.from_quat(quat)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
@@ -408,19 +405,23 @@ class Rotation():
         ----------
         .. [#] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
         """
-        rot = scRotation.from_rotvec(rotvec, degrees=False)
+        rot = ScipyRotation.from_rotvec(rotvec, degrees=False)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_view_up(cls, views, ups):
         """
-        Initialize Rotation from a view an up vector.
+        Initialize Rotation from view and up vectors.
 
-        Rotations are internally stored as quaternions for better spherical
-        linear interpolation (SLERP) and spherical harmonics operations.
-        More intuitionally, they can be expressed as view and up vectors
-        which cannot be collinear. In this case, they are restricted to be
-        perpendicular to minimize rounding errors.
+        The view vector defines the forward-looking direction, while the up
+        vector defines what direction is "up". These two vectors must be
+        perpendicular to each other.
+
+        The rotation is constructed using a right-handed coordinate system
+        where the right vector is computed as the cross product of view and up:
+        ``right = view × up``. The resulting rotation matrix has columns
+        ``[view, -right, up]``, corresponding to the x, y, and z axes
+        respectively.
 
         Parameters
         ----------
@@ -604,7 +605,7 @@ class Rotation():
                "Pointing in Real Euclidean Space", Journal of Guidance,
                Control, and Dynamics, Vol. 20, No. 5, 1997, pp. 916-922.
         """
-        result = scRotation.align_vectors(a, b, weights, return_sensitivity)
+        result = ScipyRotation.align_vectors(a, b, weights, return_sensitivity)
 
         return (cls._from_scipy_rotation(result[0]), *result[1:])
 
@@ -634,7 +635,7 @@ class Rotation():
 
         rotations = [rotation._rot for rotation in rotations]
 
-        rot = scRotation.concatenate(rotations)
+        rot = ScipyRotation.concatenate(rotations)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
@@ -660,7 +661,7 @@ class Rotation():
         identity : Rotation
             The identity rotation.
         """
-        rot  = scRotation.identity(num, shape=shape)
+        rot  = ScipyRotation.identity(num, shape=shape)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
@@ -699,7 +700,7 @@ class Rotation():
         matrices in three dimensions. For generating random rotation matrices
         in higher dimensions, see :py:data:`scipy.stats.special_ortho_group`.
         """
-        rot = scRotation.random(num, rng, shape=shape)
+        rot = ScipyRotation.random(num, rng, shape=shape)
         return cls._from_scipy_rotation(rot)
 
     # private class methods
@@ -980,19 +981,23 @@ class Rotation():
         return self._rot.as_rotvec(degrees=False)
 
     def as_view_up(self):
-        """Get Rotation as a view, up, and right vector.
+        """
+        Get Rotation as view and up vectors.
 
-        Rotation are internally stored as quaternions for better spherical
-        linear interpolation (SLERP) and spherical harmonics operations.
-        More intuitionally, they can be expressed as view and and up of vectors
-        which cannot be collinear. In this case are restricted to be
-        perpendicular to minimize rounding errors.
+        The view vector defines the forward-looking direction, while the up
+        vector defines what direction is "up". These two vectors are
+        perpendicular to each other.
+
+        The rotation matrix uses a right-handed coordinate system with columns
+        ``[view, -right, up]``, where ``right = view × up``. This method
+        extracts the view and up vectors from that representation.
 
         Returns
         -------
-        vector_triple: ndarray, shape (..., 3), normalized vectors
-            - views, see :py:func:`Rotation.from_view_up`
-            - ups, see :py:func:`Rotation.from_view_up`
+        views : ndarray, shape (..., 3)
+            Normalized view vectors, see :py:func:`Rotation.from_view_up`
+        ups : ndarray, shape (..., 3)
+            Normalized up vectors, see :py:func:`Rotation.from_view_up`
         """
         vector_triple = self.as_matrix()
         views, _, ups = np.split(vector_triple, 3, axis=-2)

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -18,14 +18,13 @@ warnings.filterwarnings("error", category=VisibleDeprecationWarning)
 
 class Rotation():
     """
-    This class for Rotation in the three-dimensional space,
-    is largely based on :py:class:`scipy:scipy.spatial.transform.Rotation` and
-    wraps all functionality that
-    scipy's Rotation class provides.
+    Rotation in the three-dimensional space.
+
+    This class is largely based on :py:class:`scipy:scipy.spatial.transform.Rotation`
+    and wraps all functionality that scipy's Rotation class provides.
     In addition the pyfar Rotation class adds the creation from perpendicular
-    view and up vectors through :py:func:`~from_view_up`, the representation
-    as view / up in :py:func:`~as_view_up` and a convenient plot
-    function :py:func:`~show`.
+    view and up vectors through :py:func:`~from_view_up`, and the
+    representation as view / up in :py:func:`~as_view_up`.
 
     A rotation can be visualized with the triple of view, up and right
     vectors and it is tied to the object's local coordinate system.
@@ -60,17 +59,16 @@ class Rotation():
     def __repr__(self):
         """String representation of Rotation object."""
         repr_string = \
-              f"Pyfar Rotations object with {self.n_rotations} rotations."
+              f"Pyfar.Rotation with {self.cshape} rotations."
         return repr_string
 
     def __iter__(self):
         """Iterate over rotations."""
         if self.as_quat().ndim == 1:
             raise TypeError("Single rotation is not iterable.")
-
-        for i in range(self.n_rotations):
-            rot = self._rot[i]
-            yield self._from_scipy_rotation(rot)
+        quat = self.as_quat().reshape((-1, 4))
+        for i in range(self.csize):
+            yield self.from_quat(quat[i])
 
     def __getitem__(self, idx):
         """
@@ -89,10 +87,11 @@ class Rotation():
 
         This is disabled for `Rotation`.
         """
-        raise NotImplementedError('Setting an item is disabled for pyfar '
-        'Rotations. If you want to modify the Rotation, use an array '
-        'representation like `as_quat()` or `as_matrix()` and create a new '
-        'object.')
+        raise NotImplementedError(
+            'Setting an item is disabled for pyfar '
+            'Rotations. If you want to modify the Rotation, use an array '
+            'representation like `as_quat()` or `as_matrix()` and create a new '
+            'object.')
 
     def __mul__(self, other):
         """
@@ -106,9 +105,8 @@ class Rotation():
         """
         if isinstance(other, Rotation):
             other = scRotation.from_quat(other.as_quat())
-        if isinstance(other, scRotation):
-            self._rot *= other
-            return self
+        self._rot *= other
+        return self
 
     def __rmul__(self, other):
         """
@@ -137,12 +135,18 @@ class Rotation():
 
     # properties
     @property
-    def n_rotations(self):
-        """Number of rotations."""
+    def cshape(self):
+        """Cshape of rotations."""
         quat = self._rot.as_quat()
-        n_rotations = \
-            1 if quat.ndim == 1 else quat.shape[0]
-        return n_rotations
+        if quat.ndim==1:
+            return (1,)
+        return quat.shape[:-1]
+
+    @property
+    def csize(self):
+        """Number of rotations."""
+        return np.prod(self.cshape)
+
 
     # from-... methods
     @classmethod
@@ -439,13 +443,13 @@ class Rotation():
 
         Parameters
         ----------
-        views : array_like, shape (N, 3) or (3,), Coordinates
+        views : array_like, shape (..., 3) or (3,), Coordinates
             A single vector or a stack of vectors, giving the look-direction of
             an object in three-dimensional space, e.g. from a listener, or the
             acoustic axis of a loudspeaker, or the direction of a main lobe.
             Views can also be passed as a Coordinates object.
 
-        ups : array_like, shape (N, 3) or (3,), Coordinates
+        ups : array_like, shape (..., 3) or (3,), Coordinates
             A single vector or a stack of vectors, giving the up-direction of
             an object, which is usually the up-direction in world-space. Views
             can also be passed as a Coordinates object.
@@ -456,44 +460,41 @@ class Rotation():
             Object containing the rotations.
         """
         # init views and up
+        views = np.atleast_2d(views)
+        ups = np.atleast_2d(ups)
+
+        # determine broadcasted shape
         try:
-            views = np.atleast_2d(views).astype(np.float64)
-            ups = np.atleast_2d(ups).astype(np.float64)
-        except VisibleDeprecationWarning as exc:
+            shape = np.broadcast_shapes(views.shape, ups.shape)
+        except ValueError as exc:
             raise ValueError(
-                "Expected `views` and `ups` to have shape (N, 3)") from exc
+                f"shape missmatch: `views` {views.shape} and `ups` {ups.shape}"
+                " cannot be broadcasted to a single shape"
+            )
 
-        # check views and ups
-        if (views.ndim > 2 or views.shape[-1] != 3 or
-                ups.ndim > 2 or ups.shape[-1] != 3):
-            raise ValueError(f"Expected `views` and `ups` to have shape (N, 3)"
-                             f" or (3,), got {views.shape}")
-        if views.shape == ups.shape:
-            pass
-        elif views.shape[0] > 1 and ups.shape[0] == 1:
-            ups = np.repeat(ups, views.shape[0], axis=0)
-        elif ups.shape[0] > 1 and views.shape[0] == 1:
-            views = np.repeat(views, ups.shape[0], axis=0)
-        else:
-            raise ValueError("Expected 1:1, 1:N or N:1 `views` and `ups` "
-                             f"not M:N, got {views.shape} and {ups.shape}")
+        # check shape
+        if shape[-1] != 3:
+            raise ValueError(f"Expected `views` and `ups` to have shape "
+                             f"(..., 3) or (3,), got {views.shape} and "
+                             f"{ups.shape}")
 
-        if not (np.all(np.linalg.norm(views, axis=1)) and
-                np.all(np.linalg.norm(ups, axis=1))):
+        views = np.broadcast_to(views, shape)
+        ups = np.broadcast_to(ups, shape)
+
+        if not (np.all(np.linalg.norm(views, axis=-1)) and
+                np.all(np.linalg.norm(ups, axis=-1))):
             raise ValueError("View and Up Vectors must have a length.")
-        if not np.allclose(0, np.einsum('ij,kj->k', views, ups)):
+        if not np.allclose(0, np.einsum('...j,...j->...', views, ups)):
             raise ValueError("View and Up vectors must be perpendicular.")
 
         # Assuming that the direction of the cross product is defined
         # by the right-hand rule
-        rights = np.cross(views, ups)
+        rights = np.cross(views, ups, axis=-1)
 
         # In a standard Cartesian right-handed coordinate system,
         # these vectors are defined as [x, y, z] = [view, left, up], where
         # left is the same vector as -rights
-        rotation_matrix = np.asarray([views, -rights, ups])
-        rotation_matrix = np.swapaxes(rotation_matrix, 0, 1)
-
+        rotation_matrix = np.stack((views, -rights, ups), axis=-1)
         return cls.from_matrix(rotation_matrix)
 
     # other class methods
@@ -1012,12 +1013,9 @@ class Rotation():
 
         Returns
         -------
-        vector_triple: ndarray, shape (N, 3), normalized vectors
+        vector_triple: ndarray, shape (..., 3), normalized vectors
             - views, see :py:func:`Rotation.from_view_up`
             - ups, see :py:func:`Rotation.from_view_up`
-            - rights, see :py:func:`Rotation.from_view_up`
-                A single vector or a stack of vectors, pointing to the right of
-                the object, constructed as a cross product of ups and rights.
         """
         vector_triple = self.as_matrix()
         views, _, ups = np.split(vector_triple, 3, axis=-2)
@@ -1133,55 +1131,3 @@ class Rotation():
         rot = self._rot.reduce(left, right, return_indices)
         return self._from_scipy_rotation(rot)
 
-    def show(self, positions=None,
-             show_views=True, show_ups=True, show_rights=True, **kwargs):
-        """
-        Visualize Rotation as triples of view (red), up (green) and
-        right (blue) vectors in a quiver plot.
-
-        Parameters
-        ----------
-        positions : array_like, shape (O, 3), O is len(self)
-            These are the positions of each vector triple. If not provided,
-            all triples are positioned in the origin of the coordinate system.
-        show_views: bool
-            select wether to show the view vectors or not.
-            The default is True.
-        show_ups: bool
-            select wether to show the up vectors or not.
-            The default is True.
-        show_rights: bool
-            select wether to show the right vectors or not.
-            The default is True.
-        kwargs : dict
-            Additional arguments passed to :py:func:`pyfar.plot.quiver`.
-
-        Returns
-        -------
-        ax : :py:class:`~mpl_toolkits.mplot3d.axes3d.Axes3D`
-            The axis used for the plot.
-
-        """
-        if positions is None:
-            positions = np.zeros((self.as_quat().shape[0], 3))
-        positions = np.atleast_2d(positions).astype(np.float64)
-        if positions.shape[0] != self.as_quat().shape[0]:
-            raise ValueError("If provided, there must be the same number"
-                             "of positions as rotations.")
-
-        # Create view, up and right vectors from Rotation object
-        views, ups = self.as_view_up()
-        rights = np.cross(views, ups)
-
-        kwargs.pop('color', None)
-
-        ax = None
-        if show_views:
-            ax = pf.plot.quiver(
-                positions, views, color=pf.plot.color('r'), **kwargs)
-        if show_ups:
-            ax = pf.plot.quiver(
-                positions, ups, ax=ax, color=pf.plot.color('g'), **kwargs)
-        if show_rights:
-            ax = pf.plot.quiver(
-                positions, rights, ax=ax, color=pf.plot.color('b'), **kwargs)

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -466,10 +466,11 @@ class Rotation():
         try:
             shape = np.broadcast_shapes(views.shape, ups.shape)
         except ValueError as exc:
-            raise ValueError from exc(
+            message = (
                 f"shape missmatch: `views` {views.shape} and `ups` {ups.shape}"
-                " cannot be broadcasted to a single shape",
+                " cannot be broadcasted to a single shape"
             )
+            raise ValueError(message) from exc
 
         # check shape
         if shape[-1] != 3:

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -713,15 +713,15 @@ class Rotation():
             - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
             - ``axis1 == axis3`` (symmetric sequence)
 
-        For Davenport angles, this last relationship is relaxed [1]_, and only
+        For Davenport angles, this last relationship is relaxed [#]_, and only
         the consecutive orthogonal axes requirement is maintained.
 
-        A slightly modified version of the algorithm from [2]_ has been used to
+        A slightly modified version of the algorithm from [#]_ has been used to
         calculate Davenport angles for the rotation about a given sequence of
         axes.
 
         Davenport angles, just like Euler angles, suffer from the problem of
-        gimbal lock [3]_, where the representation loses a degree of freedom
+        gimbal lock [#]_, where the representation loses a degree of freedom
         and it is not possible to determine the first and third angles
         uniquely. In this case, a warning is raised (unless the
         ``suppress_warnings`` option is used), and the third angle is set
@@ -759,13 +759,13 @@ class Rotation():
 
         References
         ----------
-        .. [1] Shuster, Malcolm & Markley, Landis. (2003). Generalization of
+        .. [#] Shuster, Malcolm & Markley, Landis. (2003). Generalization of
                the Euler Angles. Journal of the Astronautical Sciences. 51. 123-132.
                10.1007/BF03546304.
-        .. [2] Bernardes E, Viollet S (2022) Quaternion to Euler angles
+        .. [#] Bernardes E, Viollet S (2022) Quaternion to Euler angles
                conversion: A direct, general and computationally efficient method.
                PLoS ONE 17(11): e0276302. 10.1371/journal.pone.0276302
-        .. [3] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
+        .. [#] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
 
         return self._rot.as_davenport(axes, order, degrees, suppress_warnings)
@@ -778,12 +778,12 @@ class Rotation():
 
         Any orientation can be expressed as a composition of 3 elementary
         rotations. Once the axis sequence has been chosen, Euler angles define
-        the angle of rotation around each respective axis [1]_.
+        the angle of rotation around each respective axis [#]_.
 
-        The algorithm from [2]_ has been used to calculate Euler angles for the
+        The algorithm from [#]_ has been used to calculate Euler angles for the
         rotation about a given sequence of axes.
 
-        Euler angles suffer from the problem of gimbal lock [3]_, where the
+        Euler angles suffer from the problem of gimbal lock [#]_, where the
         representation loses a degree of freedom and it is not possible to
         determine the first and third angles uniquely. In this case,
         a warning is raised (unless the ``suppress_warnings`` option is used),
@@ -794,7 +794,7 @@ class Rotation():
         ----------
         seq : string, length 3
             3 characters belonging to the set {'X', 'Y', 'Z'} for intrinsic
-            rotations, or {'x', 'y', 'z'} for extrinsic rotations [1]_.
+            rotations, or {'x', 'y', 'z'} for extrinsic rotations [#]_.
             Adjacent axes cannot be the same.
             Extrinsic and intrinsic rotations cannot be mixed in one function
             call.
@@ -820,12 +820,12 @@ class Rotation():
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
-        .. [2] Bernardes E, Viollet S (2022) Quaternion to Euler angles
+        .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
+        .. [#] Bernardes E, Viollet S (2022) Quaternion to Euler angles
                conversion: A direct, general and computationally efficient
                method. PLoS ONE 17(11): e0276302.
                https://doi.org/10.1371/journal.pone.0276302
-        .. [3] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
+        .. [#] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
 
         return self._rot.as_euler(seq, degrees, suppress_warnings)
@@ -837,7 +837,7 @@ class Rotation():
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_matrix`.
 
         3D rotations can be represented using rotation matrices, which
-        are 3 x 3 real orthogonal matrices with determinant equal to +1 [1]_.
+        are 3 x 3 real orthogonal matrices with determinant equal to +1 [#]_.
 
         Returns
         -------
@@ -846,7 +846,7 @@ class Rotation():
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
+        .. [#] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
         """
 
         return self._rot.as_matrix()
@@ -859,7 +859,7 @@ class Rotation():
 
         MRPs are a 3 dimensional vector co-directional to the axis of rotation
         and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
-        the angle of rotation (in radians) [1]_.
+        the angle of rotation (in radians) [#]_.
 
         MRPs have a singularity at 360 degrees which can be avoided by ensuring
         the angle of rotation does not exceed 180 degrees, i.e. switching the
@@ -874,7 +874,7 @@ class Rotation():
 
         References
         ----------
-        .. [1] Shuster, M. D. "A Survey of Attitude Representations",
+        .. [#] Shuster, M. D. "A Survey of Attitude Representations",
                The Journal of Astronautical Sciences, Vol. 41, No.4, 1993,
                pp. 475-476
         """
@@ -887,7 +887,7 @@ class Rotation():
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_quat`.
 
         Rotations in 3 dimensions can be represented using unit norm
-        quaternions [1]_.
+        quaternions [#]_.
 
         The 4 components of a quaternion are divided into a scalar part ``w``
         and a vector part ``(x, y, z)`` and can be expressed from the angle
@@ -930,7 +930,7 @@ class Rotation():
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+        .. [#] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
         """
         return self._rot.as_quat(canonical, scalar_first)
 
@@ -941,7 +941,7 @@ class Rotation():
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_rotvec`.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
-        the axis of rotation and whose norm gives the angle of rotation [1]_.
+        the axis of rotation and whose norm gives the angle of rotation [#]_.
 
         Parameters
         ----------
@@ -956,7 +956,7 @@ class Rotation():
 
         References
         ----------
-        .. [1] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
+        .. [#] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
         """
 
         return self._rot.as_rotvec(degrees)

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -33,8 +33,9 @@ class Rotation():
 
     def __repr__(self):
         """String representation of Rotation object."""
-        repr = f"Pyfar Rotations object with {self.n_rotations} rotations."
-        return repr
+        repr_string = \
+              f"Pyfar Rotations object with {self.n_rotations} rotations."
+        return repr_string
 
     def __iter__(self):
         """Iterate over rotations."""
@@ -50,6 +51,7 @@ class Rotation():
         return self._from_scipy_rotation(self._rot[idx])
 
     def __setitem__(self, *args):
+        """"""
         raise NotImplementedError('Setting an item is disabled for pyfar '
         'Rotations. If you want to modify the Rotation, use an array '
         'representation like `as_quat()` or `as_matrix()` and create a new '
@@ -73,16 +75,17 @@ class Rotation():
 
     def __pow__(self, n):
         """Compose orientation with itself n times."""
-        self._rot = self._rot.__pow__(n)
-        return self
+        rot = self._rot.__pow__(n)
+        return self._from_scipy_rotation(rot)
 
     def __eq__(self, other):
         """Check for equality of two objects."""
         return np.array_equal(self.as_quat(), other.as_quat())
 
-    # properties (!!! WRITE TEST !!!)
+    # properties
     @property
     def n_rotations(self):
+        """"""
         quat = self._rot.as_quat()
         n_rotations = \
             1 if quat.ndim == 1 else quat.shape[0]
@@ -92,45 +95,40 @@ class Rotation():
     @classmethod
     def from_davenport(cls, axes, order, angles, degrees=False):
         """"""
-        instance = cls.__new__(cls)
-        instance._rot = scRotation.from_davenport(
+        rot = scRotation.from_davenport(
             axes, order, angles, degrees=degrees)
-        return instance
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_euler(cls, seq, angles, degrees=False):
         """"""
-        instance = cls.__new__(cls)
-        instance._rot = scRotation.from_euler(
+        rot = scRotation.from_euler(
             seq, angles, degrees=degrees)
-        return instance
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_matrix(cls, matrix):
         """"""
-        instance = cls.__new__(cls)
-        instance._rot = scRotation.from_matrix(matrix)
-        return instance
+        rot = scRotation.from_matrix(matrix)
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_mrp(cls, mrp):
-        instance = cls.__new__(cls)
-        instance._rot = scRotation.from_mrp(mrp)
-        return instance
+        """"""
+        rot = scRotation.from_mrp(mrp)
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_quat(cls, quat):
         """"""
-        instance = cls.__new__(cls)
-        instance._rot = scRotation.from_quat(quat)
-        return instance
+        rot = scRotation.from_quat(quat)
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_rotvec(cls, rotvec, degrees=False):
         """"""
-        instance = cls.__new__(cls)
-        instance._rot = scRotation.from_rotvec(rotvec, degrees)
-        return instance
+        rot = scRotation.from_rotvec(rotvec, degrees)
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_view_up(cls, views, ups):
@@ -160,8 +158,6 @@ class Rotation():
         orientations : Orientations
             Object containing the orientations represented by quaternions.
         """
-        instance = cls.__new__(cls)
-
         # init views and up
         try:
             views = np.atleast_2d(views).astype(np.float64)
@@ -201,24 +197,38 @@ class Rotation():
         rotation_matrix = np.asarray([views, -rights, ups])
         rotation_matrix = np.swapaxes(rotation_matrix, 0, 1)
 
-        return instance.from_matrix(rotation_matrix)
+        return cls.from_matrix(rotation_matrix)
 
     # other class methods
     @classmethod
-    def align_vectors(a, b, weights=None, return_sensitivity=False):
-        raise NotImplementedError
+    def align_vectors(cls, a, b, weights=None, return_sensitivity=False):
+        """"""
+        result = scRotation.align_vectors(a, b, weights, return_sensitivity)
+
+        return (cls._from_scipy_rotation(result[0]), *result[1:])
 
     @classmethod
-    def concatenate(cls, rotation):
-        raise NotImplementedError
+    def concatenate(cls, rotations):
+        """"""
+        if np.asarray(rotations).shape[0] == 1:
+            return rotations[0].copy()
+
+        rotations = [rotation._rot for rotation in rotations]
+
+        rot = scRotation.concatenate(rotations)
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def identity(cls, num=None, *, shape=None):
-        raise NotImplementedError
+        """"""
+        rot  = scRotation.identity(num, shape=shape)
+        return cls._from_scipy_rotation(rot)
 
     @classmethod
     def random(cls, num=None, rng=None, *, shape=None):
-        raise NotImplementedError
+        """"""
+        rot = scRotation.random(num, rng, shape=shape)
+        return cls._from_scipy_rotation(rot)
 
     # private class methods
     @classmethod
@@ -242,13 +252,21 @@ class Rotation():
         """"""
         return self._rot.as_euler()
 
+    def as_matrix(self):
+        """"""
+        return self._rot.as_matrix()
+
+    def as_mrp(self):
+        """"""
+        return self._rot.as_mrp()
+
     def as_quat(self):
         """"""
         return self._rot.as_quat()
 
-    def as_matrix(self):
+    def as_rotvec(self):
         """"""
-        return self._rot.as_matrix()
+        return self._rot.as_rotvec()
 
     def as_view_up_right(self):
         """"""
@@ -290,6 +308,7 @@ class Rotation():
 
     def show(self, positions=None,
              show_views=True, show_ups=True, show_rights=True, **kwargs):
+        """"""
         if positions is None:
             positions = np.zeros((self.as_quat().shape[0], 3))
         positions = np.atleast_2d(positions).astype(np.float64)
@@ -312,6 +331,3 @@ class Rotation():
         if show_rights:
             ax = pf.plot.quiver(
                 positions, rights, ax=ax, color=pf.plot.color('b'), **kwargs)
-
-    # private instance methods
-

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -99,8 +99,8 @@ class Rotation():
         """
         if isinstance(other, Rotation):
             other = scRotation.from_quat(other.as_quat())
-        self._rot *= other
-        return self
+        result = self._rot * other
+        return self._from_scipy_rotation(result)
 
     def __rmul__(self, other):
         """
@@ -113,10 +113,9 @@ class Rotation():
             The object to multiply with.
         """
         if isinstance(other, Rotation):
-            other = scRotation.from_quat(other.as_quat())
-        if isinstance(other, scRotation):
-            self._rot *= other
-            return self
+            other = other._rot
+        result = other * self._rot
+        return self._from_scipy_rotation(result)
 
     def __pow__(self, n):
         """Compose rotation with itself n times."""

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -139,7 +139,10 @@ class Rotation():
     # from-... methods
     @classmethod
     def from_davenport(cls, axes, order, angles, degrees=False):
-        """Initialize from Davenport angles.
+        """
+        Initialize from Davenport angles.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_davenport`.
 
         Rotations in 3-D can be represented by a sequence of 3
         rotations around a sequence of axes.
@@ -200,6 +203,8 @@ class Rotation():
         """
         Initialize from Euler angles.
 
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_euler`.
+
         Rotations in 3-D can be represented by a sequence of 3
         rotations around a sequence of axes. In theory, any three axes spanning
         the 3-D Euclidean space are enough. In practice, the axes of rotation
@@ -241,6 +246,8 @@ class Rotation():
         """
         Initialize from rotation matrix.
 
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_matrix`.
+
         Rotations in 3 dimensions can be represented with 3 x 3 orthogonal
         matrices [#]_. If the input is not orthogonal, an approximation is
         created by orthogonalizing the input matrix using the method described
@@ -277,6 +284,8 @@ class Rotation():
         """
         Initialize from Modified Rodrigues Parameters (MRPs).
 
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_mrp`.
+
         MRPs are a 3 dimensional vector co-directional to the axis of rotation
         and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
         the angle of rotation (in radians) [#]_.
@@ -304,6 +313,8 @@ class Rotation():
     def from_quat(cls, quat):
         """
         Initialize from quaternions.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_quat`.
 
         Rotations in 3 dimensions can be represented using unit norm
         quaternions [#]_.
@@ -355,6 +366,8 @@ class Rotation():
     def from_rotvec(cls, rotvec, degrees=False):
         """
         Initialize from rotation vectors.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.from_rotvec`.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation [#]_.
@@ -449,6 +462,8 @@ class Rotation():
     def align_vectors(cls, a, b, weights=None, return_sensitivity=False):
         r"""
         Estimate an orientation to optimally align two sets of vectors.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.align_vectors`.
 
         Find a rotation between frames A and B which best aligns a set of
         vectors `a` and `b` observed in these frames. The following loss
@@ -576,6 +591,8 @@ class Rotation():
         """
         Concatenate a sequence of Orientations objects into a single object.
 
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.concatenate`.
+
         This is useful if you want to, for example, take the mean of a set of
         orientations and need to pack them into a single object to do so.
 
@@ -603,6 +620,8 @@ class Rotation():
         """
         Get identity orientation(s).
 
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.identity`.
+
         Composition with the identity orientation has no effect.
 
         Parameters
@@ -626,6 +645,8 @@ class Rotation():
     def random(cls, num=None, rng=None, *, shape=None):
         """
         Generate orientations that are uniformly distributed on a sphere.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.random`.
 
         Formally, the orientations follow the Haar-uniform distribution over
         the SO(3) group.
@@ -667,45 +688,299 @@ class Rotation():
 
     @classmethod
     def _from_scipy_rotation(cls, sc_rotation):
-        """"""
+        """Internal helper to create instance from scipy Rotation."""
         instance = cls.__new__(cls)
         instance._rot = sc_rotation
         return instance
 
     # Instance methods
-    def as_davenport(self):
-        """"""
-        return self._rot.as_davenport()
+    def as_davenport(self, axes, order, degrees=False,
+                     suppress_warnings=False):
+        """
+        Represent as Davenport angles.
 
-    def as_euler(self):
-        """"""
-        return self._rot.as_euler()
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_davenport`.
+
+
+        Any orientation can be expressed as a composition of 3 elementary
+        rotations.
+
+        For both Euler angles and Davenport angles, consecutive axes must
+        be are orthogonal (``axis2`` is orthogonal to both ``axis1`` and
+        ``axis3``). For Euler angles, there is an additional relationship
+        between ``axis1`` or ``axis3``, with two possibilities:
+
+            - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
+            - ``axis1 == axis3`` (symmetric sequence)
+
+        For Davenport angles, this last relationship is relaxed [1]_, and only
+        the consecutive orthogonal axes requirement is maintained.
+
+        A slightly modified version of the algorithm from [2]_ has been used to
+        calculate Davenport angles for the rotation about a given sequence of
+        axes.
+
+        Davenport angles, just like Euler angles, suffer from the problem of
+        gimbal lock [3]_, where the representation loses a degree of freedom
+        and it is not possible to determine the first and third angles
+        uniquely. In this case, a warning is raised (unless the
+        ``suppress_warnings`` option is used), and the third angle is set
+        to zero. Note however that the returned angles still represent the
+        correct rotation.
+
+        Parameters
+        ----------
+        axes : array_like, shape (..., [1 or 2 or 3], 3) or (..., 3)
+            Axis of rotation, if one dimensional. If N dimensional, describes the
+            sequence of axes for rotations, where each axes[..., i, :] is the ith
+            axis. If more than one axis is given, then the second axis must be
+            orthogonal to both the first and third axes.
+        order : string
+            If it belongs to the set {'e', 'extrinsic'}, the sequence will be
+            extrinsic. If it belongs to the set {'i', 'intrinsic'}, sequence
+            will be treated as intrinsic.
+        degrees : boolean, optional
+            Returned angles are in degrees if this flag is True, else they are
+            in radians. Default is False.
+        suppress_warnings : boolean, optional
+            Disable warnings about gimbal lock. Default is False.
+
+        Returns
+        -------
+        angles : ndarray, shape (..., 3)
+            Shape depends on shape of inputs used to initialize object.
+            The returned angles are in the range:
+
+            - First angle belongs to [-180, 180] degrees (both inclusive)
+            - Third angle belongs to [-180, 180] degrees (both inclusive)
+            - Second angle belongs to a set of size 180 degrees,
+              given by: ``[-abs(lambda), 180 - abs(lambda)]``, where ``lambda``
+              is the angle between the first and third axes.
+
+        References
+        ----------
+        .. [1] Shuster, Malcolm & Markley, Landis. (2003). Generalization of
+               the Euler Angles. Journal of the Astronautical Sciences. 51. 123-132.
+               10.1007/BF03546304.
+        .. [2] Bernardes E, Viollet S (2022) Quaternion to Euler angles
+               conversion: A direct, general and computationally efficient method.
+               PLoS ONE 17(11): e0276302. 10.1371/journal.pone.0276302
+        .. [3] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
+        """
+
+        return self._rot.as_davenport(axes, order, degrees, suppress_warnings)
+
+    def as_euler(self, seq, degrees=False, suppress_warnings=False):
+        """
+        Represent as Euler angles.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_euler`.
+
+        Any orientation can be expressed as a composition of 3 elementary
+        rotations. Once the axis sequence has been chosen, Euler angles define
+        the angle of rotation around each respective axis [1]_.
+
+        The algorithm from [2]_ has been used to calculate Euler angles for the
+        rotation about a given sequence of axes.
+
+        Euler angles suffer from the problem of gimbal lock [3]_, where the
+        representation loses a degree of freedom and it is not possible to
+        determine the first and third angles uniquely. In this case,
+        a warning is raised (unless the ``suppress_warnings`` option is used),
+        and the third angle is set to zero. Note however that the returned
+        angles still represent the correct rotation.
+
+        Parameters
+        ----------
+        seq : string, length 3
+            3 characters belonging to the set {'X', 'Y', 'Z'} for intrinsic
+            rotations, or {'x', 'y', 'z'} for extrinsic rotations [1]_.
+            Adjacent axes cannot be the same.
+            Extrinsic and intrinsic rotations cannot be mixed in one function
+            call.
+        degrees : boolean, optional
+            Returned angles are in degrees if this flag is True, else they are
+            in radians. Default is False.
+        suppress_warnings : boolean, optional
+            Disable warnings about gimbal lock. Default is False.
+
+        Returns
+        -------
+        angles : ndarray, shape (..., 3)
+            Shape depends on shape of inputs used to initialize object.
+            The returned angles are in the range:
+
+            - First angle belongs to [-180, 180] degrees (both inclusive)
+            - Third angle belongs to [-180, 180] degrees (both inclusive)
+            - Second angle belongs to:
+
+                - [-90, 90] degrees if all axes are different (like xyz)
+                - [0, 180] degrees if first and third axes are the same
+                  (like zxz)
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
+        .. [2] Bernardes E, Viollet S (2022) Quaternion to Euler angles
+               conversion: A direct, general and computationally efficient
+               method. PLoS ONE 17(11): e0276302.
+               https://doi.org/10.1371/journal.pone.0276302
+        .. [3] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
+        """
+
+        return self._rot.as_euler(seq, degrees, suppress_warnings)
 
     def as_matrix(self):
-        """"""
+        """
+        Represent as rotation matrix.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_matrix`.
+
+        3D rotations can be represented using rotation matrices, which
+        are 3 x 3 real orthogonal matrices with determinant equal to +1 [1]_.
+
+        Returns
+        -------
+        matrix : ndarray, shape (..., 3)
+            Shape depends on shape of inputs used for initialization.
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
+        """
+
         return self._rot.as_matrix()
 
     def as_mrp(self):
-        """"""
+        """
+        Represent as Modified Rodrigues Parameters (MRPs).
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_mrp`.
+
+        MRPs are a 3 dimensional vector co-directional to the axis of rotation
+        and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
+        the angle of rotation (in radians) [1]_.
+
+        MRPs have a singularity at 360 degrees which can be avoided by ensuring
+        the angle of rotation does not exceed 180 degrees, i.e. switching the
+        direction of the rotation when it is past 180 degrees. This function
+        will always return MRPs corresponding to a rotation of less than or
+        equal to 180 degrees.
+
+        Returns
+        -------
+        mrps : ndarray, shape (..., 3)
+            Shape depends on shape of inputs used for initialization.
+
+        References
+        ----------
+        .. [1] Shuster, M. D. "A Survey of Attitude Representations",
+               The Journal of Astronautical Sciences, Vol. 41, No.4, 1993,
+               pp. 475-476
+        """
+
         return self._rot.as_mrp()
 
-    def as_quat(self):
-        """"""
-        return self._rot.as_quat()
+    def as_quat(self, canonical=False, *, scalar_first=False):
+        """Represent as quaternions.
 
-    def as_rotvec(self):
-        """"""
-        return self._rot.as_rotvec()
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_quat`.
+
+        Rotations in 3 dimensions can be represented using unit norm
+        quaternions [1]_.
+
+        The 4 components of a quaternion are divided into a scalar part ``w``
+        and a vector part ``(x, y, z)`` and can be expressed from the angle
+        ``theta`` and the axis ``n`` of a rotation as follows::
+
+            w = cos(theta / 2)
+            x = sin(theta / 2) * n_x
+            y = sin(theta / 2) * n_y
+            z = sin(theta / 2) * n_z
+
+        There are 2 conventions to order the components in a quaternion:
+
+        - scalar-first order -- ``(w, x, y, z)``
+        - scalar-last order -- ``(x, y, z, w)``
+
+        The choice is controlled by `scalar_first` argument.
+        By default, it is False and the scalar-last order is used.
+
+        The mapping from quaternions to rotations is
+        two-to-one, i.e. quaternions ``q`` and ``-q``, where ``-q`` simply
+        reverses the sign of each component, represent the same spatial
+        rotation.
+
+        Parameters
+        ----------
+        canonical : `bool`, default False
+            Whether to map the redundant double cover of rotation space to a
+            unique "canonical" single cover. If True, then the quaternion is
+            chosen from {q, -q} such that the w term is positive. If the w term
+            is 0, then the quaternion is chosen such that the first nonzero
+            term of the x, y, and z terms is positive.
+        scalar_first : bool, optional
+            Whether the scalar component goes first or last.
+            Default is False, i.e. the scalar-last order is used.
+
+        Returns
+        -------
+        quat : `numpy.ndarray`, shape (..., 4)
+            Shape depends on shape of inputs used for initialization.
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+        """
+        return self._rot.as_quat(canonical, scalar_first)
+
+    def as_rotvec(self, degrees=False):
+        """
+        Represent as rotation vectors.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_rotvec`.
+
+        A rotation vector is a 3 dimensional vector which is co-directional to
+        the axis of rotation and whose norm gives the angle of rotation [1]_.
+
+        Parameters
+        ----------
+        degrees : boolean, optional
+            Returned magnitudes are in degrees if this flag is True, else they
+            are in radians. Default is False.
+
+        Returns
+        -------
+        rotvec : ndarray, shape (..., 3)
+            Shape depends on shape of inputs used for initialization.
+
+        References
+        ----------
+        .. [1] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
+        """
+
+        return self._rot.as_rotvec(degrees)
 
     def as_view_up(self):
-        """"""
-        vector_triple = self.as_matrix()
-        views, lefts, ups = np.split(vector_triple, 3, axis=-2)
+        """Get Orientations as a view, up, and right vector.
 
-        # In a standard Cartesian right-handed coordinate system,
-        # standard basis is defined as [x, y, z] = [view, left, up], where
-        # left is the same vector as -rights
-        vector_triple = np.concatenate((views, ups, -lefts), axis=-2)
+        Orientations are internally stored as quaternions for better spherical
+        linear interpolation (SLERP) and spherical harmonics operations.
+        More intuitionally, they can be expressed as view and and up of vectors
+        which cannot be collinear. In this case are restricted to be
+        perpendicular to minimize rounding errors.
+
+        Returns
+        -------
+        vector_triple: ndarray, shape (N, 3), normalized vectors
+            - views, see :py:func:`Orientations.from_view_up`
+            - ups, see :py:func:`Orientations.from_view_up`
+            - rights, see :py:func:`Orientations.from_view_up`
+                A single vector or a stack of vectors, pointing to the right of
+                the object, constructed as a cross product of ups and rights.
+        """
+        vector_triple = self.as_matrix()
+        views, _, ups = np.split(vector_triple, 3, axis=-2)
 
         views = np.squeeze(views, axis=-2)
         ups   = np.squeeze(ups, axis=-2)
@@ -717,16 +992,99 @@ class Rotation():
         return self.from_quat(self.as_quat())
 
     def inv(self):
-        """"""
+        """
+        Invert this orientation.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.inv`.
+
+        Composition of an orientation with its inverse results in an identity
+        transformation.
+
+        Returns
+        -------
+        inverse : Orientations
+            Object containing inverse of the orientations in the current
+            instance.
+        """
         self._rot = self._rot.inv()
         return self
 
     def mean(self, weights=None, axis=None):
-        """"""
+        r"""
+        Get the mean of the orientations.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.mean`.
+
+        The mean used is the chordal L2 mean (also called the projected or
+        induced arithmetic mean) [#]_. If ``A`` is a set of rotation matrices,
+        then the mean ``M`` is the rotation matrix that minimizes the
+        following loss function:
+
+        .. math::
+
+            L(M) = \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{A}_i -
+            \\mathbf{M} \\rVert^2 ,
+
+        where :math:`w_i`'s are the `weights` corresponding to each matrix.
+
+        Parameters
+        ----------
+        weights : array_like shape (..., N), optional
+            Weights describing the relative importance of the orientations. If
+            None (default), then all values in `weights` are assumed to be
+            equal. If given, the shape of `weights` must be broadcastable to
+            the rotation shape. Weights must be non-negative.
+        axis : None, int, or tuple of ints, optional
+            Axis or axes along which the means are computed. The default is to
+            compute the mean of all orientations.
+
+        Returns
+        -------
+        mean : Orientations
+            Single orientation containing the mean of the orientations in the
+            current instance.
+
+        References
+        ----------
+        .. [#] Hartley, Richard, et al.,
+                "Rotation Averaging", International Journal of Computer Vision
+                103, 2013, pp. 267-305.
+        """
         return self._from_scipy_rotation(self._rot.mean(weights, axis))
 
     def reduce(self, left=None, right=None, return_indices=False):
-        """"""
+        """Reduce this orientation with the provided orientation groups.
+
+        Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.reduce`.
+
+        Reduction of a orientation ``p`` is a transformation of the form
+        ``q = l * p * r``, where ``l`` and ``r`` are chosen from `left` and
+        `right` respectively, such that orientation ``q`` has the smallest
+        magnitude.
+
+        If `left` and `right` are orientation groups representing symmetries of
+        two objects rotated by ``p``, then ``q`` is the orientation of the
+        smallest magnitude to align these objects considering their symmetries.
+
+        Parameters
+        ----------
+        left : Orientation, optional
+            Object containing the left orientation(s). Default value (None)
+            corresponds to the identity orientation.
+        right : Orientation, optional
+            Object containing the right orientation(s). Default value (None)
+            corresponds to the identity orientation.
+        return_indices : bool, optional
+            Whether to return the indices of the orientations from `left` and
+            `right` used for reduction.
+
+        Returns
+        -------
+        reduced : Orientations
+            Object containing reduced orientations.
+        left_best, right_best: integer ndarray
+            Indices of elements from `left` and `right` used for reduction.
+        """
         if return_indices:
             rot, left_idx, right_idx = \
                 self._rot.reduce(left, right, return_indices)
@@ -737,7 +1095,33 @@ class Rotation():
 
     def show(self, positions=None,
              show_views=True, show_ups=True, show_rights=True, **kwargs):
-        """"""
+        """
+        Visualize Orientations as triples of view (red), up (green) and
+        right (blue) vectors in a quiver plot.
+
+        Parameters
+        ----------
+        positions : array_like, shape (O, 3), O is len(self)
+            These are the positions of each vector triple. If not provided,
+            all triples are positioned in the origin of the coordinate system.
+        show_views: bool
+            select wether to show the view vectors or not.
+            The default is True.
+        show_ups: bool
+            select wether to show the up vectors or not.
+            The default is True.
+        show_rights: bool
+            select wether to show the right vectors or not.
+            The default is True.
+        kwargs : dict
+            Additional arguments passed to :py:func:`pyfar.plot.quiver`.
+
+        Returns
+        -------
+        ax : :py:class:`~mpl_toolkits.mplot3d.axes3d.Axes3D`
+            The axis used for the plot.
+
+        """
         if positions is None:
             positions = np.zeros((self.as_quat().shape[0], 3))
         positions = np.atleast_2d(positions).astype(np.float64)

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -304,14 +304,17 @@ class Rotation():
     def as_view_up(self):
         """"""
         vector_triple = self.as_matrix()
+        views, lefts, ups = np.split(vector_triple, 3, axis=-2)
 
-        if vector_triple.ndim == 2:
-            view = vector_triple[0]
-            up = vector_triple[2]
-        else:
-            view, _, up = np.split(vector_triple, 3, axis=-2)
+        # In a standard Cartesian right-handed coordinate system,
+        # standard basis is defined as [x, y, z] = [view, left, up], where
+        # left is the same vector as -rights
+        vector_triple = np.concatenate((views, ups, -lefts), axis=-2)
 
-        return view, up
+        views = np.squeeze(views, axis=-2)
+        ups   = np.squeeze(ups, axis=-2)
+
+        return views, ups
 
     def copy(self):
         """Return a deep copy of the Orientations object."""

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -834,7 +834,7 @@ class Rotation():
         ----------
         seq : string, length 3
             3 characters belonging to the set {'X', 'Y', 'Z'} for intrinsic
-            rotations, or {'x', 'y', 'z'} for extrinsic rotations [#]_.
+            rotations, or {'x', 'y', 'z'} for extrinsic rotations.
             Adjacent axes cannot be the same.
             Extrinsic and intrinsic rotations cannot be mixed in one function
             call.

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -1,0 +1,110 @@
+"""This module contains the Rotation class."""
+from scipy.spatial.transform import Rotation as scRotation
+import numpy as np
+import warnings
+
+import pyfar as pf
+if np.__version__ < '2.0.0':
+    from numpy import VisibleDeprecationWarning
+else:
+    from numpy.exceptions import VisibleDeprecationWarning
+
+# this warning needs to be caught and appears if numpy array are generated
+# from nested lists containing lists of unequal lengths,
+#  e.g., [[1, 0, 0], [1, 0]]
+warnings.filterwarnings("error", category=VisibleDeprecationWarning)
+
+
+class Rotation():
+    """
+    Pyfar Rotation class.
+    """
+    def __init__(self):
+        raise RuntimeError("Rotation objects must be created using one of "
+                           "the `from_...` methods")
+
+    def __repr__(self):
+        """String representation of Rotation object."""
+        num_orientations = \
+            1 if self._quat.ndim == 1 else self._quat.shape[0]
+
+        _repr = f"Pyfar Rotations object with {num_orientations} rotations."
+        return _repr
+
+    # Factory Methods
+    @classmethod
+    def from_davenport(cls, axes, order, angles, degrees=False):
+        """"""
+        instance = cls.__new__(cls)
+        instance._store_rotation(scRotation.from_davenport(
+            axes, order, angles, degrees=False))
+
+        return instance
+
+    @classmethod
+    def from_euler(cls, seq, angles, degrees=False):
+        """"""
+        instance = cls.__new__(cls)
+        instance._store_rotation(scRotation.from_euler(
+            seq, angles, degrees=False))
+
+        return instance
+
+    @classmethod
+    def from_matrix(cls, matrix):
+        """"""
+        instance = cls.__new__(cls)
+        instance._store_rotation(scRotation.from_matrix(matrix))
+
+        return instance
+
+    @classmethod
+    def from_quat(cls, quat):
+        """"""
+        instance = cls.__new__(cls)
+        instance._store_rotation(scRotation.from_quat(quat))
+        return instance
+
+
+    @classmethod
+    def _from_scipy_rotation(cls, sc_rotation):
+        """"""
+        instance = cls.__new__(cls)
+        instance._store_rotation(sc_rotation)
+        return instance
+
+    # Instance methods
+    def as_davenport(self):
+        """"""
+        return self._rot.as_davenport()
+
+    def as_euler(self):
+        """"""
+        return self._rot.as_euler()
+
+    def as_quat(self):
+        """"""
+        return self._quat
+
+    def as_matrix(self):
+        """"""
+        return self._rot.as_matrix()
+
+    def mean(self, weights=None, axis=None):
+        """"""
+        return self._from_scipy_rotation(self._rot.mean(weights, axis))
+
+    # Private methods
+    def _store_rotation(self, sc_rotation: scRotation):
+        """
+        Stores scipy rotation and raw quaternion data.
+
+        This is an auxiliary private function to save some codelines.
+
+        Parameters
+        ----------
+        sc_rotatiton : scipy.Rotation
+            Scipy Rotation object
+        """
+        self._rot = sc_rotation
+        self._quat = sc_rotation.as_quat()

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -489,12 +489,12 @@ class Rotation():
 
         # Assuming that the direction of the cross product is defined
         # by the right-hand rule
-        rights = np.cross(views, ups, axis=-1)
+        rights = np.cross(views, ups)
 
         # In a standard Cartesian right-handed coordinate system,
         # these vectors are defined as [x, y, z] = [view, left, up], where
         # left is the same vector as -rights
-        rotation_matrix = np.stack((views, -rights, ups), axis=-1)
+        rotation_matrix = np.stack((views, -rights, ups), axis=-2)
         return cls.from_matrix(rotation_matrix)
 
     # other class methods

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -32,21 +32,16 @@ class Rotation():
 
     Examples
     --------
-    >>> from pyfar import Rotation
+    >>> import pyfar as pf
     >>> views = [[1, 0, 0], [2, 0, 0]]
     >>> ups = [[0, 1, 0], [0, -2, 0]]
-    >>> rotations = Rotation.from_view_up(views, ups)
+    >>> rotations = pf.Rotation.from_view_up(views, ups)
 
-    Visualize rotations at certain positions:
-
-    >>> positions = [[0, 0.5, 0], [0, -0.5, 0]]
-    >>> rotations.show(positions)
 
     Rotate by 45 degree in x-direction:
 
-    >>> rot_x45 = Rotation.from_euler('x', 45, degrees=True)
-    >>> rotations = rotations * rot_x45
-    >>> rotations.show(positions)
+    >>> rot_x45 = pf.Rotation.from_euler('x', 45, degrees=True)
+    >>> rot_x45 = pf.Rotation.from_euler('x', 45, degrees=True)
 
     To create `Rotation` objects use ``from_...`` methods.
     """
@@ -656,7 +651,7 @@ class Rotation():
         return cls._from_scipy_rotation(rot)
 
     @classmethod
-    def identity(cls, num=None, *, shape=None):
+    def identity(cls, num=None, shape=None):
         """
         Get identity rotation(s).
 
@@ -682,7 +677,7 @@ class Rotation():
         return cls._from_scipy_rotation(rot)
 
     @classmethod
-    def random(cls, num=None, rng=None, *, shape=None):
+    def random(cls, num=None, rng=None, shape=None):
         """
         Generate rotations that are uniformly distributed on a sphere.
 
@@ -922,7 +917,7 @@ class Rotation():
 
         return self._rot.as_mrp()
 
-    def as_quat(self, canonical=False, *, scalar_first=False):
+    def as_quat(self, canonical=False, scalar_first=False):
         """Represent as quaternions.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_quat`.

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -3,8 +3,6 @@ from scipy.spatial.transform import Rotation as scRotation
 import numpy as np
 import warnings
 
-import pyfar as pf
-
 if np.__version__ < '2.0.0':
     from numpy import VisibleDeprecationWarning
 else:
@@ -20,8 +18,9 @@ class Rotation():
     """
     Rotation in the three-dimensional space.
 
-    This class is largely based on :py:class:`scipy:scipy.spatial.transform.Rotation`
-    and wraps all functionality that scipy's Rotation class provides.
+    This class is largely based on '
+    ':py:class:`scipy:scipy.spatial.transform.Rotation and wraps all '
+    'functionality that scipy's Rotation class provides.'
     In addition the pyfar Rotation class adds the creation from perpendicular
     view and up vectors through :py:func:`~from_view_up`, and the
     representation as view / up in :py:func:`~as_view_up`.
@@ -90,8 +89,8 @@ class Rotation():
         raise NotImplementedError(
             'Setting an item is disabled for pyfar '
             'Rotations. If you want to modify the Rotation, use an array '
-            'representation like `as_quat()` or `as_matrix()` and create a new '
-            'object.')
+            'representation like `as_quat()` or `as_matrix()` and create a '
+            'new object.')
 
     def __mul__(self, other):
         """
@@ -467,9 +466,9 @@ class Rotation():
         try:
             shape = np.broadcast_shapes(views.shape, ups.shape)
         except ValueError as exc:
-            raise ValueError(
+            raise ValueError from exc(
                 f"shape missmatch: `views` {views.shape} and `ups` {ups.shape}"
-                " cannot be broadcasted to a single shape"
+                " cannot be broadcasted to a single shape",
             )
 
         # check shape

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -40,8 +40,8 @@ class Rotation():
 
     Rotate by 45 degree in x-direction:
 
-    >>> rot_x45 = pf.Rotation.from_euler('x', 45, degrees=True)
-    >>> rot_x45 = pf.Rotation.from_euler('x', 45, degrees=True)
+    >>> rot_x45 = pf.Rotation.from_euler('x', 45/180*np.pi)
+    >>> rot_x45 = pf.Rotation.from_euler('x', 45/180*np.pi)
 
     To create `Rotation` objects use ``from_...`` methods.
     """
@@ -144,7 +144,7 @@ class Rotation():
 
     # from-... methods
     @classmethod
-    def from_davenport(cls, axes, order, angles, degrees=False):
+    def from_davenport(cls, axes, order, angles):
         """
         Initialize from Davenport angles.
 
@@ -181,17 +181,12 @@ class Rotation():
             extrinsic. If it is equal to 'i' or 'intrinsic', sequence
             will be treated as intrinsic.
         angles : float or array_like, shape (..., [1 or 2 or 3])
-            Angles specified in radians (`degrees` is False) or degrees
-            (`degrees` is True).
+            Angles specified in radians.
             Each angle i in the last dimension of `angles` turns around the
             corresponding axis axis[..., i, :]. The resulting rotation has the
             shape np.broadcast_shapes(np.atleast_2d(axes).shape[:-2],
             np.atleast_1d(angles).shape[:-1]) Dimensionless angles are thus
             only valid for a single axis.
-
-        degrees : bool, optional
-            If True, then the given angles are assumed to be in degrees.
-            Default is False.
 
         Returns
         -------
@@ -206,11 +201,11 @@ class Rotation():
                123-132. 10.1007/BF03546304.
         """
         rot = scRotation.from_davenport(
-            axes, order, angles, degrees=degrees)
+            axes, order, angles, degrees=False)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
-    def from_euler(cls, seq, angles, degrees=False):
+    def from_euler(cls, seq, angles):
         """
         Initialize from Euler angles.
 
@@ -233,17 +228,11 @@ class Rotation():
             {'x', 'y', 'z'} for extrinsic rotations. Extrinsic and intrinsic
             rotations cannot be mixed in one function call.
         angles : float or array_like, shape (...,  [1 or 2 or 3])
-            Euler angles specified in radians (`degrees` is False) or degrees
-            (`degrees` is True).
+            Euler angles specified in radians.
             Each character in `seq` defines one axis around which `angles`
             turns. The resulting rotation has the shape
             np.atleast_1d(angles).shape[:-1]. Dimensionless angles are thus
             only valid for single character `seq`.
-
-        degrees : bool, optional
-            If True, then the given angles are assumed to be in degrees.
-            Default is False.
-
         Returns
         -------
         rotations : Rotation
@@ -254,7 +243,7 @@ class Rotation():
         .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
         """
         rot = scRotation.from_euler(
-            seq, angles, degrees=degrees)
+            seq, angles, degrees=False)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
@@ -394,7 +383,7 @@ class Rotation():
         return cls._from_scipy_rotation(rot)
 
     @classmethod
-    def from_rotvec(cls, rotvec, degrees=False):
+    def from_rotvec(cls, rotvec):
         """
         Initialize from rotation vectors.
 
@@ -407,10 +396,7 @@ class Rotation():
         ----------
         rotvec : array_like, shape (..., 3)
             A single vector or an ND array of vectors, where the last dimension
-            contains the rotation vectors.
-        degrees : bool, optional
-            If True, then the given magnitudes are assumed to be in degrees.
-            Default is False.
+            contains the rotation vectors in radians.
 
         Returns
         -------
@@ -421,7 +407,7 @@ class Rotation():
         ----------
         .. [#] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
         """
-        rot = scRotation.from_rotvec(rotvec, degrees)
+        rot = scRotation.from_rotvec(rotvec, degrees=False)
         return cls._from_scipy_rotation(rot)
 
     @classmethod

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -74,7 +74,7 @@ class Rotation():
 
     def __getitem__(self, idx):
         """
-        Get orientation(s) at given indices.
+        Get rotation(s) at given indices.
 
         Parameters
         ----------
@@ -85,7 +85,7 @@ class Rotation():
 
     def __setitem__(self, *args):
         """
-        Assign orientations(s) at given index(es) from object.
+        Assign rotation(s) at given index(es) from object.
 
         This is disabled for `Rotation`.
         """
@@ -96,12 +96,12 @@ class Rotation():
 
     def __mul__(self, other):
         """
-        Multiply Rotation object with another Rotation or a
-        scipy.spatial.transform.Rotation.
+        Multiply Rotation object with another Rotation or
+        :py:class:`scipy:scipy.spatial.transform.Rotation`.
 
         Parameters
         ----------
-        other : Rotation or scipy.spatial.transform.Rotation
+        other : Rotation or :py:class:`scipy:scipy.spatial.transform.Rotation`
             The object to multiply with.
         """
         if isinstance(other, Rotation):
@@ -113,11 +113,11 @@ class Rotation():
     def __rmul__(self, other):
         """
         Right multiplication of Rotation object with another Rotation or a
-        scipy.spatial.transform.Rotation.
+        :py:class:`scipy:scipy.spatial.transform.Rotation`.
 
         Parameters
         ----------
-        other : Rotation or scipy.spatial.transform.Rotation
+        other : Rotation or :py:class:`scipy:scipy.spatial.transform.Rotation`.
             The object to multiply with.
         """
         if isinstance(other, Rotation):
@@ -127,7 +127,7 @@ class Rotation():
             return self
 
     def __pow__(self, n):
-        """Compose orientation with itself n times."""
+        """Compose rotation with itself n times."""
         rot = self._rot.__pow__(n)
         return self._from_scipy_rotation(rot)
 
@@ -195,6 +195,11 @@ class Rotation():
             If True, then the given angles are assumed to be in degrees.
             Default is False.
 
+        Returns
+        -------
+        rotations : Rotation
+            Object containing the rotations.
+
         References
         ----------
         .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
@@ -241,6 +246,11 @@ class Rotation():
             If True, then the given angles are assumed to be in degrees.
             Default is False.
 
+        Returns
+        -------
+        rotations : Rotation
+            Object containing the rotations.
+
         References
         ----------
         .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
@@ -276,6 +286,11 @@ class Rotation():
             incorrect results. If True, normalization steps are skipped, which
             can improve runtime performance.
 
+        Returns
+        -------
+        rotations : Rotation
+            Object containing the rotations.
+
         References
         ----------
         .. [#] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
@@ -307,6 +322,11 @@ class Rotation():
         mrp : array_like, shape (..., 3)
             A single vector or an ND array of vectors, where the last dimension
             contains the rotation parameters.
+
+        Returns
+        -------
+        rotations : Rotation
+            Object containing the rotations.
 
         References
         ----------
@@ -361,6 +381,11 @@ class Rotation():
             Whether the scalar component goes first or last.
             Default is False, i.e. the scalar-last order is assumed.
 
+        Returns
+        -------
+        rotations : Rotation
+            Object containing the rotations.
+
         References
         ----------
         .. [#] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
@@ -389,6 +414,11 @@ class Rotation():
             If True, then the given magnitudes are assumed to be in degrees.
             Default is False.
 
+        Returns
+        -------
+        rotations : Rotation
+            Object containing the rotations.
+
         References
         ----------
         .. [#] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
@@ -398,9 +428,10 @@ class Rotation():
 
     @classmethod
     def from_view_up(cls, views, ups):
-        """Initialize Orientations from a view an up vector.
+        """
+        Initialize Rotation from a view an up vector.
 
-        Orientations are internally stored as quaternions for better spherical
+        Rotations are internally stored as quaternions for better spherical
         linear interpolation (SLERP) and spherical harmonics operations.
         More intuitionally, they can be expressed as view and up vectors
         which cannot be collinear. In this case, they are restricted to be
@@ -421,8 +452,8 @@ class Rotation():
 
         Returns
         -------
-        orientations : Orientations
-            Object containing the orientations represented by quaternions.
+        rotations : Rotation
+            Object containing the rotations.
         """
         # init views and up
         try:
@@ -469,7 +500,7 @@ class Rotation():
     @classmethod
     def align_vectors(cls, a, b, weights=None, return_sensitivity=False):
         r"""
-        Estimate an orientation to optimally align two sets of vectors.
+        Estimate a rotation to optimally align two sets of vectors.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.align_vectors`.
 
@@ -532,7 +563,7 @@ class Rotation():
 
         Returns
         -------
-        orientation : Orientations
+        rotation : Rotation
             Best estimate of the rotation that transforms `b` to `a`.
         rssd : float
             Stands for "root sum squared distance". Square root of the weighted
@@ -597,23 +628,23 @@ class Rotation():
     @classmethod
     def concatenate(cls, rotations):
         """
-        Concatenate a sequence of Orientations objects into a single object.
+        Concatenate a sequence of Rotation objects into a single object.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.concatenate`.
 
         This is useful if you want to, for example, take the mean of a set of
-        orientations and need to pack them into a single object to do so.
+        rotations and need to pack them into a single object to do so.
 
         Parameters
         ----------
-        rotations : sequence of Orientations objects
-            The orientations to concatenate. If a single Orientations object is
+        rotations : sequence of Rotation objects
+            The rotation to concatenate. If a single Rotation object is
             passed in, a copy is returned.
 
         Returns
         -------
-        concatenated : Orientations
-            The concatenated orientations.
+        concatenated : Rotation
+            The concatenated rotations.
         """
         if np.asarray(rotations).shape[0] == 1:
             return rotations[0].copy()
@@ -626,24 +657,24 @@ class Rotation():
     @classmethod
     def identity(cls, num=None, *, shape=None):
         """
-        Get identity orientation(s).
+        Get identity rotation(s).
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.identity`.
 
-        Composition with the identity orientation has no effect.
+        Composition with the identity rotation has no effect.
 
         Parameters
         ----------
         num : int or None, optional
-            Number of identity orientations to generate. If None (default),
+            Number of identity rotations to generate. If None (default),
             then a single rotation is generated.
         shape : int or tuple of ints, optional
-            Shape of identity orientations to generate. If specified, `num`
+            Shape of identity rotations to generate. If specified, `num`
             must be None.
 
         Returns
         -------
-        identity : Orientations
+        identity : Rotation
             The identity rotation.
         """
         rot  = scRotation.identity(num, shape=shape)
@@ -652,32 +683,32 @@ class Rotation():
     @classmethod
     def random(cls, num=None, rng=None, *, shape=None):
         """
-        Generate orientations that are uniformly distributed on a sphere.
+        Generate rotations that are uniformly distributed on a sphere.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.random`.
 
-        Formally, the orientations follow the Haar-uniform distribution over
+        Formally, the rotations follow the Haar-uniform distribution over
         the SO(3) group.
 
         Parameters
         ----------
         num : int or None, optional
-            Number of random orientations to generate. If None (default), then
-            a single orientation is generated.
+            Number of random rotations to generate. If None (default), then
+            a single rotation is generated.
         rng : `numpy.random.Generator`, optional
             Pseudorandom number generator state. When `rng` is None, a new
             `numpy.random.Generator` is created using entropy from the
             operating system. Types other than `numpy.random.Generator` are
             passed to `numpy.random.default_rng` to instantiate a `Generator`.
         shape : tuple of ints, optional
-            Shape of random orientations to generate. If specified, `num` must
+            Shape of random rotations to generate. If specified, `num` must
             be None.
 
         Returns
         -------
-        random_orientation : Orientaions
-            Contains a single orientation if `num` is None. Otherwise contains
-            a stack of `num` orientations.
+        random_rotation : Rotation
+            Contains a single rotation if `num` is None. Otherwise contains
+            a stack of `num` rotation.
 
         Notes
         -----
@@ -710,7 +741,7 @@ class Rotation():
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_davenport`.
 
 
-        Any orientation can be expressed as a composition of 3 elementary
+        Any rotation can be expressed as a composition of 3 elementary
         rotations.
 
         For both Euler angles and Davenport angles, consecutive axes must
@@ -784,7 +815,7 @@ class Rotation():
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.as_euler`.
 
-        Any orientation can be expressed as a composition of 3 elementary
+        Any rotation can be expressed as a composition of 3 elementary
         rotations. Once the axis sequence has been chosen, Euler angles define
         the angle of rotation around each respective axis [#]_.
 
@@ -971,9 +1002,9 @@ class Rotation():
         return self._rot.as_rotvec(degrees)
 
     def as_view_up(self):
-        """Get Orientations as a view, up, and right vector.
+        """Get Rotation as a view, up, and right vector.
 
-        Orientations are internally stored as quaternions for better spherical
+        Rotation are internally stored as quaternions for better spherical
         linear interpolation (SLERP) and spherical harmonics operations.
         More intuitionally, they can be expressed as view and and up of vectors
         which cannot be collinear. In this case are restricted to be
@@ -982,9 +1013,9 @@ class Rotation():
         Returns
         -------
         vector_triple: ndarray, shape (N, 3), normalized vectors
-            - views, see :py:func:`Orientations.from_view_up`
-            - ups, see :py:func:`Orientations.from_view_up`
-            - rights, see :py:func:`Orientations.from_view_up`
+            - views, see :py:func:`Rotation.from_view_up`
+            - ups, see :py:func:`Rotation.from_view_up`
+            - rights, see :py:func:`Rotation.from_view_up`
                 A single vector or a stack of vectors, pointing to the right of
                 the object, constructed as a cross product of ups and rights.
         """
@@ -997,22 +1028,22 @@ class Rotation():
         return views, ups
 
     def copy(self):
-        """Return a deep copy of the Orientations object."""
+        """Return a deep copy of the Rotation object."""
         return self.from_quat(self.as_quat())
 
     def inv(self):
         """
-        Invert this orientation.
+        Invert this rotation.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.inv`.
 
-        Composition of an orientation with its inverse results in an identity
+        Composition of an rotation with its inverse results in an identity
         transformation.
 
         Returns
         -------
-        inverse : Orientations
-            Object containing inverse of the orientations in the current
+        inverse : Rotation
+            Object containing inverse of the rotations in the current
             instance.
         """
         self._rot = self._rot.inv()
@@ -1020,7 +1051,7 @@ class Rotation():
 
     def mean(self, weights=None, axis=None):
         r"""
-        Get the mean of the orientations.
+        Get the mean of the rotations.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.mean`.
 
@@ -1039,18 +1070,18 @@ class Rotation():
         Parameters
         ----------
         weights : array_like shape (..., N), optional
-            Weights describing the relative importance of the orientations. If
+            Weights describing the relative importance of the rotations. If
             None (default), then all values in `weights` are assumed to be
             equal. If given, the shape of `weights` must be broadcastable to
             the rotation shape. Weights must be non-negative.
         axis : None, int, or tuple of ints, optional
             Axis or axes along which the means are computed. The default is to
-            compute the mean of all orientations.
+            compute the mean of all rotations.
 
         Returns
         -------
-        mean : Orientations
-            Single orientation containing the mean of the orientations in the
+        mean : Rotation
+            Single rotation containing the mean of the rotations in the
             current instance.
 
         References
@@ -1062,35 +1093,35 @@ class Rotation():
         return self._from_scipy_rotation(self._rot.mean(weights, axis))
 
     def reduce(self, left=None, right=None, return_indices=False):
-        """Reduce this orientation with the provided orientation groups.
+        """Reduce this rotation with the provided rotation groups.
 
         Wraps :py:meth:`scipy:scipy.spatial.transform.Rotation.reduce`.
 
-        Reduction of a orientation ``p`` is a transformation of the form
+        Reduction of a rotation ``p`` is a transformation of the form
         ``q = l * p * r``, where ``l`` and ``r`` are chosen from `left` and
-        `right` respectively, such that orientation ``q`` has the smallest
+        `right` respectively, such that rotation ``q`` has the smallest
         magnitude.
 
-        If `left` and `right` are orientation groups representing symmetries of
-        two objects rotated by ``p``, then ``q`` is the orientation of the
+        If `left` and `right` are rotation groups representing symmetries of
+        two objects rotated by ``p``, then ``q`` is the rotation of the
         smallest magnitude to align these objects considering their symmetries.
 
         Parameters
         ----------
-        left : Orientation, optional
-            Object containing the left orientation(s). Default value (None)
-            corresponds to the identity orientation.
-        right : Orientation, optional
-            Object containing the right orientation(s). Default value (None)
-            corresponds to the identity orientation.
+        left : Rotation, optional
+            Object containing the left rotation(s). Default value (None)
+            corresponds to the identity rotation.
+        right : Rotation, optional
+            Object containing the right rotation(s). Default value (None)
+            corresponds to the identity rotation.
         return_indices : bool, optional
-            Whether to return the indices of the orientations from `left` and
+            Whether to return the indices of the rotations from `left` and
             `right` used for reduction.
 
         Returns
         -------
-        reduced : Orientations
-            Object containing reduced orientations.
+        reduced : Rotation
+            Object containing reduced rotations.
         left_best, right_best: integer ndarray
             Indices of elements from `left` and `right` used for reduction.
         """
@@ -1105,7 +1136,7 @@ class Rotation():
     def show(self, positions=None,
              show_views=True, show_ups=True, show_rights=True, **kwargs):
         """
-        Visualize Orientations as triples of view (red), up (green) and
+        Visualize Rotation as triples of view (red), up (green) and
         right (blue) vectors in a quiver plot.
 
         Parameters
@@ -1136,7 +1167,7 @@ class Rotation():
         positions = np.atleast_2d(positions).astype(np.float64)
         if positions.shape[0] != self.as_quat().shape[0]:
             raise ValueError("If provided, there must be the same number"
-                             "of positions as orientations.")
+                             "of positions as rotations.")
 
         # Create view, up and right vectors from Rotation object
         views, ups = self.as_view_up()

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -18,9 +18,9 @@ class Rotation():
     """
     Rotation in the three-dimensional space.
 
-    This class is largely based on '
-    ':py:class:`scipy:scipy.spatial.transform.Rotation and wraps all '
-    'functionality that scipy's Rotation class provides.'
+    This class is largely based on
+    :py:class:`scipy:scipy.spatial.transform.Rotation` and wraps all
+    functionality that scipy's Rotation class provides.
     In addition the pyfar Rotation class adds the creation from perpendicular
     view and up vectors through :py:func:`~from_view_up`, and the
     representation as view / up in :py:func:`~as_view_up`.

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -18,7 +18,40 @@ warnings.filterwarnings("error", category=VisibleDeprecationWarning)
 
 class Rotation():
     """
-    Pyfar Rotation class.
+    This class for Rotation in the three-dimensional space,
+    is largely based on :py:class:`scipy:scipy.spatial.transform.Rotation` and
+    wraps all functionality that
+    :py:class:`scipy:scipy.spatial.transform.Rotation` provides.
+    In addition the pyfar Rotation class adds the creation from perpendicular
+    view and up vectors through :py:func:`~from_view_up`, the representation
+    as view / up in :py:func:`~as_view_up` and a convenient plot
+    function :py:func:`~show`.
+
+    An orientation can be visualized with the triple of view, up and right
+    vectors and it is tied to the object's local coordinate system.
+    Alternatively the object's orientation can be illustrated with help of the
+    right hand: Thumb (view), forefinger (up) and middle finger (right).
+
+    Examples
+    --------
+    >>> from pyfar import Orientations
+    >>> views = [[1, 0, 0], [2, 0, 0]]
+    >>> ups = [[0, 1, 0], [0, -2, 0]]
+    >>> orientations = Orientations.from_view_up(views, ups)
+
+    Visualize orientations at certain positions:
+
+    >>> positions = [[0, 0.5, 0], [0, -0.5, 0]]
+    >>> orientations.show(positions)
+
+    Rotate first element of orientations:
+
+    >>> from scipy.spatial.transform import Rotation
+    >>> rot_x45 = Rotation.from_euler('x', 45, degrees=True)
+    >>> orientations[1] = orientations[1] * rot_x45
+    >>> orientations.show(positions)
+
+    To create `Orientations` objects use ``from_...`` methods.
 
 
     .. note::
@@ -268,20 +301,17 @@ class Rotation():
         """"""
         return self._rot.as_rotvec()
 
-    def as_view_up_right(self):
+    def as_view_up(self):
         """"""
         vector_triple = self.as_matrix()
 
-        views, lefts, ups = np.split(vector_triple, 3, axis=-2)
+        if vector_triple.ndim == 2:
+            view = vector_triple[0]
+            up = vector_triple[2]
+        else:
+            view, _, up = np.split(vector_triple, 3, axis=-2)
 
-        # In a standard Cartesian right-handed coordinate system,
-        # standard basis is defined as [x, y, z] = [view, left, up], where
-        # left is the same vector as -rights
-        vector_triple = np.concatenate((views, ups, -lefts), axis=-2)
-
-        if vector_triple.ndim == 3:
-            return np.swapaxes(vector_triple, 0, 1)
-        return vector_triple
+        return view, up
 
     def copy(self):
         """Return a deep copy of the Orientations object."""
@@ -317,7 +347,8 @@ class Rotation():
                              "of positions as orientations.")
 
         # Create view, up and right vectors from Rotation object
-        views, ups, rights = self.as_view_up_right()
+        views, ups = self.as_view_up()
+        rights = np.cross(views, ups)
 
         kwargs.pop('color', None)
 

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -58,7 +58,7 @@ class Rotation():
     def __repr__(self):
         """String representation of Rotation object."""
         repr_string = \
-              f"Pyfar.Rotation with {self.cshape} rotations."
+              f"pyfar.Rotation with {self.cshape} rotations."
         return repr_string
 
     def __iter__(self):

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -3,7 +3,6 @@ from scipy.spatial.transform import Rotation as scRotation
 import numpy as np
 import warnings
 
-import pyfar as pf
 if np.__version__ < '2.0.0':
     from numpy import VisibleDeprecationWarning
 else:
@@ -19,6 +18,7 @@ class Rotation():
     """
     Pyfar Rotation class.
     """
+
     def __init__(self):
         raise RuntimeError("Rotation objects must be created using one of "
                            "the `from_...` methods")
@@ -38,7 +38,7 @@ class Rotation():
         """"""
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_davenport(
-            axes, order, angles, degrees=False)
+            axes, order, angles, degrees=degrees)
 
         return instance
 
@@ -47,7 +47,7 @@ class Rotation():
         """"""
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_euler(
-            seq, angles, degrees=False)
+            seq, angles, degrees=degrees)
 
         return instance
 
@@ -65,7 +65,6 @@ class Rotation():
         instance = cls.__new__(cls)
         instance._rot = scRotation.from_quat(quat)
         return instance
-
 
     @classmethod
     def _from_scipy_rotation(cls, sc_rotation):

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -27,37 +27,30 @@ class Rotation():
     as view / up in :py:func:`~as_view_up` and a convenient plot
     function :py:func:`~show`.
 
-    An orientation can be visualized with the triple of view, up and right
+    A rotation can be visualized with the triple of view, up and right
     vectors and it is tied to the object's local coordinate system.
-    Alternatively the object's orientation can be illustrated with help of the
+    Alternatively the object's rotation can be illustrated with help of the
     right hand: Thumb (view), forefinger (up) and middle finger (right).
 
     Examples
     --------
-    >>> from pyfar import Orientations
+    >>> from pyfar import Rotation
     >>> views = [[1, 0, 0], [2, 0, 0]]
     >>> ups = [[0, 1, 0], [0, -2, 0]]
-    >>> orientations = Orientations.from_view_up(views, ups)
+    >>> rotations = Rotation.from_view_up(views, ups)
 
-    Visualize orientations at certain positions:
+    Visualize rotations at certain positions:
 
     >>> positions = [[0, 0.5, 0], [0, -0.5, 0]]
-    >>> orientations.show(positions)
+    >>> rotations.show(positions)
 
-    Rotate first element of orientations:
+    Rotate by 45 degree in x-direction:
 
-    >>> from scipy.spatial.transform import Rotation
     >>> rot_x45 = Rotation.from_euler('x', 45, degrees=True)
-    >>> orientations[1] = orientations[1] * rot_x45
-    >>> orientations.show(positions)
+    >>> rotations = rotations * rot_x45
+    >>> rotations.show(positions)
 
-    To create `Orientations` objects use ``from_...`` methods.
-
-
-    .. note::
-        Class uses scipy.spatial.transform.Rotation for internal storage of
-        rotations. Methods from scipy.spatial.transform.Rotation are wrapped
-        in pyfar Rotation.
+    To create `Rotation` objects use ``from_...`` methods.
     """
 
     def __init__(self):
@@ -80,11 +73,22 @@ class Rotation():
             yield self._from_scipy_rotation(rot)
 
     def __getitem__(self, idx):
-        """"""
+        """
+        Get orientation(s) at given indices.
+
+        Parameters
+        ----------
+        idx : indexes
+            see NumPy Indexing
+        """
         return self._from_scipy_rotation(self._rot[idx])
 
     def __setitem__(self, *args):
-        """"""
+        """
+        Assign orientations(s) at given index(es) from object.
+
+        This is disabled for `Rotation`.
+        """
         raise NotImplementedError('Setting an item is disabled for pyfar '
         'Rotations. If you want to modify the Rotation, use an array '
         'representation like `as_quat()` or `as_matrix()` and create a new '
@@ -99,7 +103,15 @@ class Rotation():
             return self
 
     def __rmul__(self, other):
-        """"""
+        """
+        Multiply Rotation object with another Rotation or a
+        scipy.spatial.transform.Rotation.
+
+        Parameters
+        ----------
+        other : Rotation or scipy.spatial.transform.Rotation
+            The object to multiply with.
+        """
         if isinstance(other, Rotation):
             other = scRotation.from_quat(other.as_quat())
         if isinstance(other, scRotation):
@@ -118,7 +130,7 @@ class Rotation():
     # properties
     @property
     def n_rotations(self):
-        """"""
+        """Number of rotations."""
         quat = self._rot.as_quat()
         n_rotations = \
             1 if quat.ndim == 1 else quat.shape[0]
@@ -127,39 +139,239 @@ class Rotation():
     # from-... methods
     @classmethod
     def from_davenport(cls, axes, order, angles, degrees=False):
-        """"""
+        """Initialize from Davenport angles.
+
+        Rotations in 3-D can be represented by a sequence of 3
+        rotations around a sequence of axes.
+
+        The three rotations can either be in a global frame of reference
+        (extrinsic) or in a body centred frame of reference (intrinsic), which
+        is attached to, and moves with, the object under rotation [#]_.
+
+        For both Euler angles and Davenport angles, consecutive axes must
+        be are orthogonal (``axis2`` is orthogonal to both ``axis1`` and
+        ``axis3``). For Euler angles, there is an additional relationship
+        between ``axis1`` or ``axis3``, with two possibilities:
+
+            - ``axis1`` and ``axis3`` are also orthogonal (asymmetric sequence)
+            - ``axis1 == axis3`` (symmetric sequence)
+
+        For Davenport angles, this last relationship is relaxed [#]_, and only
+        the consecutive orthogonal axes requirement is maintained.
+
+        Parameters
+        ----------
+        axes : array_like, shape (3,) or (..., [1 or 2 or 3], 3)
+            Axis of rotation, if one dimensional. If two or more dimensional,
+            describes the sequence of axes for rotations, where each
+            axes[..., i, :] is the ith axis. If more than one axis is given,
+            then the second axis must be orthogonal to both the first and third
+            axes.
+        order : string
+            If it is equal to 'e' or 'extrinsic', the sequence will be
+            extrinsic. If it is equal to 'i' or 'intrinsic', sequence
+            will be treated as intrinsic.
+        angles : float or array_like, shape (..., [1 or 2 or 3])
+            Angles specified in radians (`degrees` is False) or degrees
+            (`degrees` is True).
+            Each angle i in the last dimension of `angles` turns around the
+            corresponding axis axis[..., i, :]. The resulting rotation has the
+            shape np.broadcast_shapes(np.atleast_2d(axes).shape[:-2],
+            np.atleast_1d(angles).shape[:-1]) Dimensionless angles are thus
+            only valid for a single axis.
+
+        degrees : bool, optional
+            If True, then the given angles are assumed to be in degrees.
+            Default is False.
+
+        References
+        ----------
+        .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
+        .. [#] Shuster, Malcolm & Markley, Landis. (2003). Generalization of
+               the Euler Angles. Journal of the Astronautical Sciences. 51.
+               123-132. 10.1007/BF03546304.
+        """
         rot = scRotation.from_davenport(
             axes, order, angles, degrees=degrees)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_euler(cls, seq, angles, degrees=False):
-        """"""
+        """
+        Initialize from Euler angles.
+
+        Rotations in 3-D can be represented by a sequence of 3
+        rotations around a sequence of axes. In theory, any three axes spanning
+        the 3-D Euclidean space are enough. In practice, the axes of rotation
+        are chosen to be the basis vectors.
+
+        The three rotations can either be in a global frame of reference
+        (extrinsic) or in a body centred frame of reference (intrinsic), which
+        is attached to, and moves with, the object under rotation [#]_.
+
+        Parameters
+        ----------
+        seq : string
+            Specifies sequence of axes for rotations. Up to 3 characters
+            belonging to the set {'X', 'Y', 'Z'} for intrinsic rotations, or
+            {'x', 'y', 'z'} for extrinsic rotations. Extrinsic and intrinsic
+            rotations cannot be mixed in one function call.
+        angles : float or array_like, shape (...,  [1 or 2 or 3])
+            Euler angles specified in radians (`degrees` is False) or degrees
+            (`degrees` is True).
+            Each character in `seq` defines one axis around which `angles`
+            turns. The resulting rotation has the shape
+            np.atleast_1d(angles).shape[:-1]. Dimensionless angles are thus
+            only valid for single character `seq`.
+
+        degrees : bool, optional
+            If True, then the given angles are assumed to be in degrees.
+            Default is False.
+
+        References
+        ----------
+        .. [#] https://en.wikipedia.org/wiki/Euler_angles#Definition_by_intrinsic_rotations
+        """
         rot = scRotation.from_euler(
             seq, angles, degrees=degrees)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_matrix(cls, matrix):
-        """"""
+        """
+        Initialize from rotation matrix.
+
+        Rotations in 3 dimensions can be represented with 3 x 3 orthogonal
+        matrices [#]_. If the input is not orthogonal, an approximation is
+        created by orthogonalizing the input matrix using the method described
+        in [#]_, and then converting the orthogonal rotation matrices to
+        quaternions using the algorithm described in [#]_. Matrices must be
+        right-handed.
+
+        Parameters
+        ----------
+        matrix : array_like, shape (..., 3, 3)
+            A single matrix or an ND array of matrices, where the last two
+            dimensions contain the rotation matrices.
+        assume_valid : bool, optional
+            Must be False unless users can guarantee the input is a valid
+            rotation matrix, i.e. it is orthogonal, rows and columns have unit
+            norm and the determinant is 1. Setting this to True without
+            ensuring these properties is unsafe and will silently lead to
+            incorrect results. If True, normalization steps are skipped, which
+            can improve runtime performance.
+
+        References
+        ----------
+        .. [#] https://en.wikipedia.org/wiki/Rotation_matrix#In_three_dimensions
+        .. [#] https://en.wikipedia.org/wiki/Orthogonal_Procrustes_problem
+        .. [#] F. Landis Markley, "Unit Quaternion from Rotation Matrix",
+               Journal of guidance, control, and dynamics vol. 31.2, pp.
+               440-442, 2008.
+        """
         rot = scRotation.from_matrix(matrix)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_mrp(cls, mrp):
-        """"""
+        """
+        Initialize from Modified Rodrigues Parameters (MRPs).
+
+        MRPs are a 3 dimensional vector co-directional to the axis of rotation
+        and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
+        the angle of rotation (in radians) [#]_.
+
+        MRPs have a singularity at 360 degrees which can be avoided by ensuring
+        the angle of rotation does not exceed 180 degrees, i.e. switching the
+        direction of the rotation when it is past 180 degrees.
+
+        Parameters
+        ----------
+        mrp : array_like, shape (..., 3)
+            A single vector or an ND array of vectors, where the last dimension
+            contains the rotation parameters.
+
+        References
+        ----------
+        .. [#] Shuster, M. D. "A Survey of Attitude Representations",
+               The Journal of Astronautical Sciences, Vol. 41, No.4, 1993,
+               pp. 475-476
+        """
         rot = scRotation.from_mrp(mrp)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_quat(cls, quat):
-        """"""
+        """
+        Initialize from quaternions.
+
+        Rotations in 3 dimensions can be represented using unit norm
+        quaternions [#]_.
+
+        The 4 components of a quaternion are divided into a scalar part ``w``
+        and a vector part ``(x, y, z)`` and can be expressed from the angle
+        ``theta`` and the axis ``n`` of a rotation as follows::
+
+            w = cos(theta / 2)
+            x = sin(theta / 2) * n_x
+            y = sin(theta / 2) * n_y
+            z = sin(theta / 2) * n_z
+
+        There are 2 conventions to order the components in a quaternion:
+
+        - scalar-first order -- ``(w, x, y, z)``
+        - scalar-last order -- ``(x, y, z, w)``
+
+        The choice is controlled by `scalar_first` argument.
+        By default, it is False and the scalar-last order is assumed.
+
+        Advanced users may be interested in the "double cover" of 3D space by
+        the quaternion representation [#]_. As of version 1.11.0, the
+        following subset (and only this subset) of operations on a `Rotation`
+        ``r`` corresponding to a quaternion ``q`` are guaranteed to preserve
+        the double cover property: ``r = Rotation.from_quat(q)``,
+        ``r.as_quat(canonical=False)``, ``r.inv()``, and composition using the
+        ``*`` operator such as ``r*r``.
+
+        Parameters
+        ----------
+        quat : array_like, shape (..., 4)
+            Each row is a (possibly non-unit norm) quaternion representing an
+            active rotation. Each quaternion will be normalized to unit norm.
+        scalar_first : bool, optional
+            Whether the scalar component goes first or last.
+            Default is False, i.e. the scalar-last order is assumed.
+
+        References
+        ----------
+        .. [#] https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
+        .. [#] Hanson, Andrew J. "Visualizing quaternions."
+            Morgan Kaufmann Publishers Inc., San Francisco, CA. 2006.
+        """
         rot = scRotation.from_quat(quat)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def from_rotvec(cls, rotvec, degrees=False):
-        """"""
+        """
+        Initialize from rotation vectors.
+
+        A rotation vector is a 3 dimensional vector which is co-directional to
+        the axis of rotation and whose norm gives the angle of rotation [#]_.
+
+        Parameters
+        ----------
+        rotvec : array_like, shape (..., 3)
+            A single vector or an ND array of vectors, where the last dimension
+            contains the rotation vectors.
+        degrees : bool, optional
+            If True, then the given magnitudes are assumed to be in degrees.
+            Default is False.
+
+        References
+        ----------
+        .. [#] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
+        """
         rot = scRotation.from_rotvec(rotvec, degrees)
         return cls._from_scipy_rotation(rot)
 
@@ -235,14 +447,149 @@ class Rotation():
     # other class methods
     @classmethod
     def align_vectors(cls, a, b, weights=None, return_sensitivity=False):
-        """"""
+        r"""
+        Estimate an orientation to optimally align two sets of vectors.
+
+        Find a rotation between frames A and B which best aligns a set of
+        vectors `a` and `b` observed in these frames. The following loss
+        function is minimized to solve for the rotation matrix
+        :math:`C`:
+
+        .. math::
+
+            L(C) = \\frac{1}{2} \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{a}_i -
+            C \\mathbf{b}_i \\rVert^2 ,
+
+        where :math:`w_i`'s are the `weights` corresponding to each vector.
+
+        The rotation is estimated with Kabsch algorithm [#]_, and solves what
+        is known as the "pointing problem", or "Wahba's problem" [#]_.
+
+        Note that the length of each vector in this formulation acts as an
+        implicit weight. So for use cases where all vectors need to be
+        weighted equally, you should normalize them to unit length prior to
+        calling this method.
+
+        There are two special cases. The first is if a single vector is given
+        for `a` and `b`, in which the shortest distance rotation that aligns
+        `b` to `a` is returned.
+
+        The second is when one of the weights is infinity. In this case, the
+        shortest distance rotation between the primary infinite weight vectors
+        is calculated as above. Then, the rotation about the aligned primary
+        vectors is calculated such that the secondary vectors are optimally
+        aligned per the above loss function. The result is the composition
+        of these two rotations. The result via this process is the same as the
+        Kabsch algorithm as the corresponding weight approaches infinity in
+        the limit. For a single secondary vector this is known as the
+        "align-constrain" algorithm [#]_.
+
+        For both special cases (single vectors or an infinite weight), the
+        sensitivity matrix does not have physical meaning and an error will be
+        raised if it is requested. For an infinite weight, the primary vectors
+        act as a constraint with perfect alignment, so their contribution to
+        `rssd` will be forced to 0 even if they are of different lengths.
+
+        Parameters
+        ----------
+        a : array_like, shape (3,) or (N, 3)
+            Vector components observed in initial frame A. Each row of `a`
+            denotes a vector.
+        b : array_like, shape (3,) or (N, 3)
+            Vector components observed in another frame B. Each row of `b`
+            denotes a vector.
+        weights : array_like shape (N,), optional
+            Weights describing the relative importance of the vector
+            observations. If None (default), then all values in `weights` are
+            assumed to be 1. One and only one weight may be infinity, and
+            weights must be positive.
+        return_sensitivity : bool, optional
+            Whether to return the sensitivity matrix. See Notes for details.
+            Default is False.
+
+        Returns
+        -------
+        orientation : Orientations
+            Best estimate of the rotation that transforms `b` to `a`.
+        rssd : float
+            Stands for "root sum squared distance". Square root of the weighted
+            sum of the squared distances between the given sets of vectors
+            after alignment. It is equal to ``sqrt(2 * minimum_loss)``, where
+            ``minimum_loss`` is the loss function evaluated for the found
+            optimal rotation.
+            Note that the result will also be weighted by the vectors'
+            magnitudes, so perfectly aligned vector pairs will have nonzero
+            `rssd` if they are not of the same length. This can be avoided by
+            normalizing them to unit length prior to calling this method,
+            though note that doing this will change the resulting rotation.
+        sensitivity_matrix : ndarray, shape (3, 3)
+            Sensitivity matrix of the estimated rotation estimate as explained
+            in Notes. Returned only when `return_sensitivity` is True. Not
+            valid if aligning a single pair of vectors or if there is an
+            infinite weight, in which cases an error will be raised.
+
+        Notes
+        -----
+        The sensitivity matrix gives the sensitivity of the estimated rotation
+        to small perturbations of the vector measurements. Specifically we
+        consider the rotation estimate error as a small rotation vector of
+        frame A. The sensitivity matrix is proportional to the covariance of
+        this rotation vector assuming that the vectors in `a` was measured with
+        errors significantly less than their lengths. To get the true
+        covariance matrix, the returned sensitivity matrix must be multiplied
+        by harmonic mean [#]_ of variance in each observation. Note that
+        `weights` are supposed to be inversely proportional to the observation
+        variances to get consistent results. For example, if all vectors are
+        measured with the same accuracy of 0.01 (`weights` must be all equal),
+        then you should multiple the sensitivity matrix by 0.01**2 to get the
+        covariance.
+
+        Refer to [#]_ for more rigorous discussion of the covariance
+        estimation. See [#]_ for more discussion of the pointing problem and
+        minimal proper pointing.
+
+        This function does not support broadcasting or ND arrays with N > 2.
+
+        References
+        ----------
+        .. [#] https://en.wikipedia.org/wiki/Kabsch_algorithm
+        .. [#] https://en.wikipedia.org/wiki/Wahba%27s_problem
+        .. [#] Magner, Robert,
+                "Extending target tracking capabilities through trajectory and
+                momentum setpoint optimization." Small Satellite Conference,
+                2018.
+        .. [#] https://en.wikipedia.org/wiki/Harmonic_mean
+        .. [#] F. Landis Markley,
+                "Attitude determination using vector observations: a fast
+                optimal matrix algorithm", Journal of Astronautical Sciences,
+                Vol. 41, No.2, 1993, pp. 261-280.
+        .. [#] Bar-Itzhack, Itzhack Y., Daniel Hershkowitz, and Leiba Rodman,
+                "Pointing in Real Euclidean Space", Journal of Guidance,
+                Control, and Dynamics, Vol. 20, No. 5, 1997, pp. 916-922.
+        """
         result = scRotation.align_vectors(a, b, weights, return_sensitivity)
 
         return (cls._from_scipy_rotation(result[0]), *result[1:])
 
     @classmethod
     def concatenate(cls, rotations):
-        """"""
+        """
+        Concatenate a sequence of Orientations objects into a single object.
+
+        This is useful if you want to, for example, take the mean of a set of
+        orientations and need to pack them into a single object to do so.
+
+        Parameters
+        ----------
+        orientations : sequence of Orientations objects
+            The orientations to concatenate. If a single Orientations object is
+            passed in, a copy is returned.
+
+        Returns
+        -------
+        concatenated : Orientations
+            The concatenated orientations.
+        """
         if np.asarray(rotations).shape[0] == 1:
             return rotations[0].copy()
 
@@ -253,13 +600,62 @@ class Rotation():
 
     @classmethod
     def identity(cls, num=None, *, shape=None):
-        """"""
+        """
+        Get identity orientation(s).
+
+        Composition with the identity orientation has no effect.
+
+        Parameters
+        ----------
+        num : int or None, optional
+            Number of identity orientations to generate. If None (default),
+            then a single rotation is generated.
+        shape : int or tuple of ints, optional
+            Shape of identity orientations to generate. If specified, `num`
+            must be None.
+
+        Returns
+        -------
+        identity : Orientations
+            The identity rotation.
+        """
         rot  = scRotation.identity(num, shape=shape)
         return cls._from_scipy_rotation(rot)
 
     @classmethod
     def random(cls, num=None, rng=None, *, shape=None):
-        """"""
+        """
+        Generate orientations that are uniformly distributed on a sphere.
+
+        Formally, the orientations follow the Haar-uniform distribution over
+        the SO(3) group.
+
+        Parameters
+        ----------
+        num : int or None, optional
+            Number of random orientations to generate. If None (default), then
+            a single orientation is generated.
+        rng : `numpy.random.Generator`, optional
+            Pseudorandom number generator state. When `rng` is None, a new
+            `numpy.random.Generator` is created using entropy from the
+            operating system. Types other than `numpy.random.Generator` are
+            passed to `numpy.random.default_rng` to instantiate a `Generator`.
+        shape : tuple of ints, optional
+            Shape of random orientations to generate. If specified, `num` must
+            be None.
+
+        Returns
+        -------
+        random_orientation : Orientaions
+            Contains a single orientation if `num` is None. Otherwise contains
+            a stack of `num` orientations.
+
+        Notes
+        -----
+        This function is optimized for efficiently sampling random rotation
+        matrices in three dimensions. For generating random rotation matrices
+        in higher dimensions, see `scipy.stats.special_ortho_group`.
+        """
         rot = scRotation.random(num, rng, shape=shape)
         return cls._from_scipy_rotation(rot)
 

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -3,6 +3,8 @@ from scipy.spatial.transform import Rotation as scRotation
 import numpy as np
 import warnings
 
+import pyfar as pf
+
 if np.__version__ < '2.0.0':
     from numpy import VisibleDeprecationWarning
 else:
@@ -17,6 +19,12 @@ warnings.filterwarnings("error", category=VisibleDeprecationWarning)
 class Rotation():
     """
     Pyfar Rotation class.
+
+
+    .. note::
+        Class uses scipy.spatial.transform.Rotation for internal storage of
+        rotations. Methods from scipy.spatial.transform.Rotation are wrapped
+        in pyfar Rotation.
     """
 
     def __init__(self):
@@ -25,19 +33,21 @@ class Rotation():
 
     def __repr__(self):
         """String representation of Rotation object."""
-        quat = self._rot.as_quat()
-        num_orientations = \
-            1 if quat.ndim == 1 else quat.shape[0]
-
-        repr = f"Pyfar Rotations object with {num_orientations} rotations."
+        repr = f"Pyfar Rotations object with {self.n_rotations} rotations."
         return repr
 
-    def __getitem__(self, idx):
-        self._rot = self._rot[idx]
-        return self
-
     def __iter__(self):
-        raise NotImplementedError
+        """Iterate over rotations."""
+        if self.as_quat().ndim == 1:
+            raise TypeError("Single rotation is not iterable.")
+
+        for i in range(self.n_rotations):
+            rot = self._rot[i]
+            yield self._from_scipy_rotation(rot)
+
+    def __getitem__(self, idx):
+        """"""
+        return self._from_scipy_rotation(self._rot[idx])
 
     def __setitem__(self, *args):
         raise NotImplementedError('Setting an item is disabled for pyfar '
@@ -69,6 +79,14 @@ class Rotation():
     def __eq__(self, other):
         """Check for equality of two objects."""
         return np.array_equal(self.as_quat(), other.as_quat())
+
+    # properties (!!! WRITE TEST !!!)
+    @property
+    def n_rotations(self):
+        quat = self._rot.as_quat()
+        n_rotations = \
+            1 if quat.ndim == 1 else quat.shape[0]
+        return n_rotations
 
     # from-... methods
     @classmethod
@@ -233,25 +251,67 @@ class Rotation():
         return self._rot.as_matrix()
 
     def as_view_up_right(self):
-        raise NotImplementedError
+        """"""
+        vector_triple = self.as_matrix()
+
+        views, lefts, ups = np.split(vector_triple, 3, axis=-2)
+
+        # In a standard Cartesian right-handed coordinate system,
+        # standard basis is defined as [x, y, z] = [view, left, up], where
+        # left is the same vector as -rights
+        vector_triple = np.concatenate((views, ups, -lefts), axis=-2)
+
+        if vector_triple.ndim == 3:
+            return np.swapaxes(vector_triple, 0, 1)
+        return vector_triple
 
     def copy(self):
         """Return a deep copy of the Orientations object."""
         return self.from_quat(self.as_quat())
 
     def inv(self):
-        raise NotImplementedError
+        """"""
+        self._rot = self._rot.inv()
+        return self
 
     def mean(self, weights=None, axis=None):
         """"""
         return self._from_scipy_rotation(self._rot.mean(weights, axis))
 
     def reduce(self, left=None, right=None, return_indices=False):
-        raise NotImplementedError
+        """"""
+        if return_indices:
+            rot, left_idx, right_idx = \
+                self._rot.reduce(left, right, return_indices)
+            return self._from_scipy_rotation(rot), left_idx, right_idx
+
+        rot = self._rot.reduce(left, right, return_indices)
+        return self._from_scipy_rotation(rot)
 
     def show(self, positions=None,
              show_views=True, show_ups=True, show_rights=True, **kwargs):
-        raise NotImplementedError
+        if positions is None:
+            positions = np.zeros((self.as_quat().shape[0], 3))
+        positions = np.atleast_2d(positions).astype(np.float64)
+        if positions.shape[0] != self.as_quat().shape[0]:
+            raise ValueError("If provided, there must be the same number"
+                             "of positions as orientations.")
+
+        # Create view, up and right vectors from Rotation object
+        views, ups, rights = self.as_view_up_right()
+
+        kwargs.pop('color', None)
+
+        ax = None
+        if show_views:
+            ax = pf.plot.quiver(
+                positions, views, color=pf.plot.color('r'), **kwargs)
+        if show_ups:
+            ax = pf.plot.quiver(
+                positions, ups, ax=ax, color=pf.plot.color('g'), **kwargs)
+        if show_rights:
+            ax = pf.plot.quiver(
+                positions, rights, ax=ax, color=pf.plot.color('b'), **kwargs)
 
     # private instance methods
 

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -512,8 +512,8 @@ class Rotation():
 
         .. math::
 
-            L(C) = \\frac{1}{2} \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{a}_i -
-            C \\mathbf{b}_i \\rVert^2 ,
+            L(C) = \frac{1}{2} \sum_{i = 1}^{n} w_i \lVert \mathbf{a}_i -
+            C \mathbf{b}_i \rVert^2 ,
 
         where :math:`w_i`'s are the `weights` corresponding to each vector.
 
@@ -1060,8 +1060,8 @@ class Rotation():
 
         .. math::
 
-            L(M) = \\sum_{i = 1}^{n} w_i \\lVert \\mathbf{A}_i -
-            \\mathbf{M} \\rVert^2 ,
+            L(M) = \sum_{i = 1}^{n} w_i \lVert \mathbf{A}_i -
+            \mathbf{M} \rVert^2 ,
 
         where :math:`w_i`'s are the `weights` corresponding to each matrix.
 

--- a/pyfar/classes/rotation.py
+++ b/pyfar/classes/rotation.py
@@ -41,7 +41,7 @@ class Rotation():
     Rotate by 45 degree in x-direction:
 
     >>> rot_x45 = pf.Rotation.from_euler('x', 45/180*np.pi)
-    >>> rot_x45 = pf.Rotation.from_euler('x', 45/180*np.pi)
+    >>> rotations = rotations * rot_x45
 
     To create `Rotation` objects use ``from_...`` methods.
     """
@@ -233,6 +233,7 @@ class Rotation():
             turns. The resulting rotation has the shape
             np.atleast_1d(angles).shape[:-1]. Dimensionless angles are thus
             only valid for single character `seq`.
+
         Returns
         -------
         rotations : Rotation
@@ -291,7 +292,7 @@ class Rotation():
 
     @classmethod
     def from_mrp(cls, mrp):
-        """
+        r"""
         Initialize from Modified Rodrigues Parameters (MRPs).
 
         Wraps :py:meth:`scipy.spatial.transform.Rotation.from_mrp`.
@@ -300,9 +301,10 @@ class Rotation():
         and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
         the angle of rotation (in radians) [#]_.
 
-        MRPs have a singularity at 360 degrees which can be avoided by ensuring
-        the angle of rotation does not exceed 180 degrees, i.e. switching the
-        direction of the rotation when it is past 180 degrees.
+        MRPs have a singularity at :math:`2\pi` radians which can be avoided by
+        ensuring the angle of rotation does not exceed :math:`\pi`,
+        i.e. switching the direction of the rotation when it is past
+        :math:`\pi` radians.
 
         Parameters
         ----------
@@ -715,9 +717,8 @@ class Rotation():
         return instance
 
     # Instance methods
-    def as_davenport(self, axes, order, degrees=False,
-                     suppress_warnings=False):
-        """
+    def as_davenport(self, axes, order, suppress_warnings=False):
+        r"""
         Represent as Davenport angles.
 
         Wraps :py:meth:`scipy.spatial.transform.Rotation.as_davenport`.
@@ -760,9 +761,6 @@ class Rotation():
             If it belongs to the set {'e', 'extrinsic'}, the sequence will be
             extrinsic. If it belongs to the set {'i', 'intrinsic'}, sequence
             will be treated as intrinsic.
-        degrees : boolean, optional
-            Returned angles are in degrees if this flag is True, else they are
-            in radians. Default is False.
         suppress_warnings : boolean, optional
             Disable warnings about gimbal lock. Default is False.
 
@@ -772,11 +770,13 @@ class Rotation():
             Shape depends on shape of inputs used to initialize object.
             The returned angles are in the range:
 
-            - First angle belongs to [-180, 180] degrees (both inclusive)
-            - Third angle belongs to [-180, 180] degrees (both inclusive)
-            - Second angle belongs to a set of size 180 degrees,
-              given by: ``[-abs(lambda), 180 - abs(lambda)]``, where ``lambda``
-              is the angle between the first and third axes.
+            - First angle belongs to [:math:`-\pi`, :math:`\pi`] radians (both
+              inclusive)
+            - Third angle belongs to [:math:`-\pi`, :math:`\pi`] radians (both
+              inclusive)
+            - Second angle belongs to a set of size :math:`\pi` radians,
+              given by: ``[-abs(lambda), np.pi - abs(lambda)]``, where
+              ``lambda`` is the angle between the first and third axes.
 
         References
         ----------
@@ -789,10 +789,11 @@ class Rotation():
         .. [#] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
 
-        return self._rot.as_davenport(axes, order, degrees, suppress_warnings)
+        return self._rot.as_davenport(axes, order, degrees=False,
+                                      suppress_warnings=suppress_warnings)
 
-    def as_euler(self, seq, degrees=False, suppress_warnings=False):
-        """
+    def as_euler(self, seq, suppress_warnings=False):
+        r"""
         Represent as Euler angles.
 
         Wraps :py:meth:`scipy.spatial.transform.Rotation.as_euler`.
@@ -819,9 +820,6 @@ class Rotation():
             Adjacent axes cannot be the same.
             Extrinsic and intrinsic rotations cannot be mixed in one function
             call.
-        degrees : boolean, optional
-            Returned angles are in degrees if this flag is True, else they are
-            in radians. Default is False.
         suppress_warnings : boolean, optional
             Disable warnings about gimbal lock. Default is False.
 
@@ -831,12 +829,15 @@ class Rotation():
             Shape depends on shape of inputs used to initialize object.
             The returned angles are in the range:
 
-            - First angle belongs to [-180, 180] degrees (both inclusive)
-            - Third angle belongs to [-180, 180] degrees (both inclusive)
+            - First angle belongs to [:math:`-\pi`, :math:`\pi`] radians (both
+              inclusive)
+            - Third angle belongs to [:math:`-\pi`, :math:`\pi`] radians (both
+              inclusive)
             - Second angle belongs to:
 
-                - [-90, 90] degrees if all axes are different (like xyz)
-                - [0, 180] degrees if first and third axes are the same
+                - [:math:`-\pi/2`, :math:`\pi/2`] radians if all axes are
+                  different (like xyz)
+                - [0, :math:`\pi`] radians if first and third axes are the same
                   (like zxz)
 
         References
@@ -849,7 +850,7 @@ class Rotation():
         .. [#] https://en.wikipedia.org/wiki/Gimbal_lock#In_applied_mathematics
         """
 
-        return self._rot.as_euler(seq, degrees,
+        return self._rot.as_euler(seq, degrees=False,
                                   suppress_warnings=suppress_warnings)
 
     def as_matrix(self):
@@ -874,7 +875,7 @@ class Rotation():
         return self._rot.as_matrix()
 
     def as_mrp(self):
-        """
+        r"""
         Represent as Modified Rodrigues Parameters (MRPs).
 
         Wraps :py:meth:`scipy.spatial.transform.Rotation.as_mrp`.
@@ -883,11 +884,12 @@ class Rotation():
         and whose magnitude is equal to ``tan(theta / 4)``, where ``theta`` is
         the angle of rotation (in radians) [#]_.
 
-        MRPs have a singularity at 360 degrees which can be avoided by ensuring
-        the angle of rotation does not exceed 180 degrees, i.e. switching the
-        direction of the rotation when it is past 180 degrees. This function
-        will always return MRPs corresponding to a rotation of less than or
-        equal to 180 degrees.
+        MRPs have a singularity at :math:`2\pi` radians which can be avoided by
+        ensuring the angle of rotation does not exceed :math:`\pi` radians,
+        i.e. switching the direction of the rotation when it is past
+        :math:`\pi` radians. This function will always return MRPs
+        corresponding to a rotation of less than or equal to :math:`\pi`
+        radians.
 
         Returns
         -------
@@ -956,20 +958,15 @@ class Rotation():
         """
         return self._rot.as_quat(canonical, scalar_first=scalar_first)
 
-    def as_rotvec(self, degrees=False):
+    def as_rotvec(self):
         """
-        Represent as rotation vectors.
+        Represent as rotation vectors in radians.
 
         Wraps :py:meth:`scipy.spatial.transform.Rotation.as_rotvec`.
 
         A rotation vector is a 3 dimensional vector which is co-directional to
         the axis of rotation and whose norm gives the angle of rotation [#]_.
 
-        Parameters
-        ----------
-        degrees : boolean, optional
-            Returned magnitudes are in degrees if this flag is True, else they
-            are in radians. Default is False.
 
         Returns
         -------
@@ -981,7 +978,7 @@ class Rotation():
         .. [#] https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation#Rotation_vector
         """
 
-        return self._rot.as_rotvec(degrees)
+        return self._rot.as_rotvec(degrees=False)
 
     def as_view_up(self):
         """Get Rotation as a view, up, and right vector.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -738,7 +738,7 @@ def ups():
     """Used for the creation of Orientation objects with
     `Orientations.from_view_up`.
     """
-    return [[0, 1, 0], [0, -2, 0], [0, 1, 0]]
+    return [[0, 0, 1], [0, 0, 2], [0, 0, 1]]
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -763,7 +763,6 @@ def rotation(views, ups):
     return Rotation.from_view_up(views, ups)
 
 
-
 @pytest.fixture()
 def coordinates():
     """Coordinates object.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import sofar as sf
 import pyfar as pf
 
 from pyfar import Orientations
+from pyfar import Rotation
 from pyfar import Coordinates
 from pyfar import FrequencyData, TimeData
 import pyfar.classes.filter as fo
@@ -753,6 +754,14 @@ def orientations(views, ups):
     """Orientations object uses fixtures `views` and `ups`.
     """
     return Orientations.from_view_up(views, ups)
+
+
+@pytest.fixture()
+def rotation(views, ups):
+    """Rotation object uses fixtures `views` and `ups`.
+    """
+    return Rotation.from_view_up(views, ups)
+
 
 
 @pytest.fixture()

--- a/tests/test_orientations.py
+++ b/tests/test_orientations.py
@@ -48,6 +48,25 @@ def test_orientations_from_view_up():
         Orientations.from_view_up(views, ups)
 
 
+def test_orientation_consistency_rotation_matrix():
+    """
+    Compare if the view and up vectors produce the same rotation as
+    a zero degree rotation in scipy, i.e., the identity matrix.
+    """
+    orient = Orientations.from_view_up([1, 0, 0], [0, 0, 1])
+    rot = Rotation.from_rotvec([0, 0, 0])
+
+    reference = np.eye(3)
+
+    np.testing.assert_allclose(
+        np.squeeze(orient.as_matrix()),
+        np.squeeze(reference), atol=1e-15)
+
+    np.testing.assert_allclose(
+        np.squeeze(rot.as_matrix()),
+        np.squeeze(reference), atol=1e-15)
+
+
 def test_orientations_from_view_up_invalid():
     """Try to create `Orientations` from invalid view and up vectors."""
     # mal-formed lists
@@ -128,8 +147,8 @@ def test_as_view_up_right(views, ups, orientations):
 
     views_, ups_, _ = orientations.as_view_up_right()
 
-    assert np.array_equal(views_, views), "views are not preserved"
-    assert np.array_equal(ups_, ups), "ups are not preserved"
+    np.testing.assert_allclose(views_, views, atol=1e-15)
+    np.testing.assert_allclose(ups_, ups, atol=1e-15)
 
 
 def test_from_view_as_view_roundtrip():

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -89,12 +89,6 @@ def test_rotation_from_view_up_shape_mismatch():
 
 def test_rotation_from_view_up_invalid():
     """Try to create `Rotation` from invalid view and up vectors."""
-    # mal-formed lists
-    views = [[1, 0, 0], [0, 0]]
-    ups = [[0, 1, 0], [0, 0, 0]]
-    match = 'setting an array element with a sequence.'
-    with pytest.raises(ValueError, match=match):
-        Rotation.from_view_up(views, ups)
     # any of views and ups has zero-length
     views = [[1, 0, 0], [0, 0, 1]]
     ups = [[0, 1, 0], [0, 0, 0]]

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -208,7 +208,7 @@ def test_setitem_error(rotation):
 def test_rotation_rotation(views, ups, rotation):
     """Multiply a pyfar Rotation with a scipy Rotation."""
     # Rotate rotations around x-axis by 45°
-    rot_x45 = R.from_euler('x', 45, degrees=True)
+    rot_x45 = R.from_euler('x', 45/180*np.pi)
     rotation = Rotation.from_view_up(views, ups)
     rotation = rotation * rot_x45
 
@@ -219,7 +219,7 @@ def test___eq___equal(rotation, views, ups):
 
 
 def test___eq___notEqual(rotation, views, ups):
-    rot_z45 = Rotation.from_euler('z', 45, degrees=True)
+    rot_z45 = Rotation.from_euler('z', 45/180*np.pi)
     actual = rot_z45 * Rotation.from_view_up(views, ups)
     assert not rotation == actual
 

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -159,7 +159,9 @@ def test_as_view_up(views, ups, rotation):
 def test_from_view_as_view_roundtrip(v1, v2):
     """Test from_view_up / as_view_up."""
     if np.all(np.abs(v1) == np.abs(v2)):
-        pytest.skip()
+        # skip cases where v1 and v2 extend in the same dimension
+        # view and up must be perpendicular
+        return
 
     views = np.atleast_2d(v1)
     ups = np.atleast_2d(v2)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -3,7 +3,6 @@ import re
 
 import numpy as np
 import numpy.testing as npt
-from scipy.spatial.transform import Rotation
 
 from pyfar import Rotation
 from pyfar import Coordinates
@@ -14,8 +13,11 @@ def test_rotation_init():
     match = \
         "Rotation objects must be created using one of the `from_...` methods"
     with pytest.raises(RuntimeError, match=match):
-        rotation = Rotation()
+        Rotation()
 
+def test_class_properties(rotation):
+    """Test Rotation.n_rotations parameter."""
+    assert rotation.n_rotations == 3
 
 def test_rotation_from_view_up():
     """Create `Rotation` from view and up vectors."""
@@ -181,8 +183,8 @@ def test_setitem_error(rotation):
     """
     Test if setting an item throws an error.
     """
-    match = re.escape('Setting an item is disabled for pyfar Rotations. If you '
-                      'want to modify the Rotation, use an array '
+    match = re.escape('Setting an item is disabled for pyfar Rotations. If '
+                      'you want to modify the Rotation, use an array '
                       'representation like `as_quat()` or `as_matrix()` and '
                       'create a new object.')
     with pytest.raises(NotImplementedError, match=match):
@@ -207,3 +209,98 @@ def test___eq___notEqual(rotation, views, ups):
     rot_z45 = Rotation.from_euler('z', 45, degrees=True)
     actual = rot_z45 * Rotation.from_view_up(views, ups)
     assert not rotation == actual
+
+
+@pytest.mark.parametrize(
+    ("method", "args"),
+    [
+        (
+            Rotation.from_davenport,
+            ([[1, 0, 0], [0, 1, 0], [0, 0, 1]], "extrinsic", [90, 0, 0]),
+        ),
+        (
+            Rotation.from_euler,
+            ('zyx', [90, 45, 30]),
+        ),
+        (
+            Rotation.from_matrix,
+            ([[0, -1, 0], [1, 0, 0], [0, 0, 1]],),
+        ),
+        (
+            Rotation.from_mrp,
+            ([0, 0, 1],),
+        ),
+        (
+            Rotation.from_quat,
+            ([0, 0, 0, 1],),
+        ),
+        (
+            Rotation.from_rotvec,
+            (np.pi/2 * np.array([0, 0, 1]),),
+        ),
+        (
+            Rotation.from_view_up,
+            ([1, 0, 0], [0, 0, 1]),
+        ),
+        (
+            Rotation.align_vectors,
+            ([[0, 1, 0], [0, 1, 1], [0, 1, 1]],
+             [[1, 0, 0], [1, 1.1, 0], [1, 0.9, 0]]),
+        ),
+        (
+            Rotation.random,
+            (),
+        ),
+        (
+            Rotation.identity,
+            (),
+        ),
+        (
+            Rotation.concatenate,
+            ([[Rotation.from_rotvec([0, 0, 1]),
+             Rotation.from_rotvec([0, 0, 2])]]),
+        ),
+    ],
+)
+def test_methods_return_type(method, args):
+    """Test if class-methods return Rotation instance."""
+    obj = method(*args)
+
+    if method.__name__ in ["align_vectors"]:
+        assert isinstance(obj[0], Rotation)
+    else:
+        assert isinstance(obj, Rotation)
+
+
+def test__pow__():
+    """Test wrapped __pow__ method."""
+    rotation = Rotation.from_rotvec([1, 0, 0])
+
+    assert isinstance(rotation, Rotation)
+    npt.assert_allclose((rotation**2).as_rotvec(), [2, 0, 0])
+    npt.assert_allclose((rotation**0.5).as_rotvec(), [0.5, 0, 0])
+
+def tests_instance_methods():
+    """Test wrapped reduce method."""
+    rotation = Rotation.from_rotvec([1, 0, 0])
+
+    obj = rotation.reduce()
+    assert isinstance(obj, Rotation)
+
+    obj = obj.mean()
+    assert isinstance(obj, Rotation)
+
+    obj = obj.inv()
+    assert isinstance(obj, Rotation)
+
+def test__iter__():
+    """Test iteration over Rotation."""
+    rotations = Rotation.from_rotvec([[1, 0, 0], [2, 0, 0]])
+
+    for i, rotation in enumerate(rotations):
+        if i == 0:
+            npt.assert_equal(rotation.as_rotvec(), [1, 0, 0])
+        if i == 1:
+            npt.assert_equal(rotation.as_rotvec(), [2, 0, 0])
+
+        assert isinstance(rotation, Rotation)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -22,33 +22,55 @@ def test_class_properties():
     assert multidim_rot.cshape == (3, 2)
     assert multidim_rot.csize == 6
 
-def test_rotation_from_view_up():
+
+@pytest.mark.parametrize(
+    ("views", "ups"),
+    [
+        # Single view and up vectors
+        (
+            [1, 0, 0],
+            [0, 1, 0],
+        ),
+        # Multiple view and up vectors as lists
+        (
+            [[1, 0, 0], [0, 0, 1]],
+            [[0, 1, 0], [0, 1, 0]],
+        ),
+        # Provided as Coordinates
+        (
+            Coordinates([1, 0], [0, 0], [0, 1]),
+            Coordinates([0, 0], [1, 1], [0, 0]),
+        ),
+        # N:1 shape broadcasting
+        (
+            [[1, 0, 0], [0, 0, 1]],
+            [[0, 1, 0]],
+        ),
+        # 1:N shape broadcasting
+        (
+            [[1, 0, 0]],
+            [[0, 1, 0], [0, 1, 0]],
+        ),
+        # Multi-dimensional shape (..., 3) broadcasting (2, 3)
+        (
+            np.array([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [1, 0, 0]]]),
+            np.array([[[0, 1, 0], [0, 0, 1]], [[1, 0, 0], [0, 1, 0]]]),
+        ),
+        # Multi-dimensional shape (..., 3) broadcasting (2, 1, 3) with (1, 2, 3)
+        (
+            np.array([[[1, 0, 0]], [[0, 0, 1]]]),
+            np.array([[[0, 1, 0], [0, 1, 0]]]),
+        ),
+    ]
+)
+def test_rotation_from_view_up(views, ups):
     """Create `Rotation` from view and up vectors."""
-    # test with single view and up vectors
-    view = [1, 0, 0]
-    up = [0, 1, 0]
-    Rotation.from_view_up(view, up)
-    # test with multiple view and up vectors
-    views = [[1, 0, 0], [0, 0, 1]]
-    ups = [[0, 1, 0], [0, 1, 0]]
     Rotation.from_view_up(views, ups)
-    # provided as numpy ndarrays
-    views = np.atleast_2d(views).astype(np.float64)
-    ups = np.atleast_2d(ups).astype(np.float64)
-    Rotation.from_view_up(views, ups)
-    # provided as Coordinates
-    views = Coordinates(views[:, 0], views[:, 1], views[:, 2])
-    ups = Coordinates(ups[:, 0], ups[:, 1], ups[:, 2])
-    Rotation.from_view_up(views, ups)
-    # number of views to ups N:1
-    views = [[1, 0, 0], [0, 0, 1]]
-    ups = [[0, 1, 0]]
-    Rotation.from_view_up(views, ups)
-    # number of views to ups 1:N
-    views = [[1, 0, 0]]
-    ups = [[0, 1, 0], [0, 1, 0]]
-    Rotation.from_view_up(views, ups)
-    # number of views to ups M:N
+
+
+def test_rotation_from_view_up_shape_mismatch():
+    """Test that incompatible shapes raise ValueError."""
+    # M:N shape mismatch that cannot be broadcast
     views = [[1, 0, 0], [0, 0, 1], [0, 0, 1]]
     ups = [[0, 1, 0], [0, 1, 0]]
     match = 'shape missmatch: `views` '
@@ -88,44 +110,61 @@ def test_as_view_up(views, ups, rotation):
     """
     Output of this method must be the normed input vectors.
     """
-    views = np.atleast_2d(views).astype(np.float64)
+    views = np.atleast_2d(views).astype(float)
+    # normalize view vectors
     views /= np.linalg.norm(views, axis=1)[:, np.newaxis]
-    ups = np.atleast_2d(ups).astype(np.float64)
+
+    ups = np.atleast_2d(ups).astype(float)
+    # normalize up vectors
     ups /= np.linalg.norm(ups, axis=1)[:, np.newaxis]
 
+    # return view_, ups_ from Rotation (normalized in scipy Rotation).
     views_, ups_ = rotation.as_view_up()
 
     np.testing.assert_allclose(views_, views, atol=1e-15)
     np.testing.assert_allclose(ups_, ups, atol=1e-15)
 
 
-def test_from_view_as_view_roundtrip():
-    vec = np.array([
+@pytest.mark.parametrize(
+    "v1",
+    [
         [1, 0, 0],
         [-1, 0, 0],
         [0, 1, 0],
         [0, -1, 0],
         [0, 0, 1],
-        [0, 0, -1]])
+        [0, 0, -1],
+    ],
+)
+@pytest.mark.parametrize(
+    "v2",
+    [
+        [1, 0, 0],
+        [-1, 0, 0],
+        [0, 1, 0],
+        [0, -1, 0],
+        [0, 0, 1],
+        [0, 0, -1],
+    ],
+)
+def test_from_view_as_view_roundtrip(v1, v2):
+    "Test from_view_up / as_view_up."
+    if np.all(np.abs(v1) == np.abs(v2)):
+        pytest.skip()
 
-    for v1 in range(len(vec)):
-        for v2 in range(len(vec)):
-            if np.all(np.abs(vec[v1]) == np.abs(vec[v2])):
-                continue
-            print(f"Testing combination ({v1}, {v2})")
-            views = np.atleast_2d(vec[v1])
-            ups = np.atleast_2d(vec[v2])
+    views = np.atleast_2d(v1)
+    ups = np.atleast_2d(v2)
 
-            rotation = Rotation.from_view_up(views, ups)
-            views_, ups_ = rotation.as_view_up()
-            # indexed
-            views_0, ups_0 = rotation[0].as_view_up()
+    rotation = Rotation.from_view_up(views, ups)
+    views_, ups_ = rotation.as_view_up()
+    # indexed
+    views_0, ups_0 = rotation[0].as_view_up()
 
-            npt.assert_allclose(views, views_, atol=1e-15)
-            npt.assert_allclose(ups, ups_, atol=1e-15)
-            # indexed
-            npt.assert_allclose(views[0], views_0, atol=1e-15)
-            npt.assert_allclose(ups[0], ups_0, atol=1e-15)
+    npt.assert_allclose(views, views_, atol=1e-15)
+    npt.assert_allclose(ups, ups_, atol=1e-15)
+    # indexed
+    npt.assert_allclose(views[0], views_0, atol=1e-15)
+    npt.assert_allclose(ups[0], ups_0, atol=1e-15)
 
 
 def test_rotation_indexing(rotation):

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -84,8 +84,6 @@ def test_rotation_show(positions, rotation):
     Visualize rotation via `Rotation.show()`
     with and without `positions`.
     """
-    # default orientation
-    Rotation().show()
     # single vectors no position
     view = [1, 0, 0]
     up = [0, 1, 0]
@@ -131,8 +129,8 @@ def test_as_view_up_right(views, ups, rotation):
 
     views_, ups_, _ = rotation.as_view_up_right()
 
-    assert np.array_equal(views_, views), "views are not preserved"
-    assert np.array_equal(ups_, ups), "ups are not preserved"
+    np.testing.assert_allclose(views_, views, atol=1e-15)
+    np.testing.assert_allclose(ups_, ups, atol=1e-15)
 
 
 def test_from_view_as_view_roundtrip():
@@ -193,16 +191,8 @@ def test_setitem_error(rotation):
 
 def test_rotation_rotation(views, ups, positions, rotation):
     """Multiply a pyfar Roation with a scipy Rotation and visualize them."""
-    rotation.show(positions)
-    # Rotate first Orientation around z-axis by 45°
-    rot_z45 = Rotation.from_euler('z', 45, degrees=True)
-    rotation[0] = rotation[0] * rot_z45
-    rotation.show(positions)
-    # Rotate second Orientation around x-axis by 45°
+    # Rotate rotations around x-axis by 45°
     rot_x45 = Rotation.from_euler('x', 45, degrees=True)
-    rotation[1] = rotation[1] * rot_x45
-    rotation.show(positions)
-    # Rotate both Rotation at once
     rotation = Rotation.from_view_up(views, ups)
     rotation = rotation * rot_x45
     rotation.show(positions)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -206,6 +206,18 @@ def test_rotation_rotation(views, ups, rotation):
     rotation = Rotation.from_view_up(views, ups)
     rotation = rotation * rot_x45
 
+def test_multiplication():
+    """Test multiplication results."""
+    rot_angle_z = np.pi/2
+    rot_vec = [0, 0, rot_angle_z]
+
+    rot = Rotation.from_rotvec(rot_vec)
+    result = rot * rot
+
+    ref = rot.as_matrix() @ rot.as_matrix()
+
+    np.testing.assert_allclose(ref, result.as_matrix(), atol=1e-10)
+
 
 def test___eq___equal(rotation, views, ups):
     actual = Rotation.from_view_up(views, ups)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -89,11 +89,11 @@ def test_rotation_show(positions, rotation):
     # single vectors no position
     view = [1, 0, 0]
     up = [0, 1, 0]
-    orientation_single = Rotation.from_view_up(view, up)
-    orientation_single.show()
+    rotation_single = Rotation.from_view_up(view, up)
+    rotation_single.show()
     # with position
     position = Coordinates(0, 1, 0)
-    orientation_single.show(position)
+    rotation_single.show(position)
 
     # multiple vectors no position
     rotation.show()

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -6,6 +6,7 @@ import numpy.testing as npt
 
 from pyfar import Rotation
 from pyfar import Coordinates
+from scipy.spatial.transform import Rotation as R
 
 
 def test_rotation_init():
@@ -78,7 +79,7 @@ def test_rotation_from_view_up(views, ups, expected_cshape):
 
 def test_rotation_from_view_up_shape_mismatch():
     """Test that incompatible shapes raise ValueError."""
-    # M:N shape mismatch that cannot be broadcast
+    # M:N shape mismatch that cannot be broadcasted.
     views = [[1, 0, 0], [0, 0, 1], [0, 0, 1]]
     ups = [[0, 1, 0], [0, 1, 0]]
     match = 'shape missmatch: `views` '
@@ -100,7 +101,7 @@ def test_rotation_from_view_up_invalid():
     match = 'View and Up Vectors must have a length.'
     with pytest.raises(ValueError, match=match):
         Rotation.from_view_up(views, ups)
-    # views' and ups' shape must be (N, 3) or (3,)
+    # views' and ups' shape must be (..., 3) or (3,)
     views = [0, 1]
     ups = [0, 1]
     match = 'Expected `views` and `ups` to have shape'
@@ -203,9 +204,9 @@ def test_setitem_error(rotation):
 
 
 def test_rotation_rotation(views, ups, rotation):
-    """Multiply a pyfar Roation with a scipy Rotation and visualize them."""
+    """Multiply a pyfar Rotation with a scipy Rotation."""
     # Rotate rotations around x-axis by 45°
-    rot_x45 = Rotation.from_euler('x', 45, degrees=True)
+    rot_x45 = R.from_euler('x', 45, degrees=True)
     rotation = Rotation.from_view_up(views, ups)
     rotation = rotation * rot_x45
 

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -120,7 +120,7 @@ def test_rotation_show(positions, rotation):
         rotation.show(positions)
 
 
-def test_as_view_up_right(views, ups, rotation):
+def test_as_view_up(views, ups, rotation):
     """
     Output of this method must be the normed input vectors.
     """
@@ -129,7 +129,7 @@ def test_as_view_up_right(views, ups, rotation):
     ups = np.atleast_2d(ups).astype(np.float64)
     ups /= np.linalg.norm(ups, axis=1)[:, np.newaxis]
 
-    views_, ups_, _ = rotation.as_view_up_right()
+    views_, ups_ = rotation.as_view_up()
 
     np.testing.assert_allclose(views_, views, atol=1e-15)
     np.testing.assert_allclose(ups_, ups, atol=1e-15)
@@ -153,9 +153,9 @@ def test_from_view_as_view_roundtrip():
             ups = np.atleast_2d(vec[v2])
 
             rotation = Rotation.from_view_up(views, ups)
-            views_, ups_, _ = rotation.as_view_up_right()
+            views_, ups_ = rotation.as_view_up()
             # indexed
-            views_0, ups_0, _ = rotation[0].as_view_up_right()
+            views_0, ups_0 = rotation[0].as_view_up()
 
             npt.assert_allclose(views, views_, atol=1e-15)
             npt.assert_allclose(ups, ups_, atol=1e-15)

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,0 +1,206 @@
+import pytest
+
+import numpy as np
+import numpy.testing as npt
+from scipy.spatial.transform import Rotation
+
+from pyfar import Rotation
+from pyfar import Coordinates
+
+
+def test_rotation_init():
+    """Init `Rotation` without optional parameters."""
+    match = \
+        "Rotation objects must be created using one of the `from_...` methods"
+    with pytest.raises(RuntimeError, match=match):
+        rotation = Rotation()
+
+
+def test_rotation_from_view_up():
+    """Create `Rotation` from view and up vectors."""
+    # test with single view and up vectors
+    view = [1, 0, 0]
+    up = [0, 1, 0]
+    Rotation.from_view_up(view, up)
+    # test with multiple view and up vectors
+    views = [[1, 0, 0], [0, 0, 1]]
+    ups = [[0, 1, 0], [0, 1, 0]]
+    Rotation.from_view_up(views, ups)
+    # provided as numpy ndarrays
+    views = np.atleast_2d(views).astype(np.float64)
+    ups = np.atleast_2d(ups).astype(np.float64)
+    Rotation.from_view_up(views, ups)
+    # provided as Coordinates
+    views = Coordinates(views[:, 0], views[:, 1], views[:, 2])
+    ups = Coordinates(ups[:, 0], ups[:, 1], ups[:, 2])
+    Rotation.from_view_up(views, ups)
+    # number of views to ups N:1
+    views = [[1, 0, 0], [0, 0, 1]]
+    ups = [[0, 1, 0]]
+    Rotation.from_view_up(views, ups)
+    # number of views to ups 1:N
+    views = [[1, 0, 0]]
+    ups = [[0, 1, 0], [0, 1, 0]]
+    Rotation.from_view_up(views, ups)
+    # number of views to ups M:N
+    views = [[1, 0, 0], [0, 0, 1], [0, 0, 1]]
+    ups = [[0, 1, 0], [0, 1, 0]]
+    match = 'Expected 1:1, 1:N or N:1 `views` and `ups` not M:N, got '
+    with pytest.raises(ValueError, match=match):
+        Rotation.from_view_up(views, ups)
+
+
+def test_rotation_from_view_up_invalid():
+    """Try to create `Rotation` from invalid view and up vectors."""
+    # mal-formed lists
+    views = [[1, 0, 0], [0, 0]]
+    ups = [[0, 1, 0], [0, 0, 0]]
+    match = 'setting an array element with a sequence.'
+    with pytest.raises(ValueError, match=match):
+        Rotation.from_view_up(views, ups)
+    # any of views and ups has zero-length
+    views = [[1, 0, 0], [0, 0, 1]]
+    ups = [[0, 1, 0], [0, 0, 0]]
+    match = 'View and Up Vectors must have a length.'
+    with pytest.raises(ValueError, match=match):
+        Rotation.from_view_up(views, ups)
+    # views' and ups' shape must be (N, 3) or (3,)
+    views = [0, 1]
+    ups = [0, 1]
+    match = 'Expected `views` and `ups` to have shape'
+    with pytest.raises(ValueError, match=match):
+        Rotation.from_view_up(views, ups)
+    # view and up vectors must be orthogonal
+    views = [1.0, 0.5, 0.1]
+    ups = [0, 0, 1]
+    match = 'View and Up vectors must be perpendicular'
+    with pytest.raises(ValueError, match=match):
+        Rotation.from_view_up(views, ups)
+
+
+def test_rotation_show(positions, rotation):
+    """
+    Visualize rotation via `Rotation.show()`
+    with and without `positions`.
+    """
+    # default orientation
+    Rotation().show()
+    # single vectors no position
+    view = [1, 0, 0]
+    up = [0, 1, 0]
+    orientation_single = Rotation.from_view_up(view, up)
+    orientation_single.show()
+    # with position
+    position = Coordinates(0, 1, 0)
+    orientation_single.show(position)
+
+    # multiple vectors no position
+    rotation.show()
+    # with matching number of positions
+    rotation.show(positions)
+
+    # select what to show
+    rotation.show(show_views=False)
+    rotation.show(show_ups=False)
+    rotation.show(show_rights=False)
+    rotation.show(show_views=False, show_ups=False)
+    rotation.show(show_views=False, show_rights=False)
+    rotation.show(show_ups=False, show_rights=False)
+    rotation.show(positions=positions, show_views=False, show_ups=False)
+
+    # with positions provided as Coordinates
+    positions = np.asarray(positions)
+    positions = Coordinates(positions[:, 0], positions[:, 1], positions[:, 2])
+    rotation.show(positions)
+    # with non-matching positions
+    positions = Coordinates(0, 1, 0)
+    match = 'If provided, there must be the same number'
+    with pytest.raises(ValueError, match=match):
+        rotation.show(positions)
+
+
+def test_as_view_up_right(views, ups, rotation):
+    """
+    Output of this method must be the normed input vectors.
+    """
+    views = np.atleast_2d(views).astype(np.float64)
+    views /= np.linalg.norm(views, axis=1)[:, np.newaxis]
+    ups = np.atleast_2d(ups).astype(np.float64)
+    ups /= np.linalg.norm(ups, axis=1)[:, np.newaxis]
+
+    views_, ups_, _ = rotation.as_view_up_right()
+
+    assert np.array_equal(views_, views), "views are not preserved"
+    assert np.array_equal(ups_, ups), "ups are not preserved"
+
+
+def test_from_view_as_view_roundtrip():
+    vec = np.array([
+        [1, 0, 0],
+        [-1, 0, 0],
+        [0, 1, 0],
+        [0, -1, 0],
+        [0, 0, 1],
+        [0, 0, -1]])
+
+    for v1 in range(len(vec)):
+        for v2 in range(len(vec)):
+            if np.all(np.abs(vec[v1]) == np.abs(vec[v2])):
+                continue
+            print(f"Testing combination ({v1}, {v2})")
+            views = np.atleast_2d(vec[v1])
+            ups = np.atleast_2d(vec[v2])
+
+            rotation = Rotation.from_view_up(views, ups)
+            views_, ups_, _ = rotation.as_view_up_right()
+            # indexed
+            views_0, ups_0, _ = rotation[0].as_view_up_right()
+
+            npt.assert_allclose(views, views_, atol=1e-15)
+            npt.assert_allclose(ups, ups_, atol=1e-15)
+            # indexed
+            npt.assert_allclose(views[0], views_0, atol=1e-15)
+            npt.assert_allclose(ups[0], ups_0, atol=1e-15)
+
+
+def test_rotation_indexing(rotation):
+    """
+    Apply index-operator `[]` on `Rotation` to get a single quaternion.
+    """
+    rotation[0]
+    rotation[1]
+    with pytest.raises(IndexError):
+        rotation[42]
+
+    quats = rotation.as_quat()
+    assert np.array_equal(quats[0], rotation[0].as_quat()), (
+        "Indexed rotation are not the same")
+    assert np.array_equal(quats[1], rotation[1].as_quat()), (
+        "Indexed rotation are not the same")
+
+def test_rotation_rotation(views, ups, positions, rotation):
+    """Multiply a pyfar Roation with a scipy Rotation and visualize them."""
+    rotation.show(positions)
+    # Rotate first Orientation around z-axis by 45°
+    rot_z45 = Rotation.from_euler('z', 45, degrees=True)
+    rotation[0] = rotation[0] * rot_z45
+    rotation.show(positions)
+    # Rotate second Orientation around x-axis by 45°
+    rot_x45 = Rotation.from_euler('x', 45, degrees=True)
+    rotation[1] = rotation[1] * rot_x45
+    rotation.show(positions)
+    # Rotate both Rotation at once
+    rotation = Rotation.from_view_up(views, ups)
+    rotation = rotation * rot_x45
+    rotation.show(positions)
+
+
+def test___eq___equal(rotation, views, ups):
+    actual = Rotation.from_view_up(views, ups)
+    assert rotation == actual
+
+
+def test___eq___notEqual(rotation, views, ups):
+    rot_z45 = Rotation.from_euler('z', 45, degrees=True)
+    actual = rot_z45 * Rotation.from_view_up(views, ups)
+    assert not rotation == actual

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -1,4 +1,5 @@
 import pytest
+import re
 
 import numpy as np
 import numpy.testing as npt
@@ -177,6 +178,18 @@ def test_rotation_indexing(rotation):
         "Indexed rotation are not the same")
     assert np.array_equal(quats[1], rotation[1].as_quat()), (
         "Indexed rotation are not the same")
+
+def test_setitem_error(rotation):
+    """
+    Test if setting an item throws an error.
+    """
+    match = re.escape('Setting an item is disabled for pyfar Rotations. If you '
+                      'want to modify the Rotation, use an array '
+                      'representation like `as_quat()` or `as_matrix()` and '
+                      'create a new object.')
+    with pytest.raises(NotImplementedError, match=match):
+        rotation[0] = [[0.5, 1, 0]]
+
 
 def test_rotation_rotation(views, ups, positions, rotation):
     """Multiply a pyfar Roation with a scipy Rotation and visualize them."""

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -15,9 +15,12 @@ def test_rotation_init():
     with pytest.raises(RuntimeError, match=match):
         Rotation()
 
-def test_class_properties(rotation):
+def test_class_properties():
     """Test Rotation.n_rotations parameter."""
-    assert rotation.n_rotations == 3
+    multidim_angles = np.zeros((3, 2, 3))
+    multidim_rot = Rotation.from_euler('XYZ', multidim_angles)
+    assert multidim_rot.cshape == (3, 2)
+    assert multidim_rot.csize == 6
 
 def test_rotation_from_view_up():
     """Create `Rotation` from view and up vectors."""
@@ -48,7 +51,7 @@ def test_rotation_from_view_up():
     # number of views to ups M:N
     views = [[1, 0, 0], [0, 0, 1], [0, 0, 1]]
     ups = [[0, 1, 0], [0, 1, 0]]
-    match = 'Expected 1:1, 1:N or N:1 `views` and `ups` not M:N, got '
+    match = 'shape missmatch: `views` '
     with pytest.raises(ValueError, match=match):
         Rotation.from_view_up(views, ups)
 
@@ -79,45 +82,6 @@ def test_rotation_from_view_up_invalid():
     match = 'View and Up vectors must be perpendicular'
     with pytest.raises(ValueError, match=match):
         Rotation.from_view_up(views, ups)
-
-
-def test_rotation_show(positions, rotation):
-    """
-    Visualize rotation via `Rotation.show()`
-    with and without `positions`.
-    """
-    # single vectors no position
-    view = [1, 0, 0]
-    up = [0, 1, 0]
-    rotation_single = Rotation.from_view_up(view, up)
-    rotation_single.show()
-    # with position
-    position = Coordinates(0, 1, 0)
-    rotation_single.show(position)
-
-    # multiple vectors no position
-    rotation.show()
-    # with matching number of positions
-    rotation.show(positions)
-
-    # select what to show
-    rotation.show(show_views=False)
-    rotation.show(show_ups=False)
-    rotation.show(show_rights=False)
-    rotation.show(show_views=False, show_ups=False)
-    rotation.show(show_views=False, show_rights=False)
-    rotation.show(show_ups=False, show_rights=False)
-    rotation.show(positions=positions, show_views=False, show_ups=False)
-
-    # with positions provided as Coordinates
-    positions = np.asarray(positions)
-    positions = Coordinates(positions[:, 0], positions[:, 1], positions[:, 2])
-    rotation.show(positions)
-    # with non-matching positions
-    positions = Coordinates(0, 1, 0)
-    match = 'If provided, there must be the same number'
-    with pytest.raises(ValueError, match=match):
-        rotation.show(positions)
 
 
 def test_as_view_up(views, ups, rotation):
@@ -197,7 +161,6 @@ def test_rotation_rotation(views, ups, positions, rotation):
     rot_x45 = Rotation.from_euler('x', 45, degrees=True)
     rotation = Rotation.from_view_up(views, ups)
     rotation = rotation * rot_x45
-    rotation.show(positions)
 
 
 def test___eq___equal(rotation, views, ups):

--- a/tests/test_rotation.py
+++ b/tests/test_rotation.py
@@ -16,7 +16,7 @@ def test_rotation_init():
         Rotation()
 
 def test_class_properties():
-    """Test Rotation.n_rotations parameter."""
+    """Test properties."""
     multidim_angles = np.zeros((3, 2, 3))
     multidim_rot = Rotation.from_euler('XYZ', multidim_angles)
     assert multidim_rot.cshape == (3, 2)
@@ -24,48 +24,56 @@ def test_class_properties():
 
 
 @pytest.mark.parametrize(
-    ("views", "ups"),
+    ("views", "ups", "expected_cshape"),
     [
         # Single view and up vectors
         (
             [1, 0, 0],
             [0, 1, 0],
+            (1,),
         ),
         # Multiple view and up vectors as lists
         (
             [[1, 0, 0], [0, 0, 1]],
             [[0, 1, 0], [0, 1, 0]],
+            (2,),
         ),
         # Provided as Coordinates
         (
             Coordinates([1, 0], [0, 0], [0, 1]),
             Coordinates([0, 0], [1, 1], [0, 0]),
+            (2,),
         ),
         # N:1 shape broadcasting
         (
             [[1, 0, 0], [0, 0, 1]],
             [[0, 1, 0]],
+            (2,),
         ),
         # 1:N shape broadcasting
         (
             [[1, 0, 0]],
             [[0, 1, 0], [0, 1, 0]],
+            (2,),
         ),
         # Multi-dimensional shape (..., 3) broadcasting (2, 3)
         (
             np.array([[[1, 0, 0], [0, 1, 0]], [[0, 0, 1], [1, 0, 0]]]),
             np.array([[[0, 1, 0], [0, 0, 1]], [[1, 0, 0], [0, 1, 0]]]),
+            (2, 2),
         ),
-        # Multi-dimensional shape (..., 3) broadcasting (2, 1, 3) with (1, 2, 3)
+        # Multi-dimensional shape (..., 3) broadcasting (2, 1, 3) & (1, 2, 3)
         (
             np.array([[[1, 0, 0]], [[0, 0, 1]]]),
             np.array([[[0, 1, 0], [0, 1, 0]]]),
+            (2, 2),
         ),
-    ]
+    ],
 )
-def test_rotation_from_view_up(views, ups):
+def test_rotation_from_view_up(views, ups, expected_cshape):
     """Create `Rotation` from view and up vectors."""
-    Rotation.from_view_up(views, ups)
+    rotation = Rotation.from_view_up(views, ups)
+    assert rotation.cshape == expected_cshape
 
 
 def test_rotation_from_view_up_shape_mismatch():
@@ -148,7 +156,7 @@ def test_as_view_up(views, ups, rotation):
     ],
 )
 def test_from_view_as_view_roundtrip(v1, v2):
-    "Test from_view_up / as_view_up."
+    """Test from_view_up / as_view_up."""
     if np.all(np.abs(v1) == np.abs(v2)):
         pytest.skip()
 
@@ -194,7 +202,7 @@ def test_setitem_error(rotation):
         rotation[0] = [[0.5, 1, 0]]
 
 
-def test_rotation_rotation(views, ups, positions, rotation):
+def test_rotation_rotation(views, ups, rotation):
     """Multiply a pyfar Roation with a scipy Rotation and visualize them."""
     # Rotate rotations around x-axis by 45°
     rot_x45 = Rotation.from_euler('x', 45, degrees=True)


### PR DESCRIPTION
### Note

I cherry picked #848 to fix the tests

---

Pyfar `Rotation` class to replace `Orientations` taking the inheritance problem from #886 into account and including #639 and #600 (remove show())

Idea:
- No inheritance from scipy
- Instantiate objects only via `from_...` classmethods wrapping scipy `Rotation.from_...`
- Store scipy Rotation in class

Changes to previous `Orientations`:
- remove `as_view_up_right` in favor of `as_view_up`
- add `cshape, csize` property
- Objects can only be instantiated via `from_...` classmethod. `Rotation()` throws an error
- `setitem` is disabled and throws an error
- Remove possibility of using degrees to be consistent with `Coordinates` 
- [x] remove `show() `method
- [x] fix footnotes