### PR TITLE
[FEAT] Add RIR with noise tail

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,12 +19,12 @@ Added
 - `pyfar.dsp.filter.frequency_weighting_filter` for filtering signals with the A and C-weighting curve standardised in IEC 61672-1 (PR #811, #852)
 - `pyfar.dsp.filter.check_fractional_octave_band_filter_tolerance` to check if a (fractional) octave filter bank meets the class I or II tolerances defined in IEC 61260-1 (PR #829)
 - All plots showing the magnitude response now have the `mode` parameter to specify if the absolute (default), real, or imaginary value of the spectrum is shown. This can also be toggled using the shortcut 'shift+m' in interactive plots (PR #817)
+- `pyfar.signals.files.binaural_room_impulse_response` can now return the room impulse response with noise tail (PR #906)
 - Abstract `_LTISystem` base class to better structure inheritance of the pyfar Filter classes (PR #798)
 
 Changed
 ^^^^^^^
 - The `pyfar.FIRFilter` class now uses `scipy.signal.oaconvolve`, instead of `scipy.signal.lfilter` for filtering to speed up the computation for long filters (PR #753)
-
 - Improve check of input data in `pyfar.constants.fractional_octave_frequencies_exact` and tests thereof (PR #876)
 - Improved testing for the parameter `side` used in 2D plots in the module `pyfar.plot` (PR #820)
 - Improved documentation to remove clutter from the secondary sidebar (PR #788)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -19,7 +19,7 @@ Added
 - `pyfar.dsp.filter.frequency_weighting_filter` for filtering signals with the A and C-weighting curve standardised in IEC 61672-1 (PR #811, #852)
 - `pyfar.dsp.filter.check_fractional_octave_band_filter_tolerance` to check if a (fractional) octave filter bank meets the class I or II tolerances defined in IEC 61260-1 (PR #829)
 - All plots showing the magnitude response now have the `mode` parameter to specify if the absolute (default), real, or imaginary value of the spectrum is shown. This can also be toggled using the shortcut 'shift+m' in interactive plots (PR #817)
-- `pyfar.signals.files.binaural_room_impulse_response` can now return the room impulse response with noise tail (PR #906)
+- `pyfar.signals.files.room_impulse_response` can now return the room impulse response with noise tail (PR #906)
 - Abstract `_LTISystem` base class to better structure inheritance of the pyfar Filter classes (PR #798)
 
 Changed

--- a/pyfar/signals/files.py
+++ b/pyfar/signals/files.py
@@ -453,7 +453,7 @@ def head_related_impulse_responses(
     return hrirs, sources
 
 
-def room_impulse_response(sampling_rate=48000):
+def room_impulse_response(sampling_rate=48000, noise_tail=False):
     """
     Get a room impulse response (RIR).
 
@@ -473,6 +473,12 @@ def room_impulse_response(sampling_rate=48000):
         The sampling rate of the RIR in Hz. The default of ``48000`` uses the
         RIR as it is, any other value uses :py:func:`~pyfar.dsp.resample`
         for resampling to the desired sampling rate.
+    noise_tail, bool, optional
+        If ``False``, the room impulse response is truncated at 1.75 s shortly
+        after its energy falls below that of the noise tail. If ``True``, the
+        2.5 s room impulse response including the noise tail is returned as
+        required for estimating room acoustic parameters.
+        The default is ``False``.
 
     Returns
     -------
@@ -490,7 +496,10 @@ def room_impulse_response(sampling_rate=48000):
     """
 
     # download files if requires
-    files = _load_files('room_impulse_response')
+    if noise_tail:
+        files = _load_files('room_impulse_response_with_noise')
+    else:
+        files = _load_files('room_impulse_response')
 
     # load rir
     rir = pf.io.read_audio(os.path.join(file_dir, files[0]))
@@ -519,7 +528,8 @@ def _load_files(data):
 
     # set the filenames
     if data in ['binaural_room_impulse_response', 'castanets', 'drums',
-                'guitar', 'room_impulse_response']:
+                'guitar', 'room_impulse_response',
+                'room_impulse_response_with_noise']:
         files = (f'{data}.wav', )
     elif data == 'headphone_impulse_responses':
         files = ('headphone_impulse_responses.sofa', )

--- a/pyfar/signals/files.py
+++ b/pyfar/signals/files.py
@@ -453,7 +453,7 @@ def head_related_impulse_responses(
     return hrirs, sources
 
 
-def room_impulse_response(sampling_rate=48000, noise_tail=False):
+def room_impulse_response(sampling_rate=48000, crop_noise_tail=True):
     """
     Get a room impulse response (RIR).
 
@@ -473,11 +473,11 @@ def room_impulse_response(sampling_rate=48000, noise_tail=False):
         The sampling rate of the RIR in Hz. The default of ``48000`` uses the
         RIR as it is, any other value uses :py:func:`~pyfar.dsp.resample`
         for resampling to the desired sampling rate.
-    noise_tail, bool, optional
-        If ``False``, the room impulse response is truncated at 1.75 s shortly
-        after its energy falls below that of the noise tail. If ``True``, the
+    crop_noise_tail, bool, optional
+        If ``True``, the room impulse response is truncated at 1.75 s shortly
+        after its energy falls below that of the noise tail. If ``False``, the
         2.5 s room impulse response including the noise tail is.
-        The default is ``False``.
+        The default is ``True``.
 
     Returns
     -------
@@ -495,10 +495,10 @@ def room_impulse_response(sampling_rate=48000, noise_tail=False):
     """
 
     # download files if requires
-    if noise_tail:
-        files = _load_files('room_impulse_response_with_noise')
-    else:
+    if crop_noise_tail:
         files = _load_files('room_impulse_response')
+    else:
+        files = _load_files('room_impulse_response_with_noise')
 
     # load rir
     rir = pf.io.read_audio(os.path.join(file_dir, files[0]))

--- a/pyfar/signals/files.py
+++ b/pyfar/signals/files.py
@@ -476,8 +476,7 @@ def room_impulse_response(sampling_rate=48000, noise_tail=False):
     noise_tail, bool, optional
         If ``False``, the room impulse response is truncated at 1.75 s shortly
         after its energy falls below that of the noise tail. If ``True``, the
-        2.5 s room impulse response including the noise tail is returned as
-        required for estimating room acoustic parameters.
+        2.5 s room impulse response including the noise tail is.
         The default is ``False``.
 
     Returns

--- a/tests/test_signals_files.py
+++ b/tests/test_signals_files.py
@@ -23,6 +23,15 @@ def test_files(function, sampling_rate):
     assert signal.sampling_rate == sampling_rate
 
 
+@pytest.mark.parametrize(
+        ('noise_tail', 'n_samples'), [(False, 84176), (True, 120001)])
+def test_room_impulse_response_noise_tail(noise_tail, n_samples):
+    """Test noise tail parameter of of room impulse response."""
+
+    signal = pf.signals.files.room_impulse_response(noise_tail=noise_tail)
+    assert signal.n_samples == n_samples
+
+
 @pytest.mark.parametrize('sampling_rate', [44100, 48000])
 def test_speech(sampling_rate):
 

--- a/tests/test_signals_files.py
+++ b/tests/test_signals_files.py
@@ -24,11 +24,12 @@ def test_files(function, sampling_rate):
 
 
 @pytest.mark.parametrize(
-        ('noise_tail', 'n_samples'), [(False, 84176), (True, 120001)])
-def test_room_impulse_response_noise_tail(noise_tail, n_samples):
+        ('crop_noise_tail', 'n_samples'), [(True, 84176), (False, 120001)])
+def test_room_impulse_response_noise_tail(crop_noise_tail, n_samples):
     """Test noise tail parameter of of room impulse response."""
 
-    signal = pf.signals.files.room_impulse_response(noise_tail=noise_tail)
+    signal = pf.signals.files.room_impulse_response(
+        crop_noise_tail=crop_noise_tail)
     assert signal.n_samples == n_samples
 
 


### PR DESCRIPTION
### Changes proposed in this pull request:

- Add a version of `pyfar.signals.files.room_impulse_response` that contains a noise tail. This is intended to serve as an example RIR for estimating room acoustic parameters.
- Update tests
