### PR TITLE
[BUG] multidimensional time crop

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+unreleased
+----------
+
+Fixed
+^^^^^
+- `pyfar.dsp.time_crop` did not work correctly for higher channel dimensional inputs (PR #944)
 
 0.8.0 (2026-03-16)
 ------------------

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -692,7 +692,7 @@ def time_crop(signal, interval: Union[list[float], tuple[float, float],
          raise ValueError("Interval is out of the boundaries" \
                 " of signal.times")
 
-    time_data = signal.time[:, mask]
+    time_data = signal.time[..., mask]
 
     if isinstance(signal, pyfar.Signal):
         cropped_signal = pyfar.Signal(time_data, signal.sampling_rate)

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -792,6 +792,15 @@ def test_time_crop_unit_seconds_error(signal):
     ' the boundaries'):
         dsp.time_crop(signal, interval=[2, 3], unit='s')
 
+@pytest.mark.parametrize("signal", [pyfar.Signal(np.ones((1,1,10)), 2),
+                                     pf.TimeData(np.ones((1,1,3)), [1, 2, 3])])
+def test_time_crop_multidim(signal):
+    """
+    Test the `time_crop` function with a multi-dimensional signal.
+    """
+    cropped = dsp.time_crop(signal, interval=[1, 2], unit='samples')
+    assert cropped.n_samples == 2
+    assert cropped.cshape == signal.cshape
 
 def test_kaiser_window_beta():
     """Test function call."""


### PR DESCRIPTION
I stumbled across this while working. `pf.dsp.time_crop` raised an error when applied to signals with a channel dimension greater than 1.

This PR should fix this issue. 

I have also added a test for this scenario.
