### PR TITLE
Level Module (cumulative)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ unreleased
 
 Fixed
 ^^^^^
+- Fixed deprecated Matplotlib subplot behavior (PR #942)
 - `pyfar.dsp.time_crop` did not work correctly for higher channel dimensional inputs (PR #944)
 - A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,6 +10,7 @@ Fixed
 - Fixed deprecated Matplotlib subplot behavior (PR #942)
 - `pyfar.dsp.time_crop` did not work correctly for higher channel dimensional inputs (PR #944)
 - A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
+- Normalization in `pyfar.dsp.correlate` now works correctly for multi-channel signals (PR #945)
 
 
 0.8.0 (2026-03-16)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,11 +2,12 @@
 History
 =======
 
-0.8.1
------
+unreleased
+----------
 
 Fixed
 ^^^^^
+- `pyfar.dsp.time_crop` did not work correctly for higher channel dimensional inputs (PR #944)
 - A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.8.1
+-----
+
+Fixed
+^^^^^
+- A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
+
 
 0.8.0 (2026-03-16)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,11 @@ History
 unreleased
 ----------
 
+Added
+^^^^^
+- A new submodule `pyfar.level` with various functions to compute and work with levels (PR #949), consisting of:
+    - `level.equivalent_continuous_level` for the Leq (PR #948)
+
 Fixed
 ^^^^^
 - Fixed deprecated Matplotlib subplot behavior (PR #942)

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -35,6 +35,7 @@ Modules
    modules/pyfar.dsp.fft
    modules/pyfar.dsp.filter
    modules/pyfar.io
+   modules/pyfar.level
    modules/pyfar.plot
    modules/pyfar.signals
    modules/pyfar.signals.files

--- a/docs/modules/pyfar.level.rst
+++ b/docs/modules/pyfar.level.rst
@@ -1,0 +1,7 @@
+pyfar.level
+===========
+
+.. automodule:: pyfar.level
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyfar/__init__.py
+++ b/pyfar/__init__.py
@@ -23,6 +23,7 @@ from . import dsp
 from . import signals
 from . import utils
 from . import constants
+from . import level
 
 
 __all__ = [
@@ -52,4 +53,5 @@ __all__ = [
     'constants',
     'dot',
     'cross',
+    'level',
     ]

--- a/pyfar/classes/audio.py
+++ b/pyfar/classes/audio.py
@@ -770,15 +770,8 @@ class Signal(FrequencyData, TimeData):
         """
         Create audio Signal with time or frequency data and sampling rate.
         """
-        # unpack array
-        if hasattr(sampling_rate, '__iter__'):
-            assert len(sampling_rate) != 0
-            if len(sampling_rate) != 1:
-                raise ValueError("Multirate signals are not supported.")
-            sampling_rate = sampling_rate[0]
-
         # initialize signal specific parameters
-        self._sampling_rate = sampling_rate
+        self.sampling_rate = sampling_rate
 
         if not isinstance(is_complex, bool):
             raise TypeError("``is_complex`` flag is "
@@ -969,6 +962,16 @@ class Signal(FrequencyData, TimeData):
 
     @sampling_rate.setter
     def sampling_rate(self, value):
+        # unpack iterable
+        if hasattr(value, '__iter__'):
+            value = np.atleast_1d(np.asarray(value)).flatten()  # fix #922
+            if len(value) == 0:
+                raise ValueError("Sampling rate cannot be empty!")
+            elif len(value) != 1:
+                raise ValueError("Multirate signals are not supported.")
+            value = value[0]
+        if not isinstance(value, (int, float, np.integer, np.floating)):
+            raise ValueError("Sampling rate needs to be a number.")
         self._sampling_rate = value
 
     @property

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -692,7 +692,7 @@ def time_crop(signal, interval: Union[list[float], tuple[float, float],
          raise ValueError("Interval is out of the boundaries" \
                 " of signal.times")
 
-    time_data = signal.time[:, mask]
+    time_data = signal.time[..., mask]
 
     if isinstance(signal, pyfar.Signal):
         cropped_signal = pyfar.Signal(time_data, signal.sampling_rate)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -3018,7 +3018,9 @@ def correlate(signal_1, signal_2, mode='full', normalize=False):
 
     # apply normalization
     if normalize:
-        correlation /= normalization
+        # add an axis to normalization to allow broadcasting
+        # for multi-channel signals
+        correlation /= normalization[..., np.newaxis]
 
     # compute lags, i.e., times that the second signal was shifted
     # with respect to the first

--- a/pyfar/level/__init__.py
+++ b/pyfar/level/__init__.py
@@ -1,0 +1,1 @@
+"""Sound level metering functions."""

--- a/pyfar/level/__init__.py
+++ b/pyfar/level/__init__.py
@@ -1,1 +1,9 @@
 """Sound level metering functions."""
+
+from .standard_levels import (
+    equivalent_continuous_level,
+)
+
+__all__ = [
+    "equivalent_continuous_level",
+]

--- a/pyfar/level/_utils.py
+++ b/pyfar/level/_utils.py
@@ -1,0 +1,47 @@
+"""Reusable helper functions for the individual processing steps shared
+between many of the standardized level functions.
+"""
+
+import numpy as np
+import pyfar as pf
+
+
+def _check_signal_type(signal):
+    """Raises a TypeError if not a pyfar.Signal, otherwise returns
+    the signal with type hinting.
+    """
+    if not isinstance(signal, pf.Signal):
+        raise TypeError("'signal' parameter must be a pyfar.Signal")
+    signal: pf.Signal = signal
+    return signal
+
+
+def _apply_frequency_weighting(signal, frequency_weighting):
+    """Applies frequency weighting to the signal
+    or raises a ValueError if the weighting name is invalid.
+    """
+    if frequency_weighting == "Z":
+        return signal
+    elif frequency_weighting in ["A", "C"]:
+        return pf.dsp.filter.frequency_weighting_filter(
+            signal, frequency_weighting)
+    else:
+        raise ValueError("Frequency weighting must be 'A', 'C', or 'Z'")
+
+
+def _apply_multi_band(signal, num_octave_band_fractions: int | None):
+    """Applies fractional octave band filtering to the signal or does
+    nothing if `num_octave_band_fractions` is None.
+    """
+    if num_octave_band_fractions is None:
+        return signal
+    return pf.dsp.filter.fractional_octave_bands(
+        signal, num_octave_band_fractions)
+
+
+def _energies_to_levels(energies: np.ndarray, reference_pressure: float):
+    """Converts energies to levels in dB relative to the reference pressure.
+    """
+    if reference_pressure == 0:
+        raise ValueError("Reference pressure must not be zero.")
+    return 10 * np.log10(energies / reference_pressure**2)

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -1,0 +1,91 @@
+"""Level calculation functions according to IEC 61672-1."""
+
+from typing import Literal
+import numpy as np
+import pyfar as pf
+
+from ._utils import (
+    _check_signal_type,
+    _apply_frequency_weighting,
+    _apply_multi_band,
+    _energies_to_levels,
+)
+
+
+def equivalent_continuous_level(
+        signal,
+        frequency_weighting: Literal["A", "C", "Z"],
+        num_octave_band_fractions: int | None = None,
+        reference_pressure: float = pf.constants.reference_sound_pressure,
+):
+    r"""Calculate the frequency-weighted equivalent continuous sound pressure
+    level (Leq).
+
+    The levels are calculated per channel and according to IEC 61672-1 [#]_.
+    For instance, the A-weighted equivalent continuous level is calculated as:
+
+    .. math::
+        L_\text{Aeq} = 10 \log_{10} \left[ \frac{(1/N) \sum_{n=0}^{N-1}
+        p_{\text{A}}^2[n]} {p_0^2} \right] \text{ dB}
+
+    where :math:`N` is the number of samples in the signal,
+    :math:`p_\mathrm{A}` the A-weighted sound pressure at index :math:`n`,
+    and :math:`p_0` is the `reference_pressure`.
+
+    Parameters
+    ----------
+    signal: Signal
+        The signal object to calculate the levels of
+
+    frequency_weighting: ``"A"``, ``"C"``, or ``"Z"``
+        The frequency weighting type. If ``"A"`` or ``"C"``, the corresponding
+        frequency weighting filter is applied before level
+        calculation. If ``"Z"``, no frequency weighting is applied.
+
+        The frequency weighting is applied using
+        :py:func:`~pyfar.dsp.filter.frequency_weighting_filter` with its
+        (standard-compliant) default parameters. If you need more control,
+        you can set this parameter to ``"Z"`` and apply the frequency
+        weighting filter yourself before calling this function.
+
+    num_octave_band_fractions: int or ``None``
+        Can be used to calculate the level in octave (``1``), third-octave
+        (``3``), or other positive integer fractional octave bands.
+        If ``None``, levels are calculated for the full-band signal.
+
+        The fraction octave band filtering is applied using
+        :py:func:`~pyfar.dsp.filter.fractional_octave_bands` with its
+        (standard-compliant) default parameters. If you need more control,
+        you can set this parameter to ``None`` and apply the filter bank
+        yourself before calling this function.
+
+    reference_pressure: float
+        The reference pressure to calculate levels relative to. The default
+        value, ``20e-6``, corresponds to the standard reference pressure of
+        20 micropascals, which assumes the signal is in units of pascals (Pa).
+        To compute the level in dBFS of a digital signal, or if you plan
+        to correct for the recording setup afterwards, this parameter
+        should be ``1``.
+
+    Returns
+    -------
+    levels: NDArray
+        The calculated levels of each channel in dB relative to the
+        `reference_pressure`.
+
+        `levels` has shape ``signal.cshape`` if `num_octave_band_fractions`
+        is ``None`` and ``(n_bands, signal.cshape)`` otherwise, where
+        `n_bands` denotes the number of (fractional) octave bands.
+
+    References
+    ----------
+    .. [#] International Electrotechnical Commission,
+        "IEC 61672-1:2013 - Electroacoustics - Sound level meters - Part 1:
+        Specifications", IEC, 2013.
+    """
+    signal = _check_signal_type(signal)
+    signal = _apply_frequency_weighting(signal, frequency_weighting)
+    signal = _apply_multi_band(signal, num_octave_band_fractions)
+    mean_energy_per_channel = np.mean(signal.time**2, axis=-1)
+    levels = _energies_to_levels(mean_energy_per_channel, reference_pressure)
+    return levels

--- a/tests/test_audio_signal.py
+++ b/tests/test_audio_signal.py
@@ -288,11 +288,29 @@ def test_getter_sampling_rate():
     assert signal.sampling_rate == 1000
 
 
-def test_setter_sampligrate():
+def test_setter_sampling_rate():
     """Test if attribute sampling rate is set correctly."""
     signal = Signal([1, 2, 3], 44100)
     signal.sampling_rate = 1000
     assert signal._sampling_rate == 1000
+
+
+@pytest.mark.parametrize('fs', [1, [1], [[1]], [[[1]]]])
+def test_sampling_rate_parsing(fs):
+    Signal([0], fs)
+    Signal([0], np.array(fs))
+
+
+def test_sampling_rate_multirate():
+    match="Multirate signals are not supported."
+    with pytest.raises(ValueError, match=match):
+        Signal(1, [1,2])
+
+
+def test_sampling_rate_is_a_number():
+    match="Sampling rate needs to be a number."
+    with pytest.raises(ValueError, match=match):
+        Signal(1, 'string')
 
 
 def test_getter_signal_type():

--- a/tests/test_dsp.py
+++ b/tests/test_dsp.py
@@ -792,6 +792,15 @@ def test_time_crop_unit_seconds_error(signal):
     ' the boundaries'):
         dsp.time_crop(signal, interval=[2, 3], unit='s')
 
+@pytest.mark.parametrize("signal", [pyfar.Signal(np.ones((1,1,10)), 2),
+                                     pf.TimeData(np.ones((1,1,3)), [1, 2, 3])])
+def test_time_crop_multidim(signal):
+    """
+    Test the `time_crop` function with a multi-dimensional signal.
+    """
+    cropped = dsp.time_crop(signal, interval=[1, 2], unit='samples')
+    assert cropped.n_samples == 2
+    assert cropped.cshape == signal.cshape
 
 def test_kaiser_window_beta():
     """Test function call."""

--- a/tests/test_dsp_correlate.py
+++ b/tests/test_dsp_correlate.py
@@ -124,7 +124,8 @@ def test_cyclic_mode_1d(length, delay_1, delay_2):
         correlation.time[0, correlation.times!=lag], 0., 10)
 
 
-def test_full_mode_nd():
+@pytest.mark.parametrize('normalize', [False, True])
+def test_full_mode_nd(normalize):
     """Test broadcasting and n-dimensional signals in full mode."""
 
     # compute correlation
@@ -132,7 +133,7 @@ def test_full_mode_nd():
     signal_1 = pf.signals.impulse(5, 0, sampling_rate=1)
     signal_2 = pf.signals.impulse(5, delays, sampling_rate=1)
 
-    correlation = correlate(signal_1, signal_2)
+    correlation = correlate(signal_1, signal_2, normalize=normalize)
 
     # test output shapes
     assert type(correlation) == pf.TimeData

--- a/tests/test_level_common_parameters.py
+++ b/tests/test_level_common_parameters.py
@@ -1,0 +1,152 @@
+"""
+The standard-conform level functions have shared parameters that
+can and should be tested under the exact same conditions.
+All tests that apply to multiple of these functions are grouped
+in this file to avoid code duplication or accidentally
+testing the same parameter in different ways for different functions.
+
+To do this, lambdas are used to wrap the level functions so they
+can be called with the same number and order of parameters and the same
+return type and shape, if necessary.
+"""
+
+import pyfar as pf
+import numpy as np
+import pytest
+
+### signal parameter tests ###
+
+@pytest.mark.parametrize("signal", [
+    "not a signal",
+    123,
+    None,
+    np.array([1, 2, 3]),
+    pf.TimeData(np.array([1, 2, 3]), [1, 2, 3]),
+    pf.FrequencyData(np.array([1, 2, 3]), [1, 2, 3]),
+])
+@pytest.mark.parametrize("function", [
+    lambda s: pf.level.equivalent_continuous_level(s, "Z"),
+    # other level functions go here once implemented
+])
+def test_level_common_signal_parameter(signal, function):
+    """Test that the signal parameter type is a Signal object."""
+    with pytest.raises(TypeError):
+        function(signal)
+
+
+### frequency_weighting parameter tests ###
+
+FUNCTION_WRAPPERS_FREQ_WEIGHTING = [
+    lambda s, w: pf.level.equivalent_continuous_level(s, w),
+    # other level functions go here once implemented
+]
+
+
+@pytest.mark.parametrize(("frequency", "weightings_max_to_min"), [
+    (63, ["Z", "C", "A"]), # low: C dampens a little, A dampens a lot
+    (4000, ["A", "Z", "C"]), # mid: A boosts a little, C dampens a little
+    (16000, ["Z", "A", "C"]), # high: A dampens a little, C dampens a bit more
+])
+@pytest.mark.parametrize("function", FUNCTION_WRAPPERS_FREQ_WEIGHTING)
+def test_level_common_freq_weighting_relative_level(
+        frequency, weightings_max_to_min, function):
+    """Test that the frequency weighting is applied correctly
+    by making sure the magnitudes are in the expected order relative
+    to each other. This intentionally avoids checking absolute values,
+    since the weighting uses approximated filters which should be tested
+    in the weighting filter function's tests (and would be difficult
+    to do across different level functions).
+    """
+    # start with small phase to avoid the first sample being zero,
+    # which would lead to -inf dB values and division by zero warnings
+    s = pf.signals.sine(frequency, 22050, phase=0.01)
+    mags = {
+        "Z": function(s, "Z"),
+        "C": function(s, "C"),
+        "A": function(s, "A"),
+    }
+    assert mags[weightings_max_to_min[0]] > mags[weightings_max_to_min[1]]
+    assert mags[weightings_max_to_min[1]] > mags[weightings_max_to_min[2]]
+
+
+@pytest.mark.parametrize("weighting", ["X", None])
+@pytest.mark.parametrize("function", FUNCTION_WRAPPERS_FREQ_WEIGHTING)
+def test_level_common_freq_weighting_errors(weighting, function):
+    """Test that an invalid frequency weighting raises an error."""
+    s = pf.signals.sine(1000, 22050)
+    with pytest.raises(ValueError, match="Frequency weighting"):
+        function(s, weighting)
+
+
+### num_octave_band_fractions parameter tests ###
+
+FUNCTION_WRAPPERS_BAND_FRACTIONS = [
+    lambda s, n: pf.level.equivalent_continuous_level(s, "Z", n),
+    # other level functions go here once implemented
+]
+
+
+@pytest.mark.parametrize("signal", [
+    pf.signals.impulse(1000, sampling_rate=48000),
+    pf.signals.impulse(1000, 0, (1, 2), sampling_rate=48000),
+    pf.signals.impulse(1000, 0, ((1, 2), (3, 4)), sampling_rate=48000),
+])
+@pytest.mark.parametrize("num_fractions", [1, 3, 6])
+@pytest.mark.parametrize("function", FUNCTION_WRAPPERS_BAND_FRACTIONS)
+def test_level_common_num_octave_band_fractions_dimensions(
+        signal, function, num_fractions):
+    """Test that the number of octave band fractions is applied correctly
+    by checking the dimensions of the output.
+    """
+    band_freqs, _, _ = pf.constants.fractional_octave_frequencies_exact(
+        num_fractions)
+    num_bands = len(band_freqs)
+
+    full_band = function(signal, None)
+    band_filtered = function(signal, num_fractions)
+
+    # new first dimension with the same other dimensions
+    assert band_filtered.shape == (num_bands, *full_band.shape)
+
+
+@pytest.mark.parametrize(("num_fractions", "error_type", "match"), [
+    ("3", TypeError, "integer"),
+    (2.5, TypeError, "integer"),
+    (-1, ValueError, "positive"),
+    (0, ValueError, "positive"),
+])
+@pytest.mark.parametrize("function", FUNCTION_WRAPPERS_BAND_FRACTIONS)
+def test_level_common_num_octave_band_fractions_errors(
+    function, num_fractions, error_type, match):
+    """Test that an invalid number of octave band fractions raises an error."""
+    s = pf.signals.sine(1000, 22050)
+    with pytest.raises(error_type, match=match):
+        function(s, num_fractions)
+
+
+### reference_pressure parameter tests ###
+
+FUNCTION_WRAPPERS_REFERENCE_PRESSURE = [
+    lambda s, r: pf.level.equivalent_continuous_level(
+        s, "Z", None, r),
+    # other level functions go here once implemented
+]
+
+
+@pytest.mark.parametrize("function", FUNCTION_WRAPPERS_REFERENCE_PRESSURE)
+def test_level_common_reference_pressure_relative(function):
+    """Test that the reference pressure is used correctly by comparing
+    the norm SPL to dbFS, which must be ~94 dB apart.
+    """
+    s = pf.signals.impulse(22050)
+    dbSPL = function(s, pf.constants.reference_sound_pressure)
+    dbFS = function(s, 1)
+    assert np.isclose(dbSPL - dbFS, 94, atol=0.1)
+
+
+@pytest.mark.parametrize("function", FUNCTION_WRAPPERS_REFERENCE_PRESSURE)
+def test_level_common_reference_pressure_errors(function):
+    """Test that an invalid reference pressure raises an error."""
+    s = pf.signals.sine(1000, 22050)
+    with pytest.raises(ValueError, match="Reference pressure"):
+        function(s, 0)

--- a/tests/test_level_standard_levels.py
+++ b/tests/test_level_standard_levels.py
@@ -1,0 +1,18 @@
+"""
+Test for the standard-conform level functions.
+
+Note that the tests for the shared parameters of these functions are in
+`test_level_common_parameters.py`, so this file ony contains tests
+against known values or other tests that are specific to a single function.
+"""
+
+import pyfar as pf
+import numpy as np
+
+
+def test_level_equivalent_continuous_level_known_value():
+    s = pf.signals.sine(1000, 22050)
+    levels = pf.level.equivalent_continuous_level(
+        s, "Z", None, 2e-5)
+    # 94 dB is 1 Pa, -3.01 dB is the crest factor of sine signals
+    assert np.isclose(levels, 94 - 3.01, atol=0.1)

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -419,8 +419,7 @@ def test_2d_colorbar_options(function, colorbar, handsome_signal_2d):
             function(signal, colorbar=False)
     elif colorbar == "axes":
         # test plotting colorbar to specified axis
-        fig.clear()
-        _, ax = plt.subplots(1, 2, num=fig.number)
+        _, ax = fig.subplots(1, 2)
         if function == plot.spectrogram:
             function(signal[0], ax=ax)
         else:


### PR DESCRIPTION
This is intended as the umbrella PR for all the individual feature PRs surrounding the new pyfar.level submodule.
It's not intended to commit to this branch directly. Instead, the idea is to have smaller PRs that are easier to review without having to merge an incomplete submodule into develop or main.
This PR should remain a draft until all the individual feature PRs are merged into `level_module` and act as an overview and progress report.

Closes #760 and #925. 
Might also close #675 (the parent issue) once it's complete. See the issue for what is planned for the module.

I currently plan to split the individual PRs as follows, and will mark each as done when it is merged (with squash option):
- [x] #948 for most of the shared helper functions and `equivalent_continuous_level` as the easiest standard level function. Most other features below depend on this.
- [x] #951 for the `exposure_level()` function
- [x] #952 for `sliding_equivalent_continuous_level()` and the necessary moving-average utility
- [ ] #954  for `time_weighted_level()` and time weighting helper
- [x] #955 for `peak_level()` and an oversampling helper
- [ ] `level/max_time_weighted` for `maximimum_time_weighted_level()` (depends on `level/peak` and `level/time_weighting`)
- [ ] `level/utils` for other utility for working with levels, such as:
    - energetic sum/mean of level values 
    - Maybe move dsp.decibel here too, and its inverse?
    - Perhaps a `channel_handling` parameter for the standard level functions that would make helpers largely unnecessary?
- [ ] `level/docs` to build a shared module-wide documentation for all of these functions without too much redundancy and add examples. Also check output shape hints, which should be `(n_bands, *signal.cshape)` or `(n_bands, *signal.time.shape)` etc (don't forget the asterisk!)

