### PR TITLE
[DOCS] Add delay estimation accuracy example to `find_impulse_response_delay`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,6 +13,9 @@ Fixed
 - A bug where a numpy array being passed as a `pyfar.audio.classes.Signal.sampling_rate` raised `TypeError`.
 - Normalization in `pyfar.dsp.correlate` now works correctly for multi-channel signals (PR #945)
 
+Added
+^^^^^
+- Added example to `find_impulse_response_delay` plotting the inter-sample delay estimation accuracy. (PR #950)
 
 0.8.0 (2026-03-16)
 ------------------

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1390,6 +1390,7 @@ def find_impulse_response_delay(impulse_response, N=1):
     starting sample of the impulse and plot.
 
     .. plot::
+        :context: close-figs
 
         >>> import pyfar as pf
         >>> import numpy as np
@@ -1403,12 +1404,13 @@ def find_impulse_response_delay(impulse_response, N=1):
         ...     start_samples/ir.sampling_rate*1e3,
         ...     color='k', linestyle='-.', label='start sample')
         >>> ax.legend()
-        >>> plt.show()
 
     Plot the inter-sample delay estimation error for a sinc function shifted
-    by a fractional number of samples.
+    by a fractional number of samples. The plot illustrates the expected
+    inter-sample precision of the underlying delay estimation method.
 
     .. plot::
+        :context: close-figs
 
         >>> import pyfar as pf
         >>> import numpy as np
@@ -1422,8 +1424,8 @@ def find_impulse_response_delay(impulse_response, N=1):
         ...     # center the sinc peak
         ...     true_delay = n_samples // 2 + frac_delay
         ...     sinc = np.sinc(samples - true_delay)
-        ...     win = sgn.get_window('hann', n_samples, fftbins=False)
-        ...     ir = pf.Signal(sinc * win, 44.1e3)
+        ...     ir = pf.Signal(sinc, 44.1e3)
+        ...     ir = pf.dsp.time_window(ir, (0, n_samples), shape='left')
         ...     est_delay = pf.dsp.find_impulse_response_delay(ir)
         ...     err.append(true_delay - est_delay[0])
         >>> # Plot the estimation error
@@ -1433,7 +1435,6 @@ def find_impulse_response_delay(impulse_response, N=1):
         >>> plt.xlabel('Fractional Delay in Samples')
         >>> plt.axhline(0, color='k', linewidth=0.8)
         >>> plt.title('Delay estimation error for a shifted sinc')
-        >>> plt.show()
     """
     n = int(np.ceil((N+2)/2))
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1403,7 +1403,37 @@ def find_impulse_response_delay(impulse_response, N=1):
         ...     start_samples/ir.sampling_rate*1e3,
         ...     color='k', linestyle='-.', label='start sample')
         >>> ax.legend()
+        >>> plt.show()
 
+    Plot the inter-sample delay estimation error for a sinc function shifted
+    by a fractional number of samples.
+
+    .. plot::
+
+        >>> import pyfar as pf
+        >>> import numpy as np
+        >>> import scipy.signal as sgn
+        >>> import matplotlib.pyplot as plt
+        >>> n_samples = 2**10
+        >>> frac_delays = np.linspace(0, 1, 100, endpoint=True)
+        >>> err = []
+        >>> for frac_delay in frac_delays:
+        ...     samples = np.arange(n_samples)
+        ...     # center the sinc peak
+        ...     true_delay = n_samples // 2 + frac_delay
+        ...     sinc = np.sinc(samples - true_delay)
+        ...     win = sgn.get_window('hann', n_samples, fftbins=False)
+        ...     ir = pf.Signal(sinc * win, 44.1e3)
+        ...     est_delay = pf.dsp.find_impulse_response_delay(ir)
+        ...     err.append(true_delay - est_delay[0])
+        >>> # Plot the estimation error
+        >>> plt.figure(figsize=(7, 4))
+        >>> plt.plot(frac_delays, err)
+        >>> plt.ylabel('Error in Samples')
+        >>> plt.xlabel('Fractional Delay in Samples')
+        >>> plt.axhline(0, color='k', linewidth=0.8)
+        >>> plt.title('Delay estimation error for a shifted sinc')
+        >>> plt.show()
     """
     n = int(np.ceil((N+2)/2))
 

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1414,7 +1414,6 @@ def find_impulse_response_delay(impulse_response, N=1):
 
         >>> import pyfar as pf
         >>> import numpy as np
-        >>> import scipy.signal as sgn
         >>> import matplotlib.pyplot as plt
         >>> n_samples = 2**10
         >>> frac_delays = np.linspace(0, 1, 100, endpoint=True)

--- a/pyfar/dsp/dsp.py
+++ b/pyfar/dsp/dsp.py
@@ -1405,9 +1405,9 @@ def find_impulse_response_delay(impulse_response, N=1):
         ...     color='k', linestyle='-.', label='start sample')
         >>> ax.legend()
 
-    Plot the inter-sample delay estimation error for a sinc function shifted
+    Plot the estimation error for a sinc function shifted
     by a fractional number of samples. The plot illustrates the expected
-    inter-sample precision of the underlying delay estimation method.
+    sub-sample precision of the delay estimation method for this example.
 
     .. plot::
         :context: close-figs


### PR DESCRIPTION
### Which issue(s) are closed by this pull request?

Closes #946 

### Changes proposed in this pull request:

- Add example to `find_impulse_response_delay`
- plot inter-sample delay estimation accuracy

### Note
Plot shows the error based on the code on main, once #941 is merged, the plot will change to what can be seen in #946.
