### PR TITLE
[MAINT] Remove support for python 3.9 and 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,8 +165,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.9"
-                - "3.10"
                 - "3.11"
                 - "3.12"
                 - "3.13"
@@ -213,8 +211,6 @@ workflows:
           matrix:
             parameters:
               version:
-                - "3.9"
-                - "3.10"
                 - "3.11"
                 - "3.12"
                 - "3.13"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -40,6 +40,7 @@ Deprecated
 
 Removed
 ^^^^^^^
+- Support for Python 3.9 and 3.10 was removed (PR #907)
 - The following functionality is removed from pyfar v0.8.0 after being deprecated in pyfar v0.6.0 (see below)
 - The `pyfar.samplings` module was removed and move to `spharpy.samplings` (PR #740)
 - The `pyfar.Coordinates` class methods and properties `set_cart`, `get_cart`, `set_sph`, `get_sph`, `set_cyl`, `get_cyl`, `sh_order`, `systems`, `find_nearest_k`, `find_nearest_cart`, `find_nearest_sph`, and `find_slice` were removed in favor of the new API (PRs #741, #786)

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Use pip to install pyfar
 
     pip install pyfar
 
-(Requires Python 3.9 or higher)
-
 Audio file reading/writing is supported through [SoundFile](https://python-soundfile.readthedocs.io), which is based on
 [libsndfile](http://www.mega-nerd.com/libsndfile/). On Windows and OS X, it will be installed automatically.
 On Linux, you need to install libsndfile using your distribution’s package manager, for example ``sudo apt-get install libsndfile1``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.7.4"
 description = "Python package for acoustics research."
 readme = "README.md"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 authors = [
     { name = "The pyfar developers", email = "info@pyfar.org" },
 ]
@@ -24,8 +24,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",


### PR DESCRIPTION
### Changes proposed in this pull request:

- Both versions have reached their end of life
- Requirement of scipy 1.17 introduced in #890 & #893 requires Python >=v3.11
