### PR TITLE
FIX: Avoid checking len on zero length numpy arrays

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.8.1
+-----
+
+Fixed
+^^^^^
+- A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
+
 
 0.8.0 (2026-03-16)
 ------------------

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -965,12 +965,13 @@ class Signal(FrequencyData, TimeData):
         # unpack iterable
         if hasattr(value, '__iter__'):
             value = np.atleast_1d(np.asarray(value)) # fix #922
-            assert len(value) != 0
-            if len(value) != 1:
+            if len(value) == 0:
+                raise ValueError("Sampling rate cannot be empty!")
+            elif len(value) != 1:
                 raise ValueError("Multirate signals are not supported.")
             value = value[0]
-            elif not isinstance(value, (int, float)):
-                raise ValueError("Sampling rate needs to be number.")
+            if not isinstance(value, (int, float)):
+                raise ValueError("Sampling rate needs to be a number.")
         self._sampling_rate = value
 
     @property

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -772,7 +772,7 @@ class Signal(FrequencyData, TimeData):
         """
         # unpack iterable
         if hasattr(sampling_rate, '__iter__'):
-            sampling_rate = np.atleast_1d(np.asarray(sampling_rate))  # fix #922
+            sampling_rate = np.atleast_1d(np.asarray(sampling_rate)) # fix #922
             assert len(sampling_rate) != 0
             if len(sampling_rate) != 1:
                 raise ValueError("Multirate signals are not supported.")

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -770,8 +770,9 @@ class Signal(FrequencyData, TimeData):
         """
         Create audio Signal with time or frequency data and sampling rate.
         """
-        # unpack array
+        # unpack iterable
         if hasattr(sampling_rate, '__iter__'):
+            sampling_rate = np.atleast_1d(np.asarray(sampling_rate))  # fix #922
             assert len(sampling_rate) != 0
             if len(sampling_rate) != 1:
                 raise ValueError("Multirate signals are not supported.")

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -964,7 +964,7 @@ class Signal(FrequencyData, TimeData):
     def sampling_rate(self, value):
         # unpack iterable
         if hasattr(value, '__iter__'):
-            value = np.atleast_1d(np.asarray(value)) # fix #922
+            value = np.atleast_1d(np.asarray(value)).flatten()  # fix #922
             if len(value) == 0:
                 raise ValueError("Sampling rate cannot be empty!")
             elif len(value) != 1:

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -970,7 +970,7 @@ class Signal(FrequencyData, TimeData):
             elif len(value) != 1:
                 raise ValueError("Multirate signals are not supported.")
             value = value[0]
-        if not np.issubdtype((int, float), type(value)):
+        if not isinstance(value, (int, float, np.integer, np.floating)):
             raise ValueError("Sampling rate needs to be a number.")
         self._sampling_rate = value
 

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -969,6 +969,8 @@ class Signal(FrequencyData, TimeData):
             if len(value) != 1:
                 raise ValueError("Multirate signals are not supported.")
             value = value[0]
+            elif not isinstance(value, (int, float)):
+                raise ValueError("Sampling rate needs to be number.")
         self._sampling_rate = value
 
     @property

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -770,16 +770,8 @@ class Signal(FrequencyData, TimeData):
         """
         Create audio Signal with time or frequency data and sampling rate.
         """
-        # unpack iterable
-        if hasattr(sampling_rate, '__iter__'):
-            sampling_rate = np.atleast_1d(np.asarray(sampling_rate)) # fix #922
-            assert len(sampling_rate) != 0
-            if len(sampling_rate) != 1:
-                raise ValueError("Multirate signals are not supported.")
-            sampling_rate = sampling_rate[0]
-
         # initialize signal specific parameters
-        self._sampling_rate = sampling_rate
+        self.sampling_rate = sampling_rate
 
         if not isinstance(is_complex, bool):
             raise TypeError("``is_complex`` flag is "
@@ -970,6 +962,13 @@ class Signal(FrequencyData, TimeData):
 
     @sampling_rate.setter
     def sampling_rate(self, value):
+        # unpack iterable
+        if hasattr(value, '__iter__'):
+            value = np.atleast_1d(np.asarray(value)) # fix #922
+            assert len(value) != 0
+            if len(value) != 1:
+                raise ValueError("Multirate signals are not supported.")
+            value = value[0]
         self._sampling_rate = value
 
     @property

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -970,8 +970,8 @@ class Signal(FrequencyData, TimeData):
             elif len(value) != 1:
                 raise ValueError("Multirate signals are not supported.")
             value = value[0]
-            if not isinstance(value, (int, float)):
-                raise ValueError("Sampling rate needs to be a number.")
+        if not np.issubdtype((int, float), type(value)):
+            raise ValueError("Sampling rate needs to be a number.")
         self._sampling_rate = value
 
     @property

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -308,7 +308,7 @@ def test_sampling_rate_multirate():
 
 
 def test_sampling_rate_is_a_number():
-    match="Sampling rate needs to be number."
+    match="Sampling rate needs to be a number."
     with pytest.raises(ValueError, match=match):
         Signal(1, 'string')
 

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -305,7 +305,10 @@ def test_sampling_rate_multirate():
     match="Multirate signals are not supported."
     with pytest.raises(ValueError, match=match):
         Signal(1, [1,2])
-
+def test sampling_rate_no_a_number():
+    match="Sampling rate needs to be number."
+    with pytest.raises(ValueError, match=match):
+        Signal(1, 'string')
 
 def test_getter_signal_type():
     """Test if attribute signal type is accessed correctly."""

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -288,7 +288,7 @@ def test_getter_sampling_rate():
     assert signal.sampling_rate == 1000
 
 
-def test_setter_sampligrate():
+def test_setter_sampling_rate():
     """Test if attribute sampling rate is set correctly."""
     signal = Signal([1, 2, 3], 44100)
     signal.sampling_rate = 1000

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -305,10 +305,13 @@ def test_sampling_rate_multirate():
     match="Multirate signals are not supported."
     with pytest.raises(ValueError, match=match):
         Signal(1, [1,2])
-def test sampling_rate_no_a_number():
+
+
+def test_sampling_rate_is_a_number():
     match="Sampling rate needs to be number."
     with pytest.raises(ValueError, match=match):
         Signal(1, 'string')
+
 
 def test_getter_signal_type():
     """Test if attribute signal type is accessed correctly."""

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -295,6 +295,12 @@ def test_setter_sampling_rate():
     assert signal._sampling_rate == 1000
 
 
+@pytest.mark.parametrize('fs', [1, [1], [[1]], [[[1]]]])
+def test_sampling_rate_parsing(fs):
+    Signal([0], fs)
+    Signal([0], np.array(fs))
+
+
 def test_sampling_rate_multirate():
     match="Multirate signals are not supported."
     with pytest.raises(ValueError, match=match):

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -295,6 +295,12 @@ def test_setter_sampling_rate():
     assert signal._sampling_rate == 1000
 
 
+def test_sampling_rate_multirate():
+    match="Multirate signals are not supported."
+    with pytest.raises(ValueError, match=match):
+        Signal(1, [1,2])
+
+
 def test_getter_signal_type():
     """Test if attribute signal type is accessed correctly."""
     signal = Signal([1, 2, 3], 44100, fft_norm='none')


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #922 