### PR TITLE
Add rounding options for find_nearest_time() and find_nearest_frequency() methods

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,12 +2,12 @@
 History
 =======
 
-0.9.0 (2026-XX-XX)
-------------------
+unreleased
+----------
 
 Added
 ^^^^^
-- The methods `find_nearest_frequency()` and `find_nearest_time()` were extended with a new parameter `method`." (PR #947)
+- The methods `find_nearest_frequency()` and `find_nearest_time()` were extended with a new parameter `method`. (PR #947)
 
 0.8.0 (2026-03-16)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,12 @@
 History
 =======
 
+0.9.0 (2026-XX-XX)
+------------------
+
+Added
+^^^^^
+- The methods `find_nearest_frequency()` and `find_nearest_time()` were extended with a new parameter `method`." (PR #947)
 
 0.8.0 (2026-03-16)
 ------------------

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -33,6 +33,7 @@ from copy import deepcopy
 import warnings
 import deepdiff
 import numpy as np
+from tomlkit import value
 import pyfar.dsp.fft as fft
 from typing import Callable
 
@@ -436,26 +437,12 @@ class TimeData(_Audio):
             Query times outside the range of self.times are mapped to the first
             or last valid index.
         """
-        times = np.atleast_1d(value)
-        indices = np.zeros_like(times).astype(int)
+        if len(self.times) == 0:
+            raise ValueError("The TimeData object must not be empty.")
 
-        if method == "nearest":
-            for idx, time in enumerate(times):
-                indices[idx] = np.argmin(np.abs(self.times - time))
-        elif method == "floor":
-            # find the insertion positions and select the previous indices
-            indices = np.searchsorted(self.times, times, side="right") -1
-            # clip to ensure the index is not out of range of time indices
-            indices = np.clip(indices, 0, len(self.times) - 1)
-        elif method == "ceil":
-            # find the insertion positions
-            indices = np.searchsorted(self.times, times, side="left")
-            # clip to ensure the index is not out of range of time indices
-            indices = np.clip(indices, 0, len(self.times) - 1)
-        else:
-            raise ValueError("Invalid value for the parameter 'method'."
-                    " Has to be 'nearest', 'floor', or 'ceil'.")
-        return np.squeeze(indices)
+        result = _find_nearest_helper(self.times, value, method)
+
+        return result
 
     def _assert_matching_meta_data(self, other):
         """
@@ -656,26 +643,12 @@ class FrequencyData(_Audio):
             Query frequencies outside the range of self.frequencies are mapped
             to the first or last valid index.
         """
-        freqs = np.atleast_1d(value)
-        indices = np.zeros_like(freqs).astype(int)
+        if len(self.frequencies) == 0:
+            raise ValueError("The FrequencyData object must not be empty.")
 
-        if method == "nearest":
-            for idx, freq in enumerate(freqs):
-                indices[idx] = np.argmin(np.abs(self.frequencies - freq))
-        elif method == "floor":
-            # find the insertion positions and select the previous indices
-            indices = np.searchsorted(self.frequencies, freqs, side="right") -1
-            # clip to ensure the index is not out of range of frequency indices
-            indices = np.clip(indices, 0, len(self.frequencies) - 1)
-        elif method == "ceil":
-            # find the insertion positions
-            indices = np.searchsorted(self.frequencies, freqs, side="left")
-            # clip to ensure the index is not out of range of frequency indices
-            indices = np.clip(indices, 0, len(self.frequencies) - 1)
-        else:
-            raise ValueError("Invalid value for the parameter 'method'."
-                    " Has to be 'nearest', 'floor', or 'ceil'.")
-        return np.squeeze(indices)
+        result = _find_nearest_helper(self.frequencies, value, method)
+
+        return result
 
     def _assert_matching_meta_data(self, other):
         """Check if the meta data matches across two FrequencyData objects."""
@@ -1958,3 +1931,27 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
                               f"they are {fft_norm_1} and {fft_norm_2}."))
 
     return fft_norm_result
+
+
+def _find_nearest_helper(self_values, desired_value, method):
+
+        values = np.atleast_1d(desired_value)
+        indices = np.zeros_like(values).astype(int)
+
+        if method == "nearest":
+            for idx, value in enumerate(values):
+                indices[idx] = np.argmin(np.abs(self_values - value))
+        elif method == "floor":
+            # find the insertion positions and select the previous indices
+            indices = np.searchsorted(self_values, values, side="right") -1
+            # clip to ensure the index is not out of range of value indices
+            indices = np.clip(indices, 0, len(self_values) - 1)
+        elif method == "ceil":
+            # find the insertion positions
+            indices = np.searchsorted(self_values, values, side="left")
+            # clip to ensure the index is not out of range of value indices
+            indices = np.clip(indices, 0, len(self_values) - 1)
+        else:
+            raise ValueError("Invalid value for the parameter 'method'."
+                    " Has to be 'nearest', 'floor', or 'ceil'.")
+        return np.squeeze(indices)

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -1942,7 +1942,7 @@ def _find_nearest_helper(self_values, desired_value, method):
                 indices[idx] = np.argmin(np.abs(self_values - value))
         elif method == "floor":
             # find the insertion positions and select the previous indices
-            indices = np.searchsorted(self_values, values, side="right") -1
+            indices = np.searchsorted(self_values, values, side="right") - 1
             # clip to ensure the index is not out of range of value indices
             indices = np.clip(indices, 0, len(self_values) - 1)
         elif method == "ceil":

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -436,9 +436,6 @@ class TimeData(_Audio):
             Query times outside the range of self.times are mapped to the first
             or last valid index.
         """
-        if len(self.times) == 0:
-            raise ValueError("The TimeData object must not be empty.")
-
         result = _find_nearest_helper(self.times, value, method)
 
         return result
@@ -642,9 +639,6 @@ class FrequencyData(_Audio):
             Query frequencies outside the range of self.frequencies are mapped
             to the first or last valid index.
         """
-        if len(self.frequencies) == 0:
-            raise ValueError("The FrequencyData object must not be empty.")
-
         result = _find_nearest_helper(self.frequencies, value, method)
 
         return result
@@ -1933,6 +1927,9 @@ def _match_fft_norm(fft_norm_1, fft_norm_2, division=False):
 
 
 def _find_nearest_helper(self_values, desired_value, method):
+        if len(self_values) == 0:
+            raise ValueError("The FrequencyData/TimeData object"
+                                         " must not be empty.")
 
         values = np.atleast_1d(desired_value)
         indices = np.zeros_like(values).astype(int)

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -409,24 +409,51 @@ class TimeData(_Audio):
         """Time in seconds at which the signal is sampled."""
         return self._times
 
-    def find_nearest_time(self, value):
-        """Return the index that is closest to the query time.
+    def find_nearest_time(self, value, method="nearest"):
+        """Return the indices of time samples matching the
+        specified query times.
 
         Parameters
         ----------
         value : float, array-like
             The times for which the indices are to be returned
+        method : {'nearest', 'floor', 'ceil'}, optional
+            Specifies how query times that do not exactly match a sample
+            are handled:
+
+            - ``'nearest'``: Return the index of the nearest time.
+            - ``'floor'``:  Return the index of the largest time smaller
+            than or equal to the query time.
+            - ``'ceil'``: Return the index of the smallest time larger
+            than or equal to the query time.
 
         Returns
         -------
         indices : int, array-like
             The index for the given time instance. If the input was an array
             like, a numpy array of indices is returned.
+            Query times outside the range of self.times are mapped to the first
+            or last valid index.
         """
         times = np.atleast_1d(value)
         indices = np.zeros_like(times).astype(int)
-        for idx, time in enumerate(times):
-            indices[idx] = np.argmin(np.abs(self.times - time))
+
+        if method == "nearest":
+            for idx, time in enumerate(times):
+                indices[idx] = np.argmin(np.abs(self.times - time))
+        elif method == "floor":
+            # find the insertion positions and select the previous indices
+            indices = np.searchsorted(self.times, times, side="right") -1
+            # clip to ensure the index is not out of range of time indices
+            indices = np.clip(indices, 0, len(self.times) - 1)
+        elif method == "ceil":
+            # find the insertion positions
+            indices = np.searchsorted(self.times, times, side="left")
+            # clip to ensure the index is not out of range of time indices
+            indices = np.clip(indices, 0, len(self.times) - 1)
+        else:
+            raise ValueError("Invalid value for the parameter 'method'."
+                    " Has to be 'nearest', 'floor', or 'ceil'.")
         return np.squeeze(indices)
 
     def _assert_matching_meta_data(self, other):
@@ -601,24 +628,51 @@ class FrequencyData(_Audio):
         """Number of frequency bins."""
         return self._data.shape[-1]
 
-    def find_nearest_frequency(self, value):
-        """Return the index that is closest to the query frequency.
+    def find_nearest_frequency(self, value, method="nearest"):
+        """Return the indices of frequency bins matching the
+        specified query frequencies.
 
         Parameters
         ----------
         value : float, array-like
             The frequencies for which the indices are to be returned
+        method : {'nearest', 'floor', 'ceil'}, optional
+            Specifies how query frequencies that do not exactly match a bin
+            are handled:
+
+            - ``'nearest'`` Return the index of the nearest frequency.
+            - ``'floor'``  Return the index of the largest frequency smaller
+            than or equal to the query frequency.
+            - ``'ceil'`` Return the index of the smallest frequency larger
+            than or equal to the query frequency.
 
         Returns
         -------
         indices : int, array-like
             The index for the given frequency. If the input was an array like,
             a numpy array of indices is returned.
+            Query frequencies outside the range of self.frequencies are mapped
+            to the first or last valid index.
         """
         freqs = np.atleast_1d(value)
         indices = np.zeros_like(freqs).astype(int)
-        for idx, freq in enumerate(freqs):
-            indices[idx] = np.argmin(np.abs(self.frequencies - freq))
+
+        if method == "nearest":
+            for idx, freq in enumerate(freqs):
+                indices[idx] = np.argmin(np.abs(self.frequencies - freq))
+        elif method == "floor":
+            # find the insertion positions and select the previous indices
+            indices = np.searchsorted(self.frequencies, freqs, side="right") -1
+            # clip to ensure the index is not out of range of frequency indices
+            indices = np.clip(indices, 0, len(self.frequencies) - 1)
+        elif method == "ceil":
+            # find the insertion positions
+            indices = np.searchsorted(self.frequencies, freqs, side="left")
+            # clip to ensure the index is not out of range of frequency indices
+            indices = np.clip(indices, 0, len(self.frequencies) - 1)
+        else:
+            raise ValueError("Invalid value for the parameter 'method'."
+                    " Has to be 'nearest', 'floor', or 'ceil'.")
         return np.squeeze(indices)
 
     def _assert_matching_meta_data(self, other):

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -421,7 +421,8 @@ class TimeData(_Audio):
             Specifies how query times that do not exactly match a sample
             are handled:
 
-            - ``'nearest'``: Return the index of the nearest time.
+            - ``'nearest'``: Return the index of the nearest
+            time (default).
             - ``'floor'``:  Return the index of the largest time smaller
             than or equal to the query time.
             - ``'ceil'``: Return the index of the smallest time larger
@@ -640,7 +641,8 @@ class FrequencyData(_Audio):
             Specifies how query frequencies that do not exactly match a bin
             are handled:
 
-            - ``'nearest'`` Return the index of the nearest frequency.
+            - ``'nearest'`` Return the index of the nearest
+            frequency (default).
             - ``'floor'``  Return the index of the largest frequency smaller
             than or equal to the query frequency.
             - ``'ceil'`` Return the index of the smallest frequency larger

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -33,7 +33,6 @@ from copy import deepcopy
 import warnings
 import deepdiff
 import numpy as np
-from tomlkit import value
 import pyfar.dsp.fft as fft
 from typing import Callable
 

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -176,6 +176,17 @@ def test_data_frequency_find_nearest():
     npt.assert_allclose(idx, np.asarray([1, 2]))
 
 
+def test_data_frequency_find_nearest_empty_frequency_data():
+    """
+    Test whether the function correctly raises an error when the FrequencyData
+     object is empty.
+    """
+    freq = FrequencyData([], [])
+
+    with pytest.raises(ValueError, match='must not be empty'):
+        freq.find_nearest_frequency([.1])
+
+
 @pytest.mark.parametrize(("method", "expected"),
                          [("nearest", 2), ("floor", 1), ("ceil", 2)])
 def test_data_frequency_find_nearest_argument_method(method, expected):

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -176,6 +176,63 @@ def test_data_frequency_find_nearest():
     npt.assert_allclose(idx, np.asarray([1, 2]))
 
 
+@pytest.mark.parametrize(("method", "expected"),
+                         [("nearest", 2), ("floor", 1), ("ceil", 2)])
+def test_data_frequency_find_nearest_argument_method(method, expected):
+    """Test the function with a single number as value."""
+    data = [1, 0, -1]
+    freqs = [0, .1, .3]
+    freq = FrequencyData(data, freqs)
+
+    idx = freq.find_nearest_frequency(0.25, method)
+    assert idx == expected
+
+
+@pytest.mark.parametrize(("method", "expected"), [("nearest", [0, 2, 4, 5]),
+                        ("floor", [0, 1, 4, 4]), ("ceil", [1, 2, 4, 5])])
+def test_data_frequency_find_nearest_argument_method_list(method, expected):
+    """Test the function with a list of values."""
+    data = [1, 0, -1, 1, 1, 0]
+    freqs = [0, .1, .2, .3, .4, .5]
+    freq = FrequencyData(data, freqs)
+
+    idx = freq.find_nearest_frequency([0.03, 0.16, 0.4, 0.49], method)
+    npt.assert_array_equal(idx, expected)
+
+
+@pytest.mark.parametrize("method", ["nearest", "floor", "ceil"])
+def test_data_frequency_find_nearest_argument_method_out_of_range(method):
+    """Test the function against returning indices out of frequencies range."""
+    data = [1, 0, -1]
+    freqs = [0.1, 0.2, 0.3]
+    freq = FrequencyData(data, freqs)
+
+    idx = freq.find_nearest_frequency([0.09, 0.31], method)
+    npt.assert_array_equal(idx, [0, 2])
+
+
+@pytest.mark.parametrize(("method", "expected"), [("nearest", [1, 2]),
+                                ("floor", [1, 2]), ("ceil", [1, 2])])
+def test_data_frequency_find_nearest_argument_method_equal_frequencies(method, expected):
+    """Test the function with values exactly equal to frequency instances."""
+    data = [1, 0, -1]
+    freqs = [0, .1, .3]
+    freq = FrequencyData(data, freqs)
+
+    idx = freq.find_nearest_frequency([0.1, 0.3], method)
+    npt.assert_array_equal(idx, expected)
+
+
+def test_data_frequency_find_nearest_argument_method_error():
+    """Test the function for correct error handling."""
+    data = [1, 0, -1]
+    freqs = [0, .1, .3]
+    freq = FrequencyData(data, freqs)
+
+    with pytest.raises(ValueError, match="Invalid value for the parameter"):
+        freq.find_nearest_frequency([0.1, 0.3], "fix")
+
+
 def test_magic_getitem_slice():
     """Test slicing operations by the magic function __getitem__."""
     data = np.array([[1, 0, -1], [2, 0, -2]])

--- a/tests/test_audio_frequency_data.py
+++ b/tests/test_audio_frequency_data.py
@@ -224,7 +224,8 @@ def test_data_frequency_find_nearest_argument_method_out_of_range(method):
 
 @pytest.mark.parametrize(("method", "expected"), [("nearest", [1, 2]),
                                 ("floor", [1, 2]), ("ceil", [1, 2])])
-def test_data_frequency_find_nearest_argument_method_equal_frequencies(method, expected):
+def test_data_frequency_find_nearest_argument_method_equal_frequencies(method,
+                                                                    expected):
     """Test the function with values exactly equal to frequency instances."""
     data = [1, 0, -1]
     freqs = [0, .1, .3]

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -199,6 +199,17 @@ def test_data_time_find_nearest():
     npt.assert_allclose(idx, np.asarray([1, 2]))
 
 
+def test_data_time_find_nearest_empty_time_data():
+    """
+    Test whether the function correctly raises an error when the TimeData
+     object is empty.
+    """
+    time = TimeData([], [])
+
+    with pytest.raises(ValueError, match='must not be empty'):
+        time.find_nearest_time([.1])
+
+
 @pytest.mark.parametrize(("method", "expected"),
                          [("nearest", 2), ("floor", 1), ("ceil", 2)])
 def test_data_time_find_nearest_argument_method(method, expected):

--- a/tests/test_audio_time_data.py
+++ b/tests/test_audio_time_data.py
@@ -199,6 +199,63 @@ def test_data_time_find_nearest():
     npt.assert_allclose(idx, np.asarray([1, 2]))
 
 
+@pytest.mark.parametrize(("method", "expected"),
+                         [("nearest", 2), ("floor", 1), ("ceil", 2)])
+def test_data_time_find_nearest_argument_method(method, expected):
+    """Test the function with a single number as value."""
+    data = [1, 0, -1]
+    times = [0, .1, .3]
+    time = TimeData(data, times)
+
+    idx = time.find_nearest_time(0.25, method)
+    assert idx == expected
+
+
+@pytest.mark.parametrize(("method", "expected"), [("nearest", [0, 2, 4, 5]),
+                             ("floor", [0, 1, 4, 4]), ("ceil", [1, 2, 4, 5])])
+def test_data_time_find_nearest_argument_method_list(method, expected):
+    """Test the function with a list of values."""
+    data = [1, 0, -1, 1, 1, 0]
+    times = [0, .1, .2, .3, .4, .5]
+    time = TimeData(data, times)
+
+    idx = time.find_nearest_time([0.03, 0.16, 0.4, 0.49], method)
+    npt.assert_array_equal(idx, expected)
+
+
+@pytest.mark.parametrize("method", ["nearest", "floor", "ceil"])
+def test_data_time_find_nearest_argument_method_out_of_range(method):
+    """Test the function against returning indices out of time range."""
+    data = [1, 0, -1]
+    times = [0.1, 0.2, 0.3]
+    time = TimeData(data, times)
+
+    idx = time.find_nearest_time([0.09, 0.31], method)
+    npt.assert_array_equal(idx, [0, 2])
+
+
+@pytest.mark.parametrize(("method", "expected"), [("nearest", [1, 2]),
+                                 ("floor", [1, 2]), ("ceil", [1, 2])])
+def test_data_time_find_nearest_argument_method_equal_times(method, expected):
+    """Test the function with values exactly equal to time instances."""
+    data = [1, 0, -1]
+    times = [0, .1, .3]
+    time = TimeData(data, times)
+
+    idx = time.find_nearest_time([0.1, 0.3], method)
+    npt.assert_array_equal(idx, expected)
+
+
+def test_data_time_find_nearest_argument_method_error():
+    """Test the function for correct error handling."""
+    data = [1, 0, -1]
+    times = [0, .1, .3]
+    time = TimeData(data, times)
+
+    with pytest.raises(ValueError, match="Invalid value for the parameter"):
+        time.find_nearest_time([0.1, 0.3], "fix")
+
+
 def test_magic_getitem_slice():
     """Test slicing operations by the magic function __getitem__."""
     data = np.array([[1, 0, -1], [2, 0, -2]])


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #867

### Changes proposed in this pull request:

- Add a new parameter called `method` to the `find_nearest_time()` and `find_nearest_frequency()` methods. This parameter can take one of the following three values: {`nearest`, `floor`, `ceil`}. 
- Expand the docstrings. 
- Add tests to the files `test_audio_frequency_data.py` and `test_audio_data_time.py`.
- The function’s previous functionality is preserved in `nearest` mode.
- If the specified value (list of values) is outside the range of `self.time` or `self.frequencies`, the first or last index is returned. 

### Open Question
1. How should the functions (`find_nearest_time()` and `find_nearest_frequency()`) behave if `self.times` or `self.frequencies` is empty? Currently, both functions simply return -1 for the `floor` and `ceil` modes, since there are no indices at all when the `times` or `frequencies` arrays are empty. For the `nearest` mode, numpy raises a `ValueError`. 