### PR TITLE
Level/exposure

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Added
 ^^^^^
 - A new submodule `pyfar.level` with various functions to compute and work with levels (PR #949), consisting of:
     - `level.equivalent_continuous_level` for the Leq (PR #948)
+    - `level.exposure_level` for the L_E (PR #951)
 
 Fixed
 ^^^^^

--- a/pyfar/level/__init__.py
+++ b/pyfar/level/__init__.py
@@ -2,8 +2,10 @@
 
 from .standard_levels import (
     equivalent_continuous_level,
+    exposure_level,
 )
 
 __all__ = [
     "equivalent_continuous_level",
+    "exposure_level",
 ]

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -163,6 +163,8 @@ def exposure_level(
         signal, frequency_weighting, None, reference_pressure)
 
     duration = signal.signal_length if duration is None else duration
+    if not isinstance(duration, (int, float, np.number)):
+        raise TypeError("Duration must be a number.")
     if duration <= 0:
         raise ValueError("Duration must be a positive number.")
     duration_term = 10 * np.log10(duration)

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -133,7 +133,7 @@ def exposure_level(
         set to the length of the signal in seconds to calculate the exposure
         of just the signal. You can specify a different duration to extrapolate
         the exposure level to a longer (or shorter) time period assuming the
-        same average sound pressure remains constant. 
+        same average sound pressure remains constant.
         The duration must be a positive number.
 
     reference_pressure: float

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -89,3 +89,21 @@ def equivalent_continuous_level(
     mean_energy_per_channel = np.mean(signal.time**2, axis=-1)
     levels = _energies_to_levels(mean_energy_per_channel, reference_pressure)
     return levels
+
+
+def exposure_level(
+        signal,
+        frequency_weighting: Literal["A", "C", "Z"],
+        duration: float | None = None,
+        reference_pressure: float = pf.constants.reference_sound_pressure,
+):
+    signal = _check_signal_type(signal)
+    eq_level = equivalent_continuous_level(
+        signal, frequency_weighting, None, reference_pressure)
+
+    duration = signal.signal_length if duration is None else duration
+    if duration <= 0:
+        raise ValueError("Duration must be a positive number.")
+    duration_term = 10 * np.log10(duration)
+
+    return eq_level + duration_term

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -115,7 +115,7 @@ def exposure_level(
     Parameters
     ----------
     signal: Signal
-        The signal object to calculate the levels of
+        The signal object to calculate the levels of.
 
     frequency_weighting: ``"A"``, ``"C"``, or ``"Z"``
         The frequency weighting type. If ``"A"`` or ``"C"``, the corresponding

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -112,6 +112,16 @@ def exposure_level(
     :math:`p_0` is the `reference_pressure`,
     and :math:`T` is the duration of the signal or the `duration` specified.
 
+    .. note::
+        The standard defines the sound exposure level relative to
+        a reference *energy* :math:`E_0 = p_0^2 T_0
+        = 20\,\mu\text{Pa}^2 \cdot 1 \text{ s}
+        = 400 \cdot 10^{-12} \text{ J}`.
+        However, this function uses a reference *pressure* instead to remain
+        consistent with the other level functions.
+        You can obtain the `reference_pressure` by taking the square root of of
+        the desired reference energy.
+
     Parameters
     ----------
     signal: Signal

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -97,6 +97,67 @@ def exposure_level(
         duration: float | None = None,
         reference_pressure: float = pf.constants.reference_sound_pressure,
 ):
+    r"""Calculate the frequency-weighted sound exposure level.
+
+    The levels are calculated per channel and according to IEC 61672-1 [#]_.
+    For instance, the A-weighted sound exposure level is calculated as:
+
+    .. math::
+        L_{\text{A}E,T} = 10 \log_{10} \left[ \frac{(1/N) \sum_{n=0}^{N-1}
+        p_{\text{A}}^2[n] T} {p_0^2} \right] \text{ dB}
+        = L_\text{Aeq} + 10 \log_{10}(T) \text{ dB}
+
+    where :math:`N` is the number of samples in the signal,
+    :math:`p_\mathrm{A}` the A-weighted sound pressure at index :math:`n`,
+    :math:`p_0` is the `reference_pressure`,
+    and :math:`T` is the duration of the signal or the `duration` specified.
+
+    Parameters
+    ----------
+    signal: Signal
+        The signal object to calculate the levels of
+
+    frequency_weighting: ``"A"``, ``"C"``, or ``"Z"``
+        The frequency weighting type. If ``"A"`` or ``"C"``, the corresponding
+        frequency weighting filter is applied before level
+        calculation. If ``"Z"``, no frequency weighting is applied.
+
+        The frequency weighting is applied using
+        :py:func:`~pyfar.dsp.filter.frequency_weighting_filter` with its
+        (standard-compliant) default parameters. If you need more control,
+        you can set this parameter to ``"Z"`` and apply the frequency
+        weighting filter yourself before calling this function.
+
+    duration: float or ``None``
+        The duration of the signal in seconds. If ``None``, the duration is
+        set to the length of the signal in seconds to calculate the exposure
+        of just the signal. You can specify a different duration to extrapolate
+        the exposure level to a longer (or shorter) time period assuming the
+        same average sound pressure remains constant. 
+        The duration must be a positive number.
+
+    reference_pressure: float
+        The reference pressure to calculate levels relative to. The default
+        value, ``20e-6``, corresponds to the standard reference pressure of
+        20 micropascals, which assumes the signal is in units of pascals (Pa).
+        To compute the level in dBFS of a digital signal, or if you plan
+        to correct for the recording setup afterwards, this parameter
+        should be ``1``.
+
+    Returns
+    -------
+    levels: NDArray
+        The calculated levels of each channel in dB relative to the
+        `reference_pressure`.
+
+        `levels` has shape ``signal.cshape``.
+
+    References
+    ----------
+    .. [#] International Electrotechnical Commission,
+        "IEC 61672-1:2013 - Electroacoustics - Sound level meters - Part 1:
+        Specifications", IEC, 2013.
+    """
     signal = _check_signal_type(signal)
     eq_level = equivalent_continuous_level(
         signal, frequency_weighting, None, reference_pressure)

--- a/tests/test_level_common_parameters.py
+++ b/tests/test_level_common_parameters.py
@@ -26,6 +26,7 @@ import pytest
 ])
 @pytest.mark.parametrize("function", [
     lambda s: pf.level.equivalent_continuous_level(s, "Z"),
+    lambda s: pf.level.exposure_level(s, "Z"),
     # other level functions go here once implemented
 ])
 def test_level_common_signal_parameter(signal, function):
@@ -38,6 +39,7 @@ def test_level_common_signal_parameter(signal, function):
 
 FUNCTION_WRAPPERS_FREQ_WEIGHTING = [
     lambda s, w: pf.level.equivalent_continuous_level(s, w),
+    lambda s, w: pf.level.exposure_level(s, w),
     # other level functions go here once implemented
 ]
 
@@ -127,8 +129,8 @@ def test_level_common_num_octave_band_fractions_errors(
 ### reference_pressure parameter tests ###
 
 FUNCTION_WRAPPERS_REFERENCE_PRESSURE = [
-    lambda s, r: pf.level.equivalent_continuous_level(
-        s, "Z", None, r),
+    lambda s, r: pf.level.equivalent_continuous_level(s, "Z", None, r),
+    lambda s, r: pf.level.exposure_level(s, "Z", None, r),
     # other level functions go here once implemented
 ]
 

--- a/tests/test_level_standard_levels.py
+++ b/tests/test_level_standard_levels.py
@@ -6,6 +6,7 @@ Note that the tests for the shared parameters of these functions are in
 against known values or other tests that are specific to a single function.
 """
 
+import pytest
 import pyfar as pf
 import numpy as np
 
@@ -16,3 +17,16 @@ def test_level_equivalent_continuous_level_known_value():
         s, "Z", None, 2e-5)
     # 94 dB is 1 Pa, -3.01 dB is the crest factor of sine signals
     assert np.isclose(levels, 94 - 3.01, atol=0.1)
+
+
+@pytest.mark.parametrize(("duration", "level_increase"), [
+    (None, 0),  # signal is one second long, which is the unit length
+    (1, 0),     # unit length in the standard
+    (10, 10),   # 10 s => 10x the energy => 10 dB increase
+    (100, 20),  # 100 s => 100x the energy => 20 dB increase
+])
+def test_level_exposure_level_duration(duration, level_increase):
+    s = pf.signals.sine(1000, 44100, sampling_rate=44100)
+    levels = pf.level.exposure_level(s, "Z", duration)
+    # 94 dB is 1 Pa, -3.01 dB is the crest factor of sine signals
+    assert np.isclose(levels, 94 - 3.01 + level_increase, atol=0.1)

--- a/tests/test_level_standard_levels.py
+++ b/tests/test_level_standard_levels.py
@@ -30,3 +30,17 @@ def test_level_exposure_level_duration(duration, level_increase):
     levels = pf.level.exposure_level(s, "Z", duration)
     # 94 dB is 1 Pa, -3.01 dB is the crest factor of sine signals
     assert np.isclose(levels, 94 - 3.01 + level_increase, atol=0.1)
+
+
+@pytest.mark.parametrize("duration", [-1, 0, np.int32(-1)])
+def test_level_exposure_level_duration_value_errors(duration):
+    s = pf.signals.sine(1000, 44100, sampling_rate=44100)
+    with pytest.raises(ValueError, match="positive"):
+        pf.level.exposure_level(s, "Z", duration)
+
+
+@pytest.mark.parametrize("duration", ["1", np.array([1]), [1], complex(1, 0)])
+def test_level_exposure_level_duration_type_errors(duration):
+    s = pf.signals.sine(1000, 44100, sampling_rate=44100)
+    with pytest.raises(TypeError, match="number"):
+        pf.level.exposure_level(s, "Z", duration)


### PR DESCRIPTION
Part of #949. This PR adds the `exposure_level()` function to the level module.

Potential points of discussion:
- Do you like my approach for the `duration` parameter? From what I understand, the exposure level is mostly used to calculate the daily sound expose, i.e. over an 8h work day. But it's unlikely pyfar users will have 8h long continuous audio recordings (which would be several GB) available. Therefore I added the parameter to let users extrapolate the average sound energy of the provided signal over a longer period of time, which should be more useful. Let me know what you think or different ideas to deal with this.
- I used `reference_pressure`, but the norm technically defines a reference *power*, though they define it as (2e-5)^2 (the reference pressure, squared). To keep the function consistent with the other level functions, I prefer using the pressure as parameter.

Update after weekly meeting: 
We decided to keep the duration parameter this way, and also keep the `reference_pressure` in favor of consistency, but with clear explanations regarding how the reference pressure relates to the reference energy (E0, which is p0^2 *T0) in the docstring.