### PR TITLE
Level/sliding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Added
 ^^^^^
 - A new submodule `pyfar.level` with various functions to compute and work with levels (PR #949), consisting of:
     - `level.equivalent_continuous_level` for the Leq (PR #948)
+    - `level.sliding_continuous_level` for the Leq with a sliding window (PR #952)
 
 Fixed
 ^^^^^

--- a/pyfar/level/__init__.py
+++ b/pyfar/level/__init__.py
@@ -2,8 +2,10 @@
 
 from .standard_levels import (
     equivalent_continuous_level,
+    sliding_equivalent_continuous_level,
 )
 
 __all__ = [
     "equivalent_continuous_level",
+    "sliding_equivalent_continuous_level",
 ]

--- a/pyfar/level/_utils.py
+++ b/pyfar/level/_utils.py
@@ -4,6 +4,7 @@ between many of the standardized level functions.
 
 import numpy as np
 import pyfar as pf
+import scipy.ndimage
 
 
 def _check_signal_type(signal):
@@ -45,3 +46,51 @@ def _energies_to_levels(energies: np.ndarray, reference_pressure: float):
     if reference_pressure == 0:
         raise ValueError("Reference pressure must not be zero.")
     return 10 * np.log10(energies / reference_pressure**2)
+
+
+def _moving_average(array: np.ndarray,
+                    window_size: int,
+                    axis: int = -1,
+                    cyclic: bool = False,
+                    center_window: bool = False,
+                    ):
+    """Efficiently calculates the moving average of an array along
+    an axis.
+    If `cyclic` is ``True``, the array is treated as if it were periodic
+    (like a cyclic convolution). If ``False`` (default), edges are
+    zero-padded, leading to fade-like boundary effects.
+    If `center_window` is ``True``, the window is centered on the current
+    sample. If ``False`` (default), the window is causal, meaning it only
+    considers past values, same as the `convolve` functions in `numpy`,
+    `scipy.signal`, and `pyfar.dsp`.
+    """
+    if (not isinstance(window_size, int)):
+        raise TypeError("Window size must be an integer.")
+    if window_size < 1:
+        raise ValueError("Window size must be a positive integer.")
+
+    # If the input are integers, the outputs are too (rounded), which
+    # we never want in floating point audio.
+    if np.issubdtype(array.dtype, np.integer):
+        array = array.astype(np.float64)
+
+    if center_window:
+        origin = 0  # 0 means the window is centered
+    else:
+        # For a causal window, the window needs to be shifted back
+        if window_size % 2 == 1:
+            origin = window_size // 2
+        else:
+            # since scipy.ndimage is designed for images, which normally
+            # use odd window sizes, even sizes are finnicky...
+            origin = window_size // 2 - 1
+
+    mode = "wrap" if cyclic else "constant"
+
+    # This is effectively the same as a convolution with a rectangular window,
+    # but more efficient, especially for long windows.
+    # Unlike convolve, this function has a built-in "wrap" mode, but no
+    # "full" mode
+    result = scipy.ndimage.uniform_filter1d(
+        array, size=window_size, axis=axis, mode=mode, origin=origin)
+    return result

--- a/pyfar/level/_utils.py
+++ b/pyfar/level/_utils.py
@@ -40,11 +40,19 @@ def _apply_multi_band(signal, num_octave_band_fractions: int | None):
         signal, num_octave_band_fractions)
 
 
-def _energies_to_levels(energies: np.ndarray, reference_pressure: float):
+def _energies_to_levels(energies: np.ndarray,
+                        reference_pressure: float,
+                        replace_zeros: bool = False):
     """Converts energies to levels in dB relative to the reference pressure.
+    Raises an error if the reference pressure is zero.
+    If `replace_zeros` is ``True``, zeros in the energies are replaced with
+    the float epsilon to avoid ``-inf`` values and resulting numpy warnings.
     """
     if reference_pressure == 0:
         raise ValueError("Reference pressure must not be zero.")
+    if replace_zeros:
+        energies = np.where(
+            energies == 0, np.finfo(energies.dtype).eps, energies)
     return 10 * np.log10(energies / reference_pressure**2)
 
 

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -182,6 +182,19 @@ def sliding_equivalent_continuous_level(
     .. [#] International Electrotechnical Commission,
         "IEC 61672-1:2013 - Electroacoustics - Sound level meters - Part 1:
         Specifications", IEC, 2013.
+
+    Examples
+    --------
+    Obtain the equivalent continuous level in 2-second intervals in dbFS(A).
+
+    >>> import pyfar as pf
+    >>> fs = 48000
+    >>> interval = 2
+    >>> signal = pf.signals.files.guitar()
+    >>> sliding_levels = pf.level.sliding_equivalent_continuous_level(
+    >>>         signal, "A", window_duration=interval, reference_pressure=1)
+    >>> interval_levels = sliding_levels[0][fs*interval::fs*interval]
+    >>> print(interval_levels) # [-32.24998448 -31.61894792 -28.19029974]
     """
     signal = _check_signal_type(signal)
     signal = _apply_frequency_weighting(signal, frequency_weighting)

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -9,6 +9,7 @@ from ._utils import (
     _apply_frequency_weighting,
     _apply_multi_band,
     _energies_to_levels,
+    _moving_average,
 )
 
 
@@ -88,4 +89,99 @@ def equivalent_continuous_level(
     signal = _apply_multi_band(signal, num_octave_band_fractions)
     mean_energy_per_channel = np.mean(signal.time**2, axis=-1)
     levels = _energies_to_levels(mean_energy_per_channel, reference_pressure)
+    return levels
+
+
+def sliding_equivalent_continuous_level(
+    signal,
+    frequency_weighting: Literal["A", "C", "Z"],
+    num_octave_band_fractions: int | None = None,
+    window_duration: float = 1,
+    cyclic: bool = False,
+    center_window: bool = False,
+    reference_pressure: float = pf.constants.reference_sound_pressure,
+):
+    r"""Calculate the frequency-weighted equivalent continuous sound
+    pressure level with a sliding time window.
+
+    The levels are calculated per channel and according to IEC 61672-1 [#]_.
+    See :py:func:`~pyfar.level.equivalent_continuous_level` for the definition
+    of the equivalent continuous level.
+
+    Parameters
+    ----------
+    signal: Signal
+        The signal object to calculate the levels of
+
+    frequency_weighting: ``"A"``, ``"C"``, or ``"Z"``
+        The frequency weighting type. If ``"A"`` or ``"C"``, the corresponding
+        frequency weighting filter is applied before level
+        calculation. If ``"Z"``, no frequency weighting is applied.
+
+        The frequency weighting is applied using
+        :py:func:`~pyfar.dsp.filter.frequency_weighting_filter` with its
+        (standard-compliant) default parameters. If you need more control,
+        you can set this parameter to ``"Z"`` and apply the frequency
+        weighting filter yourself before calling this function.
+
+    num_octave_band_fractions: int or ``None``
+        Can be used to calculate the level in octave (``1``), third-octave
+        (``3``), or other positive integer fractional octave bands.
+        If ``None``, levels are calculated for the full-band signal.
+
+        The fraction octave band filtering is applied using
+        :py:func:`~pyfar.dsp.filter.fractional_octave_bands` with its
+        (standard-compliant) default parameters. If you need more control,
+        you can set this parameter to ``None`` and apply the filter bank
+        yourself before calling this function.
+
+    window_duration: float
+        The duration of the sliding window in seconds, which determines
+        the time over which the energy is averaged at each sample.
+        The default value is ``1``.
+
+    cyclic: bool
+        If ``True``, the signal is treated as if it were periodic (like a
+        cyclic convolution). If ``False``, edges are zero-padded,
+        leading to fade-like boundary effects. The default is ``False``.
+
+    center_window: bool
+        If ``True``, the window is centered on the current sample.
+        If ``False``, the window is causal, meaning it only considers
+        past values, just like a convolution with a rectangular window.
+        The default is ``False``.
+
+    reference_pressure: float
+        The reference pressure to calculate levels relative to. The default
+        value, ``20e-6``, corresponds to the standard reference pressure of
+        20 micropascals, which assumes the signal is in units of pascals (Pa).
+        To compute the level in dBFS of a digital signal, or if you plan
+        to correct for the recording setup afterwards, this parameter
+        should be ``1``.
+
+    Returns
+    -------
+    levels: NDArray
+        The calculated levels of each channel in dB relative to the
+        `reference_pressure`.
+
+        `levels` has shape ``signal.time.shape`` if `num_octave_band_fractions`
+        is ``None`` and ``(n_bands, signal.time.shape)`` otherwise, where
+        `n_bands` denotes the number of (fractional) octave bands.
+
+    References
+    ----------
+    .. [#] International Electrotechnical Commission,
+        "IEC 61672-1:2013 - Electroacoustics - Sound level meters - Part 1:
+        Specifications", IEC, 2013.
+    """
+    signal = _check_signal_type(signal)
+    signal = _apply_frequency_weighting(signal, frequency_weighting)
+    signal = _apply_multi_band(signal, num_octave_band_fractions)
+
+    window_size = round(signal.sampling_rate * window_duration)
+    energies = signal.time**2
+    mean_energies = _moving_average(energies, window_size, cyclic=cyclic,
+                                    center_window=center_window)
+    levels = _energies_to_levels(mean_energies, reference_pressure)
     return levels

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -112,7 +112,7 @@ def sliding_equivalent_continuous_level(
     Parameters
     ----------
     signal: Signal
-        The signal object to calculate the levels of
+        The signal object to calculate the levels of.
 
     frequency_weighting: ``"A"``, ``"C"``, or ``"Z"``
         The frequency weighting type. If ``"A"`` or ``"C"``, the corresponding

--- a/pyfar/level/standard_levels.py
+++ b/pyfar/level/standard_levels.py
@@ -100,6 +100,7 @@ def sliding_equivalent_continuous_level(
     cyclic: bool = False,
     center_window: bool = False,
     reference_pressure: float = pf.constants.reference_sound_pressure,
+    replace_zeros: bool = True,
 ):
     r"""Calculate the frequency-weighted equivalent continuous sound
     pressure level with a sliding time window.
@@ -159,6 +160,13 @@ def sliding_equivalent_continuous_level(
         to correct for the recording setup afterwards, this parameter
         should be ``1``.
 
+    replace_zeros: bool
+        If ``False``, the function will return ``-inf`` for samples where the
+        time-weighted energy is zero. If ``True``, these energy values will be
+        replaced with a very small number (the array type epsilon)
+        to avoid ``-inf`` values and corresponding numpy warnings.
+        The default is ``True``.
+
     Returns
     -------
     levels: NDArray
@@ -183,5 +191,6 @@ def sliding_equivalent_continuous_level(
     energies = signal.time**2
     mean_energies = _moving_average(energies, window_size, cyclic=cyclic,
                                     center_window=center_window)
-    levels = _energies_to_levels(mean_energies, reference_pressure)
+    levels = _energies_to_levels(
+        mean_energies, reference_pressure, replace_zeros)
     return levels

--- a/tests/test_level__utils.py
+++ b/tests/test_level__utils.py
@@ -1,0 +1,56 @@
+import pyfar as pf
+import numpy as np
+import pytest
+
+
+@pytest.mark.parametrize("window_size", [2, 3, 100, 101])
+@pytest.mark.parametrize("cyclic", [False, True])
+@pytest.mark.parametrize("signal_data", [
+    np.repeat([0, 1, -0.5], 400),
+    np.array([np.linspace(0, 1, 1000), np.linspace(1, 0, 1000)]),
+])
+def test_level_moving_average_same_results(signal_data, window_size, cyclic):
+    """Test that the moving average function returns the same result as
+    convolving with a rectangular window using pyfar.dsp.convolve.
+    """
+    signal = pf.Signal(signal_data, 48000)
+    filt = pf.Signal(np.ones(window_size) / window_size, 48000)
+    mode = "cyclic" if cyclic else "cut"
+    expected = pf.dsp.convolve(signal, filt, mode=mode).time
+
+    result = pf.level._utils._moving_average(
+        signal_data, window_size, -1, cyclic, False)
+    result = np.atleast_2d(result)
+    print(result)
+
+    assert expected.shape == result.shape
+    assert np.allclose(expected, result)
+
+
+@pytest.mark.parametrize(("center_window", "window_size", "expected"),
+                         [(False, 3, [0, 0, 1/3, 1/3, 1/3, 0]),
+                          (True, 3, [0, 1/3, 1/3, 1/3, 0, 0]),
+                          (True, 4, [0, 1/4, 1/4, 1/4, 1/4, 0]),
+                          (True, 2, [0, 0, 1/2, 1/2, 0, 0]),
+                          ])
+def test_level_moving_average_center_window(center_window,
+                                            window_size,
+                                            expected):
+    data = np.array([0, 0, 1, 0, 0, 0])
+    result = pf.level._utils._moving_average(data, window_size, -1,
+                                             False, center_window)
+    print(result)
+    assert np.allclose(expected, result)
+
+
+@pytest.mark.parametrize(("window_size", "err", "match"), [
+    (0, ValueError, "positive"),
+    (-1, ValueError, "positive"),
+    (2.5, TypeError, "integer"),
+])
+def test_level_moving_average_invalid_window_size(window_size, err, match):
+    """Test that the moving average function raises errors if the
+    window size is not a positive integer.
+    """
+    with pytest.raises(err, match=match):
+        pf.level._utils._moving_average(np.array([0, 1, 2]), window_size)

--- a/tests/test_level_common_parameters.py
+++ b/tests/test_level_common_parameters.py
@@ -26,6 +26,7 @@ import pytest
 ])
 @pytest.mark.parametrize("function", [
     lambda s: pf.level.equivalent_continuous_level(s, "Z"),
+    lambda s: pf.level.sliding_equivalent_continuous_level(s, "Z"),
     # other level functions go here once implemented
 ])
 def test_level_common_signal_parameter(signal, function):
@@ -38,6 +39,7 @@ def test_level_common_signal_parameter(signal, function):
 
 FUNCTION_WRAPPERS_FREQ_WEIGHTING = [
     lambda s, w: pf.level.equivalent_continuous_level(s, w),
+    lambda s, w: pf.level.sliding_equivalent_continuous_level(s, w)[0][-1],
     # other level functions go here once implemented
 ]
 
@@ -82,6 +84,7 @@ def test_level_common_freq_weighting_errors(weighting, function):
 
 FUNCTION_WRAPPERS_BAND_FRACTIONS = [
     lambda s, n: pf.level.equivalent_continuous_level(s, "Z", n),
+    lambda s, n: pf.level.sliding_equivalent_continuous_level(s, "Z", n),
     # other level functions go here once implemented
 ]
 
@@ -129,6 +132,8 @@ def test_level_common_num_octave_band_fractions_errors(
 FUNCTION_WRAPPERS_REFERENCE_PRESSURE = [
     lambda s, r: pf.level.equivalent_continuous_level(
         s, "Z", None, r),
+    lambda s, r: pf.level.sliding_equivalent_continuous_level(
+        s, "Z", None, 1, False, False, r)[0][-1],
     # other level functions go here once implemented
 ]
 

--- a/tests/test_level_standard_levels.py
+++ b/tests/test_level_standard_levels.py
@@ -16,3 +16,21 @@ def test_level_equivalent_continuous_level_known_value():
         s, "Z", None, 2e-5)
     # 94 dB is 1 Pa, -3.01 dB is the crest factor of sine signals
     assert np.isclose(levels, 94 - 3.01, atol=0.1)
+
+
+def test_level_sliding_equivalent_continuous_level_known_value():
+    # phase prevents the first sample from being exactly zero, which would
+    # cause a division by zero in the level calculation
+    s = pf.signals.sine(1000, 44100, phase=0.01, sampling_rate=44100)
+    levels = pf.level.sliding_equivalent_continuous_level(
+        s, "Z", None, 1, False, False, 2e-5)
+    # 94 dB is 1 Pa, -3.01 dB is the crest factor of sine signals
+    # with 1 second window size, the value at 1 second should be
+    # the same as the equivalent continuous level of the full signal
+    assert np.isclose(levels[0][-1], 94 - 3.01, atol=0.1)
+
+
+def test_level_sliding_equivalent_continuous_level_shape():
+    s = pf.signals.impulse(1000, sampling_rate=48000)
+    levels = pf.level.sliding_equivalent_continuous_level(s, "Z")
+    assert levels.shape == s.time.shape


### PR DESCRIPTION
Part of #949. 

This PR adds a moving average utility function and uses it to add the `sliding_equivalent_continuous_level()` function according to the standard.