### PR TITLE
[Maint] deprecate regularized inversion

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -37,6 +37,7 @@ Deprecated
 ^^^^^^^^^^
 - The return parameter `frequencies` from `pyfar.dsp.filter.reconstructing_fractional_octave_bands` is deprecated and will be removed in pyfar v0.9.0 (PR #725)
 - `pyfar.dsp.filter.fractional_octave_frequencies` is deprecated in favour of `pyfar.constants.fractional_octave_frequencies_exact` and `pyfar.constants.fractional_octave_frequencies_nominal` and will be removed in pyfar v0.10.0 (PR #902)
+- `pyfar.dsp.regularized_spectrum_inversion` is deprectated in favour of `pyfar.dsp.RegularizedSpectrumInversion` and will be removed in pyfar v0.10.0 (PR #911)
 
 Removed
 ^^^^^^^

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -4,6 +4,7 @@ import numpy as np
 from scipy import signal as sgn
 import pyfar
 from pyfar.dsp import fft
+from pyfar.classes.warnings import PyfarDeprecationWarning
 import warnings
 import scipy.fft as sfft
 from typing import Literal
@@ -950,6 +951,11 @@ def regularized_spectrum_inversion(
             numerical aspects of linear inversion. Philadelphia: SIAM, 1998.
 
     """
+
+    warnings.warn(("'regularized_spectrum_inversion' will be deprecated in "
+                   "pyfar 0.10.0 in favor 'RegularizedSpectrumInversion'"),
+                   PyfarDeprecationWarning, stacklevel=2)
+
     if not isinstance(signal, pyfar.Signal):
         raise ValueError("The input signal needs to be of type pyfar.Signal.")
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -953,7 +953,7 @@ def regularized_spectrum_inversion(
     """
 
     warnings.warn(("'regularized_spectrum_inversion' will be deprecated in "
-                   "pyfar 0.10.0 in favor 'RegularizedSpectrumInversion'"),
+                   "pyfar 0.10.0 in favor of 'RegularizedSpectrumInversion'"),
                    PyfarDeprecationWarning, stacklevel=2)
 
     if not isinstance(signal, pyfar.Signal):

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -316,7 +316,7 @@ def test_deprecations_fractional_octave_frequencies():
 def test_deprecations_regularized_spectrum_inversion():
     message = re.escape(
         ("'regularized_spectrum_inversion' will be deprecated in "
-         "pyfar 0.10.0 in favor 'RegularizedSpectrumInversion'"))
+         "pyfar 0.10.0 in favor of 'RegularizedSpectrumInversion'"))
     with pytest.warns(PyfarDeprecationWarning, match=message):
         pf.dsp.regularized_spectrum_inversion(
             pf.Signal([1, 2, 3], 4), (10, 100))

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -311,3 +311,18 @@ def test_deprecations_fractional_octave_frequencies():
     if version.parse(pf.__version__) >= version.parse('0.10.0'):
         with pytest.raises(AttributeError):
             pfilt.fractional_octave_frequencies()
+
+
+def test_deprecations_regularized_spectrum_inversion():
+    message = re.escape(
+        ("'regularized_spectrum_inversion' will be deprecated in "
+         "pyfar 0.10.0 in favor 'RegularizedSpectrumInversion'"))
+    with pytest.warns(PyfarDeprecationWarning, match=message):
+        pf.dsp.regularized_spectrum_inversion(
+            pf.Signal([1, 2, 3], 4), (10, 100))
+
+    # remove function from pyfar 0.10.0!
+    if version.parse(pf.__version__) >= version.parse('0.10.0'):
+        with pytest.raises(AttributeError):
+            pf.dsp.regularized_spectrum_inversion(
+                pf.Signal([1, 2, 3], 4), (10, 100))


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Part of #895

### Changes proposed in this pull request:

- deprecate `regularized_spectrum_inversion`
- add deprecation tests
