### PR TITLE
[ENH] Replace LogFormatterITAToolbox with matplotlib's EngFormatter

### DIFF
--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -3,11 +3,10 @@ from pyfar import Signal, TimeData, FrequencyData
 import pyfar.dsp as dsp
 from . import _utils
 from .ticker import (
-    LogFormatterITAToolbox,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
-from matplotlib.ticker import NullFormatter
+from matplotlib.ticker import NullFormatter, EngFormatter
 
 
 def _time(signal, dB=False, log_prefix=20, log_reference=1, unit="s",
@@ -99,7 +98,7 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax.xaxis.set_major_formatter(EngFormatter(sep=""))
 
     return ax
 
@@ -193,7 +192,7 @@ def _phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax.xaxis.set_major_formatter(EngFormatter(sep=""))
 
     return ax
 
@@ -244,7 +243,7 @@ def _group_delay(signal, unit="s", freq_scale='log', ax=None, side='right',
     if freq_scale == 'log':
         ax.xaxis.set_major_locator(LogLocatorITAToolbox())
         ax.xaxis.set_minor_formatter(NullFormatter())
-    ax.xaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax.xaxis.set_major_formatter(EngFormatter(sep=""))
 
     return ax
 

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -4,11 +4,10 @@ import pyfar.dsp as dsp
 from . import _utils
 import warnings
 from .ticker import (
-    LogFormatterITAToolbox,
     LogLocatorITAToolbox,
     MultipleFractionLocator,
     MultipleFractionFormatter)
-from matplotlib.ticker import NullFormatter
+from matplotlib.ticker import NullFormatter, EngFormatter
 
 
 def _time_2d(signal, dB, log_prefix, log_reference, unit, indices,
@@ -108,7 +107,7 @@ def _freq_2d(signal, dB, log_prefix, log_reference, freq_scale, indices,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(LogFormatterITAToolbox())
+    axis[0].set_major_formatter(EngFormatter(sep=""))
 
     # color limits
     if dB and "vmin" not in kwargs:
@@ -173,7 +172,7 @@ def _phase_2d(signal, deg, unwrap, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(LogFormatterITAToolbox())
+    axis[0].set_major_formatter(EngFormatter(sep=""))
 
     # colorbar
     cb = _utils._add_colorbar(colorbar, fig, ax, qm,
@@ -237,7 +236,7 @@ def _group_delay_2d(signal, unit, freq_scale, indices, orientation, method,
     if freq_scale == "log":
         axis[0].set_major_locator(LogLocatorITAToolbox())
         axis[0].set_minor_formatter(NullFormatter())
-    axis[0].set_major_formatter(LogFormatterITAToolbox())
+    axis[0].set_major_formatter(EngFormatter(sep=""))
 
     # color limits
     if "vmin" not in kwargs:
@@ -407,7 +406,7 @@ def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
         ax[0].set_yscale('symlog')
         ax[0].yaxis.set_major_locator(LogLocatorITAToolbox())
         ax[0].yaxis.set_minor_formatter(NullFormatter())
-    ax[0].yaxis.set_major_formatter(LogFormatterITAToolbox())
+    ax[0].yaxis.set_major_formatter(EngFormatter(sep=""))
     ax[0].grid(ls='dotted', color='white')
 
     # colorbar

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -1,10 +1,8 @@
 """Custom tick locators and formatters for matplotlib."""
 import numpy as np
-from matplotlib import transforms as mtransforms
 from matplotlib.ticker import (
     FixedFormatter,
     FixedLocator,
-    LogFormatter,
     LogLocator,
     MultipleLocator,
     Formatter)
@@ -63,54 +61,6 @@ class LogLocatorITAToolbox(LogLocator):
             base=base,
             subs=subs,
             numticks=numticks)
-
-
-class LogFormatterITAToolbox(LogFormatter):
-    """
-    Log-formatter inspired by the tick labels used in the ITA-Toolbox
-    for MATLAB. Uses unit inspired labels e.g. `1e3 = 1k`, `1e6 = 1M`.
-    """
-
-    def __init__(
-        self,
-        base=10.0,
-        labelOnlyBase=False,
-        minor_thresholds=None,
-        linthresh=None,
-    ):
-        super().__init__(
-            base=base,
-            labelOnlyBase=labelOnlyBase,
-            minor_thresholds=minor_thresholds,
-            linthresh=linthresh)
-
-    def _num_to_string(self, x, vmin, vmax):
-        if x >= 1000 and x < 1e6:
-            s = '{:g}k'.format(x/1e3)
-        elif x >= 1e6 and x < 1e9:
-            s = '{:g}M'.format(x/1e6)
-        elif x >= 1e9:
-            s = '{:g}G'.format(x/1e9)
-        else:
-            try:
-                s = self._pprint_val(x, vmax - vmin)
-            except AttributeError:
-                s = self.pprint_val(x, vmax - vmin)
-        return s
-
-    def __call__(self, x, pos=None):  # noqa: ARG002
-        """
-        Return the format for tick val *x*.
-        """
-        if x == 0.0:  # Symlog
-            return '0'
-
-        x = x
-
-        vmin, vmax = self.axis.get_view_interval()
-        vmin, vmax = mtransforms.nonsingular(vmin, vmax, expander=0.05)
-        s = self._num_to_string(x, vmin, vmax)
-        return self.fix_minus(s)
 
 
 class MultipleFractionLocator(MultipleLocator):


### PR DESCRIPTION
Part of adding the ticker module in https://github.com/pyfar/pyfar/pull/877.

Changes proposed in this pull request:

- Removed LogFormatterITAToolbox
- Replaced with matplotlib's [EngFormatter](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.EngFormatter)

Replaces #934 due to issues with commit history.