### PR TITLE
constain sphinx to versions 8.x.x

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,7 @@ Fixed
 - `pyfar.dsp.time_crop` did not work correctly for higher channel dimensional inputs (PR #944)
 - A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
 - Normalization in `pyfar.dsp.correlate` now works correctly for multi-channel signals (PR #945)
+- Limit Sphinx versions to < 0.9.0 to avoid invalid references for type annotations (PR #929)
 
 
 0.8.0 (2026-03-16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ tests = [
     "coverage",
 ]
 docs = [
-    "sphinx",
+    "sphinx>=8.0.0,<9.0.0",
     "autodocsumm>=0.2.14",
     "pydata-sphinx-theme",
     "sphinx_mdinclude",


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Not a reported issue

### Changes proposed in this pull request:

- Constrain Sphinx to versions 8.x.x

This constrain can hopefully relaxed after https://github.com/sphinx-doc/sphinx/pull/14391 is merged
