### PR TITLE
[ENH] Ticker module: remove FractionalOctaveFormatter

### DIFF
--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -8,27 +8,6 @@ from matplotlib.ticker import (
     Formatter)
 
 
-class FractionalOctaveFormatter(FixedFormatter):
-    """Formatter for fractional octave bands."""
-
-    def __init__(self, n_fractions=1):
-        if n_fractions == 1:
-            ticks = [
-                '16', '31.5', '63', '125', '250', '500',
-                '1k', '2k', '4k', '8k', '16k']
-        elif n_fractions == 3:
-            ticks = [
-                '12.5', '16', '20', '25', '31.5', '40',
-                '50', '63', '80', '100', '125', '160',
-                '200', '250', '315', '400', '500', '630',
-                '800', '1k', '1.25k', '1.6k', '2k', '2.5k',
-                '3.15k', '4k', '5k', '6.3k', '8k', '10k',
-                '12.5k', '16k', '20k']
-        else:
-            raise ValueError("Unsupported number of fractions.")
-        super().__init__(ticks)
-
-
 class FractionalOctaveLocator(FixedLocator):
     """Locator for fractional octave bands."""
 


### PR DESCRIPTION
Part of adding the ticker module in #877.

### Changes proposed in this pull request:

Removed the FractionalOctaveFormatter class. It is was not used anywhere and is obsolete through the use of matplotlib's [EngFormatter](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.EngFormatter) introduced in #934 in combination with the fractional octave locator from #882. 
