### PR TITLE
exclude broken sphinx version

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,7 @@ History
 Fixed
 ^^^^^
 
-- exclude Sphinx version 9.1.0 as it lead to Warnings during the documentation build (PR #933)
+- exclude Sphinx version 9.1.0 as it led to Warnings during the documentation build (PR #933)
 
 
 0.8.0 (2026-03-16)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+Fixed
+^^^^^
+
+- exclude Sphinx version 9.1.0 as it lead to Warnings during the documentation build (PR #933)
+
 
 0.8.0 (2026-03-16)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ tests = [
     "coverage",
 ]
 docs = [
-    "sphinx",
+    "sphinx!=9.1.0",
     "autodocsumm>=0.2.14",
     "pydata-sphinx-theme",
     "sphinx_mdinclude",


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

replaces #929

### Changes proposed in this pull request:

- Sphinx version 9.0.x is working well, only 9.1.0 (currently latest) is not.
- hopefully it will be fixed in the next version.
- instead of restricting to <9 as suggested in #929 , i would just exclude the version which is not working. If they fix it in the next version, we would not need to revert this change. 


similary we could do that in the other packages too.