### PR TITLE
use depedency groups instead of extras

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y libsndfile1
       - run:
           name: install dependencies
-          command: pip install ".[tests]"
+          command: pip install --group tests .
       - run:
           name: Run tests
           command: pytest
@@ -59,7 +59,7 @@ jobs:
       - checkout
       - run:
           name: install dependencies
-          command: pip install ".[tests]"
+          command: pip install --group tests .
       - run:
           name: Ruff
           command: ruff check
@@ -81,7 +81,7 @@ jobs:
       - run:
           name: Sphinx
           command: |
-            pip install ".[docs]"
+          command: pip install --group docs .
             cd docs/
             make html SPHINXOPTS="-W"
 
@@ -101,7 +101,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y libsndfile1
       - run:
           name: install dependencies
-          command: pip install ".[tests]"
+          command: pip install --group tests .
       - run: |
           python --version
       - run:
@@ -124,7 +124,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y libsndfile1
       - run:
           name: install dependencies
-          command: pip install ".[deploy]"
+          command: pip install --group deploy .
       - run:
           name: deploy
           command: |  # create whl, install twine and publish to Test PyPI
@@ -147,7 +147,7 @@ jobs:
           command: sudo apt-get update && sudo apt-get install -y libsndfile1
       - run:
           name: install dependencies
-          command: pip install ".[deploy]"
+          command: pip install --group deploy .
       - run:
           name: deploy
           command: |  # create whl, install twine and publish to Test PyPI

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -46,7 +46,7 @@ Ready to contribute? Here's how to set up `pyfar` for local development using th
 
     $ conda create --name pyfar python
     $ conda activate pyfar
-    $ pip install -e ".[dev]"
+    $ pip install --group dev .
 
 4. Create a branch for local development. Indicate the intention of your branch in its respective name (i.e. `feature/branch-name` or `bugfix/branch-name`)::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "soundfile>=0.11.0",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 deploy = [
     "twine",
     "wheel",
@@ -63,7 +63,11 @@ docs = [
     "sphinx-favicon",
     "sphinx-reredirects",
 ]
-dev = ["pyfar[deploy,tests,docs]"]
+dev = [
+    {include-group = "deploy"},
+    {include-group = "tests"},
+    {include-group = "docs"},
+]
 
 [project.urls]
 Tracker = "https://github.com/pyfar/pyfar/issues"


### PR DESCRIPTION
I would suggest to use [`dependency-groups`](https://packaging.python.org/en/latest/specifications/dependency-groups/) instead of `project.optional-dependencies` for all development dependencies.

The change is pretty minor but is the recommended way of handling dev dependencies. The main difference is that `dependency-groups` are not included when packaging, making the package smaller whereas `optional-dependencies` are meant for package `extras` with optional features (I don't think any pyfar package has those, yet).

The other (minor) benefit is that it makes the dev workflow a bit cleaner, especially with `uv`, where `dev` is activated by default. The linting command is then `uv run ruff check` instead of `uv run --with ".[dev]" ruff check`. Also, it removes the problem with the `[` in some shells. The pip command becomes `pip install --group dev . `.

### Changes proposed in this pull request:

- change `pyproject.toml`
- update installation instructions in `CONTRIBUTING.rst`
- update CI
