### PR TITLE
[ENH] Ticker module: Remove custom LogFrequencyLocator

### DIFF
--- a/pyfar/plot/_line.py
+++ b/pyfar/plot/_line.py
@@ -3,10 +3,9 @@ from pyfar import Signal, TimeData, FrequencyData
 import pyfar.dsp as dsp
 from . import _utils
 from .ticker import (
-    LogFrequencyLocator,
     MultipleFractionLocator,
     MultipleFractionFormatter)
-from matplotlib.ticker import NullFormatter, EngFormatter
+from matplotlib.ticker import NullFormatter, EngFormatter, LogLocator
 
 
 def _time(signal, dB=False, log_prefix=20, log_reference=1, unit="s",
@@ -96,7 +95,7 @@ def _freq(signal, dB=True, log_prefix=None, log_reference=1, freq_scale='log',
 
     # set and format ticks
     if freq_scale == 'log':
-        ax.xaxis.set_major_locator(LogFrequencyLocator())
+        ax.xaxis.set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         ax.xaxis.set_minor_formatter(NullFormatter())
     ax.xaxis.set_major_formatter(EngFormatter(sep=""))
 
@@ -190,7 +189,7 @@ def _phase(signal, deg=False, unwrap=False, freq_scale='log', ax=None,
 
     # set and format ticks
     if freq_scale == 'log':
-        ax.xaxis.set_major_locator(LogFrequencyLocator())
+        ax.xaxis.set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         ax.xaxis.set_minor_formatter(NullFormatter())
     ax.xaxis.set_major_formatter(EngFormatter(sep=""))
 
@@ -241,7 +240,7 @@ def _group_delay(signal, unit="s", freq_scale='log', ax=None, side='right',
 
     # set and format ticks
     if freq_scale == 'log':
-        ax.xaxis.set_major_locator(LogFrequencyLocator())
+        ax.xaxis.set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         ax.xaxis.set_minor_formatter(NullFormatter())
     ax.xaxis.set_major_formatter(EngFormatter(sep=""))
 

--- a/pyfar/plot/_two_d.py
+++ b/pyfar/plot/_two_d.py
@@ -4,10 +4,9 @@ import pyfar.dsp as dsp
 from . import _utils
 import warnings
 from .ticker import (
-    LogFrequencyLocator,
     MultipleFractionLocator,
     MultipleFractionFormatter)
-from matplotlib.ticker import NullFormatter, EngFormatter
+from matplotlib.ticker import NullFormatter, EngFormatter, LogLocator
 
 
 def _time_2d(signal, dB, log_prefix, log_reference, unit, indices,
@@ -105,7 +104,7 @@ def _freq_2d(signal, dB, log_prefix, log_reference, freq_scale, indices,
 
     ax_scale[0](freq_scale)
     if freq_scale == "log":
-        axis[0].set_major_locator(LogFrequencyLocator())
+        axis[0].set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         axis[0].set_minor_formatter(NullFormatter())
     axis[0].set_major_formatter(EngFormatter(sep=""))
 
@@ -170,7 +169,7 @@ def _phase_2d(signal, deg, unwrap, freq_scale, indices, orientation, method,
 
     ax_scale[0](freq_scale)
     if freq_scale == "log":
-        axis[0].set_major_locator(LogFrequencyLocator())
+        axis[0].set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         axis[0].set_minor_formatter(NullFormatter())
     axis[0].set_major_formatter(EngFormatter(sep=""))
 
@@ -234,7 +233,7 @@ def _group_delay_2d(signal, unit, freq_scale, indices, orientation, method,
 
     ax_scale[0](freq_scale)
     if freq_scale == "log":
-        axis[0].set_major_locator(LogFrequencyLocator())
+        axis[0].set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         axis[0].set_minor_formatter(NullFormatter())
     axis[0].set_major_formatter(EngFormatter(sep=""))
 
@@ -404,7 +403,7 @@ def _spectrogram(signal, dB=True, log_prefix=None, log_reference=1,
     # scales and ticks
     if freq_scale == 'log':
         ax[0].set_yscale('symlog')
-        ax[0].yaxis.set_major_locator(LogFrequencyLocator())
+        ax[0].yaxis.set_major_locator(LogLocator(subs=(0.2, 0.4, 0.6, 1)))
         ax[0].yaxis.set_minor_formatter(NullFormatter())
     ax[0].yaxis.set_major_formatter(EngFormatter(sep=""))
     ax[0].grid(ls='dotted', color='white')

--- a/pyfar/plot/ticker.py
+++ b/pyfar/plot/ticker.py
@@ -48,61 +48,6 @@ class FractionalOctaveLocator(FixedLocator):
         super().__init__(ticks)
 
 
-class LogFrequencyLocator(LogLocator):
-    """
-    Log-locator particularly suited for frequency axes.
-
-    This locator is a wrapper of :class:`matplotlib.ticker.LogLocator`
-    with default subdivisions optimized for frequency axes.
-    The locator is used per default for frequency axes in pyfar plots.
-
-
-    Parameters
-    ----------
-    base : float, default: 10.0
-        The base of the log used, so major ticks are placed at ``base**n``,
-        where ``n`` is an integer.
-    subs : None, string, or sequence of float, default: (0.2, 0.4, 0.6, 1)
-        Gives the multiples of integer powers of the base at which to place
-        ticks.
-        The default ``(0.2, 0.4, 0.6, 1)`` places ticks at 20 Hz, 40 Hz,
-        60 Hz, 100 Hz, 200 Hz, etc. for a base of 10.
-        See :class:`matplotlib.ticker.LogLocator` for other options than
-        sequence of float.
-    numticks : None or int, default: None
-        The maximum number of ticks to allow on a given axis. The default of
-        None will try to choose intelligently as long as this Locator has
-        already been assigned to an axis using
-        :py:meth:`matplotlib.axis.Axis.get_tick_space`,
-        but otherwise falls back to 9.
-
-
-    Examples
-    --------
-    Use the locator to customize frequency axes in pyfar plots:
-
-    .. plot::
-
-        >>> import pyfar as pf
-        >>> signal = pf.signals.noise(1e3)
-        >>> ax = pf.plot.freq(signal)
-        >>> ax.xaxis.set_major_locator(
-        ...     pf.plot.ticker.LogFrequencyLocator(subs=(0.2, 0.5, 1)))
-
-    """
-
-    def __init__(
-        self,
-        base=10.0,
-        subs=(0.2, 0.4, 0.6, 1),
-        numticks=None,
-    ):
-        super().__init__(
-            base=base,
-            subs=subs,
-            numticks=numticks)
-
-
 class MultipleFractionLocator(MultipleLocator):
     r"""
     Tick locator for rational fraction multiples of a specified base,


### PR DESCRIPTION
Part of adding the ticker module in #877.

### Changes proposed in this pull request:

The LogFrequencyLocator is a simple wrapper of matplotlib's [LogLocator](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.LogLocator), just called with the parameter _subs_ differing from matplotlib's default. We had a similar situation with the EngFormatter in #935, where we decided against a custom wrapper. In this PR, I suggest to remove the LogFrequencyLocator and simply call the matplotlib LogLocator in the plot functions for consistency as well.

Instead of unnecessarily wrapping matplotlib's formatters and locators , I suggest adding convenience functions and example notebooks as part of #877 (similar to #884). For example, a frequency axis convenience function would apply matplotlib's EngFormatter and LogLocator with the pyfar specific options.
