### PR TITLE
[BUG] fix deprecated Matplotlib subplot handing

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+unreleased
+----------
+
+Fixed
+^^^^^
+- Fixed failing tests due to a Matplotlib update (PR #942)
+
 
 0.8.0 (2026-03-16)
 ------------------

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -419,8 +419,7 @@ def test_2d_colorbar_options(function, colorbar, handsome_signal_2d):
             function(signal, colorbar=False)
     elif colorbar == "axes":
         # test plotting colorbar to specified axis
-        fig.clear()
-        _, ax = plt.subplots(1, 2, num=fig.number)
+        _, ax = fig.subplots(1, 2)
         if function == plot.spectrogram:
             function(signal[0], ax=ax)
         else:


### PR DESCRIPTION
### Changes proposed in this pull request:


Test failed after a Matplotlib update. The update now raises an error, if `plt.subplots` gets an existing figure to create the subplots. This is fixed using `fig.subplots` instead.