### PR TITLE
[BUG] multidimensional, normalized correlation

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Fixed
 - Fixed deprecated Matplotlib subplot behavior (PR #942)
 - `pyfar.dsp.time_crop` did not work correctly for higher channel dimensional inputs (PR #944)
 - A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
+- Normalization in `pyfar.dsp.correlate` now works correctly for multi-channel signals (PR #945)
 
 
 0.8.0 (2026-03-16)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -3018,7 +3018,9 @@ def correlate(signal_1, signal_2, mode='full', normalize=False):
 
     # apply normalization
     if normalize:
-        correlation /= normalization
+        # add an axis to normalization to allow broadcasting
+        # for multi-channel signals
+        correlation /= normalization[..., None]
 
     # compute lags, i.e., times that the second signal was shifted
     # with respect to the first

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -3020,7 +3020,7 @@ def correlate(signal_1, signal_2, mode='full', normalize=False):
     if normalize:
         # add an axis to normalization to allow broadcasting
         # for multi-channel signals
-        correlation /= normalization[..., None]
+        correlation /= normalization[..., np.newaxis]
 
     # compute lags, i.e., times that the second signal was shifted
     # with respect to the first

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -124,7 +124,8 @@ def test_cyclic_mode_1d(length, delay_1, delay_2):
         correlation.time[0, correlation.times!=lag], 0., 10)
 
 
-def test_full_mode_nd():
+@pytest.mark.parametrize('normalize', [False, True])
+def test_full_mode_nd(normalize):
     """Test broadcasting and n-dimensional signals in full mode."""
 
     # compute correlation
@@ -132,7 +133,7 @@ def test_full_mode_nd():
     signal_1 = pf.signals.impulse(5, 0, sampling_rate=1)
     signal_2 = pf.signals.impulse(5, delays, sampling_rate=1)
 
-    correlation = correlate(signal_1, signal_2)
+    correlation = correlate(signal_1, signal_2, normalize=normalize)
 
     # test output shapes
     assert type(correlation) == pf.TimeData


### PR DESCRIPTION
### Proposed changes

When calculating a normalised correlation with multidimensional signals, a broadcasting error was raised. The cause was that the normalisation factor was "missing" the last (time) dimension. As NumPy broadcasting is evaluated from the right, the arrays could not be broadcast. 

This PR fixes this issue by appending a new dimension to the normalisation factor. Furthermore, the nd-correlation test is extended to test normalisation as well.